### PR TITLE
[UPD] ssi_school_admission: tambah ringkasan per produk (product_summary_ids)

### DIFF
--- a/ssi_school_admission/__manifest__.py
+++ b/ssi_school_admission/__manifest__.py
@@ -56,6 +56,7 @@
         "ir_module_category/school_admission.xml",
         "res_group/school_admission.xml",
         "ir_model_access/school_admission.xml",
+        "ir_model_access/school_admission_product_summary.xml",
         "ir_model_access/school_admission_payment_template.xml",
         "ir_model_access/school_admission_payment_term.xml",
         "ir_rule/school_admission.xml",

--- a/ssi_school_admission/ir_model_access/school_admission_product_summary.xml
+++ b/ssi_school_admission/ir_model_access/school_admission_product_summary.xml
@@ -1,0 +1,23 @@
+<?xml version="1.0" encoding="utf-8" ?>
+<!-- Copyright 2024 OpenSynergy Indonesia
+     Copyright 2024 PT. Simetri Sinergi Indonesia
+     License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl). -->
+<odoo>
+<record id="school_admission_product_summary_all_access" model="ir.model.access">
+    <field name="name">school_admission_product_summary - all</field>
+    <field name="model_id" ref="model_school_admission_product_summary" />
+    <field name="perm_read" eval="1" />
+    <field name="perm_create" eval="0" />
+    <field name="perm_write" eval="0" />
+    <field name="perm_unlink" eval="0" />
+</record>
+<record id="school_admission_product_summary_user_access" model="ir.model.access">
+    <field name="name">school_admission_product_summary - user</field>
+    <field name="model_id" ref="model_school_admission_product_summary" />
+    <field name="group_id" ref="school_admission_user_group" />
+    <field name="perm_read" eval="1" />
+    <field name="perm_create" eval="1" />
+    <field name="perm_write" eval="1" />
+    <field name="perm_unlink" eval="1" />
+</record>
+</odoo>

--- a/ssi_school_admission/models/__init__.py
+++ b/ssi_school_admission/models/__init__.py
@@ -12,6 +12,7 @@ from . import (  # noqa: F401
     school_admission_payment_template,
     school_admission_payment_template_term,
     school_admission_payment_template_term_detail,
+    school_admission_product_summary,
     school_admission,
     school_admission_payment_term,
     school_admission_payment_term_detail,

--- a/ssi_school_admission/models/school_admission.py
+++ b/ssi_school_admission/models/school_admission.py
@@ -213,6 +213,12 @@ class SchoolAdmission(models.Model):
         inverse_name="admission_id",
         help="The payment installment terms defined for this admission.",
     )
+    product_summary_ids = fields.One2many(
+        string="Product Summary",
+        comodel_name="school_admission_product_summary",
+        inverse_name="admission_id",
+        help="Aggregated payment amounts per product across all payment terms.",
+    )
     receivable_journal_id = fields.Many2one(
         string="Receivable Journal",
         comodel_name="account.journal",
@@ -309,6 +315,38 @@ class SchoolAdmission(models.Model):
                         "uom_id": tdetail.uom_id.id if tdetail.uom_id else False,
                         "price_unit": tdetail.price_unit,
                         "tax_ids": [(6, 0, tdetail.tax_ids.ids)],
+                    }
+                )
+        self._recompute_product_summary()
+
+    def _recompute_product_summary(self):
+        for record in self:
+            record.product_summary_ids.unlink()
+            product_data = {}
+            for term in record.payment_term_ids:
+                for detail in term.detail_ids:
+                    pid = detail.product_id.id
+                    if not pid:
+                        continue
+                    if pid not in product_data:
+                        product_data[pid] = {
+                            "product_id": pid,
+                            "amount_untaxed": 0.0,
+                            "amount_tax": 0.0,
+                            "amount_total": 0.0,
+                        }
+                    product_data[pid]["amount_untaxed"] += detail.price_subtotal
+                    product_data[pid]["amount_tax"] += detail.price_tax
+                    product_data[pid]["amount_total"] += detail.price_total
+            Summary = self.env[
+                "school_admission_product_summary"
+            ]  # pylint: disable=invalid-name
+            for seq, data in enumerate(product_data.values(), start=1):
+                Summary.create(
+                    {
+                        "admission_id": record.id,
+                        "sequence": seq * 5,
+                        **data,
                     }
                 )
 

--- a/ssi_school_admission/models/school_admission_payment_term.py
+++ b/ssi_school_admission/models/school_admission_payment_term.py
@@ -156,6 +156,12 @@ class SchoolAdmissionPaymentTerm(models.Model):
         ),
     )
 
+    def unlink(self):
+        admissions = self.mapped("admission_id")
+        result = super().unlink()
+        admissions._recompute_product_summary()  # pylint: disable=protected-access
+        return result
+
     def action_create_invoice(self):
         for record in self.sudo():
             record._create_invoice()  # pylint: disable=protected-access

--- a/ssi_school_admission/models/school_admission_payment_term_detail.py
+++ b/ssi_school_admission/models/school_admission_payment_term_detail.py
@@ -2,12 +2,10 @@
 # Copyright 2024 PT. Simetri Sinergi Indonesia
 # License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl).
 
