### PR TITLE
[UPD] Propagasi operating_unit_id ke account.move pada OU modules

### DIFF
--- a/ssi_school_admission_operating_unit/__manifest__.py
+++ b/ssi_school_admission_operating_unit/__manifest__.py
@@ -17,6 +17,7 @@
     "depends": [
         "ssi_school_admission",
         "ssi_operating_unit_mixin",
+        "ssi_financial_accounting_operating_unit",
     ],
     "data": [
         "security/res_groups/school_admission.xml",

--- a/ssi_school_admission_operating_unit/models/__init__.py
+++ b/ssi_school_admission_operating_unit/models/__init__.py
@@ -5,5 +5,6 @@
 from . import (  # noqa: F401
     school_admission,
     school_admission_form,
+    school_admission_payment_term,
     school_admission_test,
 )

--- a/ssi_school_admission_operating_unit/models/school_admission_form.py
+++ b/ssi_school_admission_operating_unit/models/school_admission_form.py
@@ -5,10 +5,11 @@
 from odoo import models
 
 
-class SchoolAdmissionForm(models.Model):  # pylint: disable=too-few-public-methods
+class SchoolAdmissionForm(models.Model):
     """
     Extends School Admission Form with single operating unit support
     for operating unit-based access and data segregation.
+    Propagates operating_unit_id to the generated accounting entry.
     """
 
     _name = "school_admission_form"
@@ -16,3 +17,8 @@ class SchoolAdmissionForm(models.Model):  # pylint: disable=too-few-public-metho
         "school_admission_form",
         "mixin.single_operating_unit",
     ]
+
+    def _prepare_standard_move(self):
+        res = super()._prepare_standard_move()
+        res["operating_unit_id"] = self.operating_unit_id.id
+        return res

--- a/ssi_school_admission_operating_unit/models/school_admission_payment_term.py
+++ b/ssi_school_admission_operating_unit/models/school_admission_payment_term.py
@@ -1,0 +1,20 @@
+# Copyright 2026 OpenSynergy Indonesia
+# Copyright 2026 PT. Simetri Sinergi Indonesia
+# License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl).
+
+from odoo import models
+
+
+class SchoolAdmissionPaymentTerm(models.Model):
+    """
+    Extends School Admission Payment Term to propagate
+    operating_unit_id from the parent admission to the generated invoice.
+    """
+
+    _name = "school_admission_payment_term"
+    _inherit = "school_admission_payment_term"
+
+    def _prepare_invoice_data(self):
+        res = super()._prepare_invoice_data()
+        res["operating_unit_id"] = self.admission_id.operating_unit_id.id
+        return res

--- a/ssi_school_operating_unit/__manifest__.py
+++ b/ssi_school_operating_unit/__manifest__.py
@@ -17,6 +17,7 @@
     "depends": [
         "ssi_school",
         "ssi_operating_unit_mixin",
+        "ssi_financial_accounting_operating_unit",
     ],
     "data": [
         # Security - transactional (school_enrollment)

--- a/ssi_school_operating_unit/models/__init__.py
+++ b/ssi_school_operating_unit/models/__init__.py
@@ -7,6 +7,7 @@ from . import (  # noqa: F401
     school_academic_term,
     school_academic_year,
     school_enrollment,
+    school_enrollment_payment_term,
     school_grade,
     school_grade_class,
     school_grade_type,

--- a/ssi_school_operating_unit/models/school_enrollment_payment_term.py
+++ b/ssi_school_operating_unit/models/school_enrollment_payment_term.py
@@ -1,0 +1,20 @@
+# Copyright 2025 OpenSynergy Indonesia
+# Copyright 2025 PT. Simetri Sinergi Indonesia
+# License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl).
+
+from odoo import models
+
+
+class SchoolEnrollmentPaymentTerm(models.Model):
+    """
+    Extends School Enrollment Payment Term to propagate
+    operating_unit_id from the parent enrollment to the generated invoice.
+    """
+
+    _name = "school_enrollment_payment_term"
+    _inherit = "school_enrollment_payment_term"
+
+    def _prepare_invoice_data(self):
+        res = super()._prepare_invoice_data()
+        res["operating_unit_id"] = self.enrollment_id.operating_unit_id.id
+        return res


### PR DESCRIPTION
## Summary

- Override `_prepare_standard_move()` pada `school_admission_form` (ssi_school_admission_operating_unit) agar `account.move` yang dihasilkan mewarisi `operating_unit_id` dari dokumen sumber
- Tambah model `school_admission_payment_term` di ssi_school_admission_operating_unit untuk propagasi `operating_unit_id` ke invoice dari `admission_id.operating_unit_id`
- Tambah model `school_enrollment_payment_term` di ssi_school_operating_unit untuk propagasi `operating_unit_id` ke invoice dari `enrollment_id.operating_unit_id`
- Tambah dependensi `ssi_financial_accounting_operating_unit` pada kedua manifest

## Test plan

- [ ] Install `ssi_school_admission_operating_unit` dan `ssi_school_operating_unit`
- [ ] Buat `school_admission_form` dengan OU → open → verifikasi `move_id.operating_unit_id` = OU form
- [ ] Buat `school_admission` dengan OU → open → buat invoice dari payment term → verifikasi `invoice_id.operating_unit_id` = OU admission
- [ ] Buat `school_enrollment` dengan OU → open → buat invoice dari payment term → verifikasi `invoice_id.operating_unit_id` = OU enrollment

🤖 Generated with [Claude Code](https://claude.com/claude-code)