-from odoo import fields, models
+from odoo import api, fields, models
 
 
-class SchoolAdmissionPaymentTermDetail(
-    models.Model
-):  # pylint: disable=too-few-public-methods
+class SchoolAdmissionPaymentTermDetail(models.Model):
     """
     Represents a single fee line detail within a school admission
     payment term, specifying the product, amount, and associated
@@ -50,6 +48,29 @@ class SchoolAdmissionPaymentTermDetail(
         ondelete="restrict",
         help=("The invoice line linked to this detail " "after the term is invoiced."),
     )
+
+    _SUMMARY_FIELDS = {"product_id", "price_subtotal", "price_tax", "price_total"}
+
+    @api.model
+    def create(self, vals):
+        record = super().create(vals)
+        admission = record.term_id.admission_id
+        if admission:
+            admission._recompute_product_summary()  # pylint: disable=protected-access
+        return record
+
+    def write(self, vals):
+        result = super().write(vals)
+        if self._SUMMARY_FIELDS & set(vals.keys()):
+            admissions = self.mapped("term_id.admission_id")
+            admissions._recompute_product_summary()  # pylint: disable=protected-access
+        return result
+
+    def unlink(self):
+        admissions = self.mapped("term_id.admission_id")
+        result = super().unlink()
+        admissions._recompute_product_summary()  # pylint: disable=protected-access
+        return result
 
     def _prepare_invoice_line(self):
         self.ensure_one()

--- a/ssi_school_admission/models/school_admission_product_summary.py
+++ b/ssi_school_admission/models/school_admission_product_summary.py
@@ -1,0 +1,58 @@
+# Copyright 2024 OpenSynergy Indonesia
+# Copyright 2024 PT. Simetri Sinergi Indonesia
+# License AGPL-3.0 or later (https://www.gnu.org/licenses/agpl).
+
+from odoo import fields, models
+
+
+class SchoolAdmissionProductSummary(models.Model):
+    """
+    Aggregates payment term detail lines across all terms in a school
+    admission, grouped by product. Recomputed automatically whenever
+    term or term detail records are created, modified, or deleted.
+    """
+
+    _name = "school_admission_product_summary"
+    _description = "School Admission Product Summary"
+    _order = "sequence, product_id, id"
+
+    admission_id = fields.Many2one(
+        string="Admission",
+        comodel_name="school_admission",
+        ondelete="cascade",
+        help="The parent school admission this summary line belongs to.",
+    )
+    sequence = fields.Integer(
+        string="Sequence",
+        default=5,
+        help="Display order of this product summary line.",
+    )
+    product_id = fields.Many2one(
+        string="Product",
+        comodel_name="product.product",
+        required=True,
+        ondelete="restrict",
+        help="The product whose amounts are aggregated across all payment terms.",
+    )
+    currency_id = fields.Many2one(
+        string="Currency",
+        comodel_name="res.currency",
+        related="admission_id.currency_id",
+        store=True,
+        help="The currency derived from the parent admission record.",
+    )
+    amount_untaxed = fields.Monetary(
+        string="Subtotal",
+        currency_field="currency_id",
+        help="Total amount before taxes for this product across all terms.",
+    )
+    amount_tax = fields.Monetary(
+        string="Tax",
+        currency_field="currency_id",
+        help="Total tax amount for this product across all terms.",
+    )
+    amount_total = fields.Monetary(
+        string="Total",
+        currency_field="currency_id",
+        help="Total amount including taxes for this product across all terms.",
+    )

--- a/ssi_school_admission/views/school_admission.xml
+++ b/ssi_school_admission/views/school_admission.xml
@@ -164,6 +164,23 @@
                         </group>
                     </group>
                 </page>
+                <page name="product_summary" string="Product Summary">
+                    <field
+                            name="product_summary_ids"
+                            colspan="4"
+                            nolabel="1"
+                            readonly="1"
+                        >
+                        <tree>
+                            <field name="sequence" invisible="1" />
+                            <field name="product_id" />
+                            <field name="currency_id" invisible="1" />
+                            <field name="amount_untaxed" />
+                            <field name="amount_tax" />
+                            <field name="amount_total" />
+                        </tree>
+                    </field>
+                </page>
                 <page name="result" string="Result">
                     <group name="result_group" colspan="4" col="2">
                         <field name="school_student_id" />


### PR DESCRIPTION
## Summary

- Tambah model `school_admission_product_summary` untuk merangkum detail payment term berdasarkan produk
- Tambah field `product_summary_ids` (O2M) pada `school_admission`
- Method `_recompute_product_summary` dipanggil otomatis saat term/detail dibuat, diubah, atau dihapus
- Tambah akses `ir.model.access` identik pola `school_admission` (viewer=read, user=full CRUD)
- Tambah tab **Product Summary** pada form view admission

## Test plan

- [ ] Install/update modul `ssi_school_admission`
- [ ] Buka form admission → tab "Product Summary" muncul
- [ ] Jalankan "Compute Payment" dari template → tab Product Summary terisi otomatis, dikelompokkan per produk
- [ ] Edit jumlah/produk di detail term secara manual → summary terupdate otomatis
- [ ] Hapus term/detail → summary terupdate otomatis
- [ ] User tanpa group `school_admission_user_group` hanya bisa read summary

🤖 Generated with [Claude Code](https://claude.com/claude-code)