### PR TITLE
[UPD] ssi_school: Tambah payment summary per produk di enrollment

### DIFF
--- a/ssi_school/__manifest__.py
+++ b/ssi_school/__manifest__.py
@@ -38,6 +38,7 @@
         "security/ir_model_access/school_enrollment.xml",
         "security/ir_model_access/school_enrollment_payment_term.xml",
         "security/ir_model_access/school_enrollment_payment_term_detail.xml",
+        "security/ir_model_access/school_enrollment_product_summary.xml",
         "security/ir_model_access/school_enrollment_payment_template.xml",
         "security/ir_rule/school_enrollment.xml",
         "ir_sequence/school_enrollment.xml",

--- a/ssi_school/models/__init__.py
+++ b/ssi_school/models/__init__.py
@@ -17,4 +17,5 @@ from . import (  # noqa: F401
     school_enrollment,
     school_enrollment_payment_term,
     school_enrollment_payment_term_detail,
+    school_enrollment_product_summary,
 )

--- a/ssi_school/models/school_enrollment.py
+++ b/ssi_school/models/school_enrollment.py
@@ -284,6 +284,16 @@ class SchoolEnrollment(models.Model):
             "by the student for this enrollment."
         ),
     )
+    product_summary_ids = fields.One2many(
+        string="Payment Summary",
+        comodel_name="school_enrollment.product_summary",
+        inverse_name="enrollment_id",
+        help=(
+            "Automatically maintained summary of all payment term details "
+            "grouped by product. Recomputed on every change to payment terms "
+            "or their detail lines."
+        ),
+    )
     receivable_journal_id = fields.Many2one(
         string="Receivable Journal",
         comodel_name="account.journal",
@@ -337,6 +347,34 @@ class SchoolEnrollment(models.Model):
         compute_sudo=True,
         help="Policy that determines whether the Graduate action button is visible.",
     )
+
+    def _recompute_product_summaries(self):
+        for record in self.sudo():
+            summary_data = {}
+            for term in record.payment_term_ids:
+                for detail in term.detail_ids:
+                    pid = detail.product_id.id
+                    if not pid:
+                        continue
+                    if pid not in summary_data:
+                        summary_data[pid] = {
+                            "enrollment_id": record.id,
+                            "product_id": pid,
+                            "uom_quantity": 0.0,
+                            "amount_untaxed": 0.0,
+                            "amount_tax": 0.0,
+                            "amount_total": 0.0,
+                        }
+                    summary_data[pid]["uom_quantity"] += detail.uom_quantity
+                    summary_data[pid]["amount_untaxed"] += detail.price_subtotal
+                    summary_data[pid]["amount_tax"] += detail.price_tax
+                    summary_data[pid]["amount_total"] += detail.price_total
+            record.product_summary_ids.unlink()
+            Summary = self.env[
+                "school_enrollment.product_summary"
+            ]  # pylint: disable=invalid-name
+            for data in summary_data.values():
+                Summary.create(data)
 
     def _compute_policy(self):  # pylint: disable=missing-return
         _super = super()

--- a/ssi_school/models/school_enrollment_payment_term.py
+++ b/ssi_school/models/school_enrollment_payment_term.py
@@ -257,3 +257,24 @@ class SchoolEnrollmentPaymentTerm(models.Model):
         self.detail_ids.write({"invoice_line_id": False})
         self.write({"invoice_id": False})
         invoice.unlink()
+
+    @api.model
+    def create(self, vals):
+        result = super().create(vals)
+        if result.enrollment_id:
+            enrollment = result.enrollment_id
+            enrollment._recompute_product_summaries()  # pylint: disable=protected-access
+        return result
+
+    def write(self, vals):
+        result = super().write(vals)
+        self.mapped(
+            "enrollment_id"
+        )._recompute_product_summaries()  # pylint: disable=protected-access
+        return result
+
+    def unlink(self):
+        enrollments = self.mapped("enrollment_id")
+        result = super().unlink()
+        enrollments._recompute_product_summaries()  # pylint: disable=protected-access
+        return result

--- a/ssi_school/models/school_enrollment_payment_term_detail.py
+++ b/ssi_school/models/school_enrollment_payment_term_detail.py
@@ -2,7 +2,7 @@
 # Copyright 2023 PT. Simetri Sinergi Indonesia
 # License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl).
 
-from odoo import fields, models
+from odoo import api, fields, models
 
 
 class SchoolEnrollmentPaymentTermDetail(
@@ -72,3 +72,24 @@ class SchoolEnrollmentPaymentTermDetail(
             "tax_ids": [(6, 0, self.tax_ids.ids)],
             "analytic_account_id": aa or False,
         }
+
+    @api.model
+    def create(self, vals):
+        result = super().create(vals)
+        enrollment = result.term_id.enrollment_id
+        if enrollment:
+            enrollment._recompute_product_summaries()  # pylint: disable=protected-access
+        return result
+
+    def write(self, vals):
+        result = super().write(vals)
+        self.mapped(
+            "term_id.enrollment_id"
+        )._recompute_product_summaries()  # pylint: disable=protected-access
+        return result
+
+    def unlink(self):
+        enrollments = self.mapped("term_id.enrollment_id")
+        result = super().unlink()
+        enrollments._recompute_product_summaries()  # pylint: disable=protected-access
+        return result

--- a/ssi_school/models/school_enrollment_product_summary.py
+++ b/ssi_school/models/school_enrollment_product_summary.py
@@ -1,0 +1,65 @@
+# Copyright 2022 OpenSynergy Indonesia
+# Copyright 2022 PT. Simetri Sinergi Indonesia
+# License AGPL-3.0 or later (https://www.gnu.org/licenses/agpl).
+
+from odoo import fields, models
+
+
+class SchoolEnrollmentProductSummary(models.Model):
+    """
+    Aggregates enrollment payment term details grouped by product.
+    Each record represents the total quantity and amounts for one product
+    across all payment terms of the parent enrollment.
+    Records are maintained automatically whenever payment terms or their
+    detail lines change.
+    """
+
+    _name = "school_enrollment.product_summary"
+    _description = "School Enrollment - Product Summary"
+    _order = "enrollment_id, product_id"
+
+    enrollment_id = fields.Many2one(
+        string="# Enrollment",
+        comodel_name="school_enrollment",
+        required=True,
+        ondelete="cascade",
+        help="The enrollment that owns this product summary line.",
+    )
+    product_id = fields.Many2one(
+        string="Product",
+        comodel_name="product.product",
+        required=True,
+        help="The product/fee type being summarised across all payment terms.",
+    )
+    currency_id = fields.Many2one(
+        string="Currency",
+        comodel_name="res.currency",
+        related="enrollment_id.currency_id",
+        store=True,
+        compute_sudo=True,
+        help="The billing currency, taken from the enrollment.",
+    )
+    uom_quantity = fields.Float(
+        string="Total Qty",
+        digits="Product Unit of Measure",
+        default=0.0,
+        help="Sum of quantities for this product across all payment term details.",
+    )
+    amount_untaxed = fields.Monetary(
+        string="Untaxed Amount",
+        currency_field="currency_id",
+        default=0.0,
+        help="Sum of untaxed subtotals for this product across all payment terms.",
+    )
+    amount_tax = fields.Monetary(
+        string="Tax",
+        currency_field="currency_id",
+        default=0.0,
+        help="Sum of tax amounts for this product across all payment terms.",
+    )
+    amount_total = fields.Monetary(
+        string="Total",
+        currency_field="currency_id",
+        default=0.0,
+        help="Sum of totals (including tax) for this product across all payment terms.",
+    )

--- a/ssi_school/security/ir_model_access/school_enrollment_product_summary.xml
+++ b/ssi_school/security/ir_model_access/school_enrollment_product_summary.xml
@@ -1,0 +1,36 @@
+<?xml version="1.0" encoding="utf-8" ?>
+<!-- Copyright 2022 OpenSynergy Indonesia
+     Copyright 2022 PT. Simetri Sinergi Indonesia
+     License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl). -->
+<odoo>
+
+<record id="school_enrollment_product_summary_all_access" model="ir.model.access">
+    <field name="name">school_enrollment_product_summary - all</field>
+    <field name="model_id" ref="model_school_enrollment_product_summary" />
+    <field name="perm_read" eval="1" />
+    <field name="perm_create" eval="0" />
+    <field name="perm_write" eval="0" />
+    <field name="perm_unlink" eval="0" />
+</record>
+
+<record id="school_enrollment_product_summary_viewer_access" model="ir.model.access">
+    <field name="name">school_enrollment_product_summary - viewer</field>
+    <field name="model_id" ref="model_school_enrollment_product_summary" />
+    <field name="group_id" ref="school_enrollment_viewer_group" />
+    <field name="perm_read" eval="1" />
+    <field name="perm_create" eval="0" />
+    <field name="perm_write" eval="0" />
+    <field name="perm_unlink" eval="0" />
+</record>
+
+<record id="school_enrollment_product_summary_user_access" model="ir.model.access">
+    <field name="name">school_enrollment_product_summary - user</field>
+    <field name="model_id" ref="model_school_enrollment_product_summary" />
+    <field name="group_id" ref="school_enrollment_user_group" />
+    <field name="perm_read" eval="1" />
+    <field name="perm_create" eval="1" />
+    <field name="perm_write" eval="1" />
+    <field name="perm_unlink" eval="1" />
+</record>
+
+</odoo>

--- a/ssi_school/tests/__init__.py
+++ b/ssi_school/tests/__init__.py
@@ -17,4 +17,5 @@ from . import (  # noqa: F401
     test_school_enrollment,
     test_school_enrollment_results,
     test_school_enrollment_payment_term_management,
+    test_school_enrollment_product_summary,
 )

--- a/ssi_school/tests/test_data_enrollment_product_summary.yaml
+++ b/ssi_school/tests/test_data_enrollment_product_summary.yaml
@@ -1,0 +1,716 @@
+scenarios:
+  - name: "Product Summary - satu produk satu term tercompute saat detail ditambah"
+    steps:
+      - step: "Setup - get account type ref"
+        action: "ref"
+        xml_id: "account.data_account_type_revenue"
+        save_as: "account_type"
+
+      - step: "Setup - create income account"
+        action: "create"
+        model: "account.account"
+        save_as: "account"
+        values:
+          name: "School Fee Income PS1"
+          code: "PS14200"
+          user_type_id: "EVAL: registry['account_type'].id"
+
+      - step: "Setup - create product"
+        action: "create"
+        model: "product.product"
+        save_as: "product"
+        values:
+          name: "School Fee PS1"
+          type: "service"
+          list_price: 1000000.0
+
+      - step: "Setup - create grade type"
+        action: "create"
+        model: "school_grade_type"
+        save_as: "grade_type"
+        values:
+          name: "Grade Type PS1"
+          code: "GTPS1"
+          sequence: 10
+
+      - step: "Setup - create academic year"
+        action: "create"
+        model: "school_academic_year"
+        save_as: "academic_year"
+        values:
+          name: "2024/2025 PS1"
+          code: "AYPS1"
+          date_start: "2024-07-01"
+          date_end: "2025-06-30"
+
+      - step: "Setup - create academic term"
+        action: "create"
+        model: "school_academic_term"
+        save_as: "academic_term"
+        values:
+          name: "Semester PS1"
+          code: "SMPS1"
+          date_start: "2024-07-01"
+          date_end: "2025-06-30"
+          year_id: "EVAL: registry['academic_year'].id"
+          enrollment_state: "open"
+
+      - step: "Setup - create school"
+        action: "create"
+        model: "school"
+        save_as: "school"
+        values:
+          name: "School PS1"
+          code: "SCHPS1"
+          grade_type_id: "EVAL: registry['grade_type'].id"
+
+      - step: "Setup - create grade"
+        action: "create"
+        model: "school_grade"
+        save_as: "grade"
+        values:
+          name: "Grade PS1"
+          code: "GPS1"
+          sequence: 10
+          type_id: "EVAL: registry['grade_type'].id"
+
+      - step: "Setup - create grade class"
+        action: "create"
+        model: "school_grade_class"
+        save_as: "grade_class"
+        values:
+          name: "Class PS1"
+          code: "CLAPS1"
+          school_id: "EVAL: registry['school'].id"
+          grade_id: "EVAL: registry['grade'].id"
+
+      - step: "Setup - create student contact"
+        action: "create"
+        model: "res.partner"
+        save_as: "contact"
+        values:
+          name: "Student Contact PS1"
+
+      - step: "Setup - create student"
+        action: "create"
+        model: "school_student"
+        save_as: "student"
+        values:
+          name: "Student PS1"
+          code: "STUPS1"
+          contact_id: "EVAL: registry['contact'].id"
+          school_id: "EVAL: registry['school'].id"
+
+      - step: "Create enrollment tanpa payment term"
+        action: "create"
+        model: "school_enrollment"
+        save_as: "enrollment"
+        values:
+          date: "2024-07-01"
+          academic_year_id: "EVAL: registry['academic_year'].id"
+          academic_term_id: "EVAL: registry['academic_term'].id"
+          school_id: "EVAL: registry['school'].id"
+          grade_id: "EVAL: registry['grade'].id"
+          grade_class_id: "EVAL: registry['grade_class'].id"
+          student_id: "EVAL: registry['student'].id"
+          currency_id: "EVAL: env.company.currency_id.id"
+
+      - step: "Assert product_summary_ids kosong di awal"
+        action: "assert"
+        target: "enrollment"
+        asserts:
+          product_summary_ids:
+            type: "o2m"
+            check: "count"
+            expected_count: 0
+
+      - step: "Tambah payment term pada enrollment"
+        action: "create"
+        model: "school_enrollment_payment_term"
+        save_as: "term"
+        values:
+          enrollment_id: "EVAL: registry['enrollment'].id"
+          name: "Term 1 PS1"
+          sequence: 10
+
+      - step: "Tambah detail pada payment term"
+        action: "create"
+        model: "school_enrollment_payment_term_detail"
+        save_as: "detail"
+        values:
+          term_id: "EVAL: registry['term'].id"
+          product_id: "EVAL: registry['product'].id"
+          name: "School Fee PS1"
+          account_id: "EVAL: registry['account'].id"
+          uom_quantity: 1.0
+          uom_id: "REF: uom.product_uom_unit"
+          price_unit: 1000000.0
+
+      - step: "Invalidate enrollment cache"
+        action: "call"
+        target: "enrollment"
+        method: "invalidate_cache"
+
+      - step: "Assert product_summary_ids berisi 1 record"
+        action: "assert"
+        target: "enrollment"
+        asserts:
+          product_summary_ids:
+            type: "o2m"
+            check: "count"
+            expected_count: 1
+
+      - step: "Cari summary record"
+        action: "search"
+        model: "school_enrollment.product_summary"
+        domain: [["enrollment_id", "=", "EVAL: registry['enrollment'].id"]]
+        save_as: "summary"
+        expect_count: 1
+
+      - step: "Assert nilai amount_untaxed pada summary"
+        action: "assert"
+        target: "summary"
+        asserts:
+          uom_quantity:
+            type: "value"
+            expected: 1.0
+          amount_untaxed:
+            type: "value"
+            expected: 1000000.0
+          amount_total:
+            type: "value"
+            expected: 1000000.0
+
+  - name: "Product Summary - dua term produk sama diaggregate jadi satu summary"
+    steps:
+      - step: "Setup - get account type ref"
+        action: "ref"
+        xml_id: "account.data_account_type_revenue"
+        save_as: "account_type"
+
+      - step: "Setup - create income account"
+        action: "create"
+        model: "account.account"
+        save_as: "account"
+        values:
+          name: "School Fee Income PS2"
+          code: "PS24200"
+          user_type_id: "EVAL: registry['account_type'].id"
+
+      - step: "Setup - create product"
+        action: "create"
+        model: "product.product"
+        save_as: "product"
+        values:
+          name: "School Fee PS2"
+          type: "service"
+          list_price: 500000.0
+
+      - step: "Setup - create grade type"
+        action: "create"
+        model: "school_grade_type"
+        save_as: "grade_type"
+        values:
+          name: "Grade Type PS2"
+          code: "GTPS2"
+          sequence: 10
+
+      - step: "Setup - create academic year"
+        action: "create"
+        model: "school_academic_year"
+        save_as: "academic_year"
+        values:
+          name: "2024/2025 PS2"
+          code: "AYPS2"
+          date_start: "2024-07-01"
+          date_end: "2025-06-30"
+
+      - step: "Setup - create academic term"
+        action: "create"
+        model: "school_academic_term"
+        save_as: "academic_term"
+        values:
+          name: "Semester PS2"
+          code: "SMPS2"
+          date_start: "2024-07-01"
+          date_end: "2025-06-30"
+          year_id: "EVAL: registry['academic_year'].id"
+          enrollment_state: "open"
+
+      - step: "Setup - create school"
+        action: "create"
+        model: "school"
+        save_as: "school"
+        values:
+          name: "School PS2"
+          code: "SCHPS2"
+          grade_type_id: "EVAL: registry['grade_type'].id"
+
+      - step: "Setup - create grade"
+        action: "create"
+        model: "school_grade"
+        save_as: "grade"
+        values:
+          name: "Grade PS2"
+          code: "GPS2"
+          sequence: 10
+          type_id: "EVAL: registry['grade_type'].id"
+
+      - step: "Setup - create grade class"
+        action: "create"
+        model: "school_grade_class"
+        save_as: "grade_class"
+        values:
+          name: "Class PS2"
+          code: "CLAPS2"
+          school_id: "EVAL: registry['school'].id"
+          grade_id: "EVAL: registry['grade'].id"
+
+      - step: "Setup - create student contact"
+        action: "create"
+        model: "res.partner"
+        save_as: "contact"
+        values:
+          name: "Student Contact PS2"
+
+      - step: "Setup - create student"
+        action: "create"
+        model: "school_student"
+        save_as: "student"
+        values:
+          name: "Student PS2"
+          code: "STUPS2"
+          contact_id: "EVAL: registry['contact'].id"
+          school_id: "EVAL: registry['school'].id"
+
+      - step: "Create enrollment"
+        action: "create"
+        model: "school_enrollment"
+        save_as: "enrollment"
+        values:
+          date: "2024-07-01"
+          academic_year_id: "EVAL: registry['academic_year'].id"
+          academic_term_id: "EVAL: registry['academic_term'].id"
+          school_id: "EVAL: registry['school'].id"
+          grade_id: "EVAL: registry['grade'].id"
+          grade_class_id: "EVAL: registry['grade_class'].id"
+          student_id: "EVAL: registry['student'].id"
+          currency_id: "EVAL: env.company.currency_id.id"
+
+      - step: "Tambah term 1 dengan detail"
+        action: "create"
+        model: "school_enrollment_payment_term"
+        save_as: "term1"
+        values:
+          enrollment_id: "EVAL: registry['enrollment'].id"
+          name: "Term 1 PS2"
+          sequence: 10
+
+      - step: "Tambah detail term 1"
+        action: "create"
+        model: "school_enrollment_payment_term_detail"
+        values:
+          term_id: "EVAL: registry['term1'].id"
+          product_id: "EVAL: registry['product'].id"
+          name: "Fee Term 1 PS2"
+          account_id: "EVAL: registry['account'].id"
+          uom_quantity: 1.0
+          uom_id: "REF: uom.product_uom_unit"
+          price_unit: 500000.0
+
+      - step: "Tambah term 2 dengan detail produk yang sama"
+        action: "create"
+        model: "school_enrollment_payment_term"
+        save_as: "term2"
+        values:
+          enrollment_id: "EVAL: registry['enrollment'].id"
+          name: "Term 2 PS2"
+          sequence: 20
+
+      - step: "Tambah detail term 2 dengan produk sama"
+        action: "create"
+        model: "school_enrollment_payment_term_detail"
+        values:
+          term_id: "EVAL: registry['term2'].id"
+          product_id: "EVAL: registry['product'].id"
+          name: "Fee Term 2 PS2"
+          account_id: "EVAL: registry['account'].id"
+          uom_quantity: 1.0
+          uom_id: "REF: uom.product_uom_unit"
+          price_unit: 500000.0
+
+      - step: "Invalidate enrollment cache"
+        action: "call"
+        target: "enrollment"
+        method: "invalidate_cache"
+
+      - step: "Assert product_summary_ids hanya 1 record meski 2 term"
+        action: "assert"
+        target: "enrollment"
+        asserts:
+          product_summary_ids:
+            type: "o2m"
+            check: "count"
+            expected_count: 1
+
+      - step: "Cari summary record"
+        action: "search"
+        model: "school_enrollment.product_summary"
+        domain: [["enrollment_id", "=", "EVAL: registry['enrollment'].id"]]
+        save_as: "summary"
+        expect_count: 1
+
+      - step: "Assert total quantity dan amount diaggregate dari dua term"
+        action: "assert"
+        target: "summary"
+        asserts:
+          uom_quantity:
+            type: "value"
+            expected: 2.0
+          amount_untaxed:
+            type: "value"
+            expected: 1000000.0
+          amount_total:
+            type: "value"
+            expected: 1000000.0
+
+  - name: "Product Summary - summary dihapus saat detail diunlink"
+    steps:
+      - step: "Setup - get account type ref"
+        action: "ref"
+        xml_id: "account.data_account_type_revenue"
+        save_as: "account_type"
+
+      - step: "Setup - create income account"
+        action: "create"
+        model: "account.account"
+        save_as: "account"
+        values:
+          name: "School Fee Income PS3"
+          code: "PS34200"
+          user_type_id: "EVAL: registry['account_type'].id"
+
+      - step: "Setup - create product"
+        action: "create"
+        model: "product.product"
+        save_as: "product"
+        values:
+          name: "School Fee PS3"
+          type: "service"
+          list_price: 750000.0
+
+      - step: "Setup - create grade type"
+        action: "create"
+        model: "school_grade_type"
+        save_as: "grade_type"
+        values:
+          name: "Grade Type PS3"
+          code: "GTPS3"
+          sequence: 10
+
+      - step: "Setup - create academic year"
+        action: "create"
+        model: "school_academic_year"
+        save_as: "academic_year"
+        values:
+          name: "2024/2025 PS3"
+          code: "AYPS3"
+          date_start: "2024-07-01"
+          date_end: "2025-06-30"
+
+      - step: "Setup - create academic term"
+        action: "create"
+        model: "school_academic_term"
+        save_as: "academic_term"
+        values:
+          name: "Semester PS3"
+          code: "SMPS3"
+          date_start: "2024-07-01"
+          date_end: "2025-06-30"
+          year_id: "EVAL: registry['academic_year'].id"
+          enrollment_state: "open"
+
+      - step: "Setup - create school"
+        action: "create"
+        model: "school"
+        save_as: "school"
+        values:
+          name: "School PS3"
+          code: "SCHPS3"
+          grade_type_id: "EVAL: registry['grade_type'].id"
+
+      - step: "Setup - create grade"
+        action: "create"
+        model: "school_grade"
+        save_as: "grade"
+        values:
+          name: "Grade PS3"
+          code: "GPS3"
+          sequence: 10
+          type_id: "EVAL: registry['grade_type'].id"
+
+      - step: "Setup - create grade class"
+        action: "create"
+        model: "school_grade_class"
+        save_as: "grade_class"
+        values:
+          name: "Class PS3"
+          code: "CLAPS3"
+          school_id: "EVAL: registry['school'].id"
+          grade_id: "EVAL: registry['grade'].id"
+
+      - step: "Setup - create student contact"
+        action: "create"
+        model: "res.partner"
+        save_as: "contact"
+        values:
+          name: "Student Contact PS3"
+
+      - step: "Setup - create student"
+        action: "create"
+        model: "school_student"
+        save_as: "student"
+        values:
+          name: "Student PS3"
+          code: "STUPS3"
+          contact_id: "EVAL: registry['contact'].id"
+          school_id: "EVAL: registry['school'].id"
+
+      - step: "Create enrollment"
+        action: "create"
+        model: "school_enrollment"
+        save_as: "enrollment"
+        values:
+          date: "2024-07-01"
+          academic_year_id: "EVAL: registry['academic_year'].id"
+          academic_term_id: "EVAL: registry['academic_term'].id"
+          school_id: "EVAL: registry['school'].id"
+          grade_id: "EVAL: registry['grade'].id"
+          grade_class_id: "EVAL: registry['grade_class'].id"
+          student_id: "EVAL: registry['student'].id"
+          currency_id: "EVAL: env.company.currency_id.id"
+
+      - step: "Tambah term"
+        action: "create"
+        model: "school_enrollment_payment_term"
+        save_as: "term"
+        values:
+          enrollment_id: "EVAL: registry['enrollment'].id"
+          name: "Term 1 PS3"
+          sequence: 10
+
+      - step: "Tambah detail"
+        action: "create"
+        model: "school_enrollment_payment_term_detail"
+        save_as: "detail"
+        values:
+          term_id: "EVAL: registry['term'].id"
+          product_id: "EVAL: registry['product'].id"
+          name: "Fee PS3"
+          account_id: "EVAL: registry['account'].id"
+          uom_quantity: 1.0
+          uom_id: "REF: uom.product_uom_unit"
+          price_unit: 750000.0
+
+      - step: "Invalidate enrollment cache"
+        action: "call"
+        target: "enrollment"
+        method: "invalidate_cache"
+
+      - step: "Assert summary ada sebelum detail dihapus"
+        action: "assert"
+        target: "enrollment"
+        asserts:
+          product_summary_ids:
+            type: "o2m"
+            check: "count"
+            expected_count: 1
+
+      - step: "Hapus detail"
+        action: "call"
+        target: "detail"
+        method: "unlink"
+
+      - step: "Invalidate enrollment cache setelah hapus detail"
+        action: "call"
+        target: "enrollment"
+        method: "invalidate_cache"
+
+      - step: "Assert summary kosong setelah detail dihapus"
+        action: "assert"
+        target: "enrollment"
+        asserts:
+          product_summary_ids:
+            type: "o2m"
+            check: "count"
+            expected_count: 0
+
+  - name: "Product Summary - summary dihapus saat term diunlink"
+    steps:
+      - step: "Setup - get account type ref"
+        action: "ref"
+        xml_id: "account.data_account_type_revenue"
+        save_as: "account_type"
+
+      - step: "Setup - create income account"
+        action: "create"
+        model: "account.account"
+        save_as: "account"
+        values:
+          name: "School Fee Income PS4"
+          code: "PS44200"
+          user_type_id: "EVAL: registry['account_type'].id"
+
+      - step: "Setup - create product"
+        action: "create"
+        model: "product.product"
+        save_as: "product"
+        values:
+          name: "School Fee PS4"
+          type: "service"
+          list_price: 250000.0
+
+      - step: "Setup - create grade type"
+        action: "create"
+        model: "school_grade_type"
+        save_as: "grade_type"
+        values:
+          name: "Grade Type PS4"
+          code: "GTPS4"
+          sequence: 10
+
+      - step: "Setup - create academic year"
+        action: "create"
+        model: "school_academic_year"
+        save_as: "academic_year"
+        values:
+          name: "2024/2025 PS4"
+          code: "AYPS4"
+          date_start: "2024-07-01"
+          date_end: "2025-06-30"
+
+      - step: "Setup - create academic term"
+        action: "create"
+        model: "school_academic_term"
+        save_as: "academic_term"
+        values:
+          name: "Semester PS4"
+          code: "SMPS4"
+          date_start: "2024-07-01"
+          date_end: "2025-06-30"
+          year_id: "EVAL: registry['academic_year'].id"
+          enrollment_state: "open"
+
+      - step: "Setup - create school"
+        action: "create"
+        model: "school"
+        save_as: "school"
+        values:
+          name: "School PS4"
+          code: "SCHPS4"
+          grade_type_id: "EVAL: registry['grade_type'].id"
+
+      - step: "Setup - create grade"
+        action: "create"
+        model: "school_grade"
+        save_as: "grade"
+        values:
+          name: "Grade PS4"
+          code: "GPS4"
+          sequence: 10
+          type_id: "EVAL: registry['grade_type'].id"
+
+      - step: "Setup - create grade class"
+        action: "create"
+        model: "school_grade_class"
+        save_as: "grade_class"
+        values:
+          name: "Class PS4"
+          code: "CLAPS4"
+          school_id: "EVAL: registry['school'].id"
+          grade_id: "EVAL: registry['grade'].id"
+
+      - step: "Setup - create student contact"
+        action: "create"
+        model: "res.partner"
+        save_as: "contact"
+        values:
+          name: "Student Contact PS4"
+
+      - step: "Setup - create student"
+        action: "create"
+        model: "school_student"
+        save_as: "student"
+        values:
+          name: "Student PS4"
+          code: "STUPS4"
+          contact_id: "EVAL: registry['contact'].id"
+          school_id: "EVAL: registry['school'].id"
+
+      - step: "Create enrollment"
+        action: "create"
+        model: "school_enrollment"
+        save_as: "enrollment"
+        values:
+          date: "2024-07-01"
+          academic_year_id: "EVAL: registry['academic_year'].id"
+          academic_term_id: "EVAL: registry['academic_term'].id"
+          school_id: "EVAL: registry['school'].id"
+          grade_id: "EVAL: registry['grade'].id"
+          grade_class_id: "EVAL: registry['grade_class'].id"
+          student_id: "EVAL: registry['student'].id"
+          currency_id: "EVAL: env.company.currency_id.id"
+
+      - step: "Tambah term dengan detail"
+        action: "create"
+        model: "school_enrollment_payment_term"
+        save_as: "term"
+        values:
+          enrollment_id: "EVAL: registry['enrollment'].id"
+          name: "Term 1 PS4"
+          sequence: 10
+
+      - step: "Tambah detail pada term"
+        action: "create"
+        model: "school_enrollment_payment_term_detail"
+        values:
+          term_id: "EVAL: registry['term'].id"
+          product_id: "EVAL: registry['product'].id"
+          name: "Fee PS4"
+          account_id: "EVAL: registry['account'].id"
+          uom_quantity: 2.0
+          uom_id: "REF: uom.product_uom_unit"
+          price_unit: 250000.0
+
+      - step: "Invalidate enrollment cache"
+        action: "call"
+        target: "enrollment"
+        method: "invalidate_cache"
+
+      - step: "Assert summary ada sebelum term dihapus"
+        action: "assert"
+        target: "enrollment"
+        asserts:
+          product_summary_ids:
+            type: "o2m"
+            check: "count"
+            expected_count: 1
+
+      - step: "Hapus term (cascade hapus detail)"
+        action: "call"
+        target: "term"
+        method: "unlink"
+
+      - step: "Invalidate enrollment cache setelah hapus term"
+        action: "call"
+        target: "enrollment"
+        method: "invalidate_cache"
+
+      - step: "Assert summary kosong setelah term dihapus"
+        action: "assert"
+        target: "enrollment"
+        asserts:
+          product_summary_ids:
+            type: "o2m"
+            check: "count"
+            expected_count: 0

--- a/ssi_school/tests/test_school_enrollment_product_summary.py
+++ b/ssi_school/tests/test_school_enrollment_product_summary.py
@@ -1,0 +1,15 @@
+# Copyright 2024 OpenSynergy Indonesia
+# Copyright 2024 PT. Simetri Sinergi Indonesia
+# License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl).
+
+from odoo_yaml_test import YamlTransactionCase
+
+from odoo.tests import tagged
+
+
+@tagged("post_install", "-at_install")
+class TestSchoolEnrollmentProductSummary(
+    YamlTransactionCase
+):  # pylint: disable=too-few-public-methods
+    def test_enrollment_product_summary(self):
+        self.run_yaml_scenario("test_data_enrollment_product_summary.yaml")

--- a/ssi_school/views/school_enrollment.xml
+++ b/ssi_school/views/school_enrollment.xml
@@ -244,6 +244,18 @@
                         <field name="receivable_account_id" />
                     </group>
                 </page>
+                <page name="payment_summary" string="Payment Summary">
+                    <field name="product_summary_ids" nolabel="1" colspan="4">
+                        <tree create="false" edit="false" delete="false">
+                            <field name="product_id" />
+                            <field name="uom_quantity" />
+                            <field name="currency_id" invisible="1" />
+                            <field name="amount_untaxed" />
+                            <field name="amount_tax" />
+                            <field name="amount_total" />
+                        </tree>
+                    </field>
+                </page>
             </xpath>
             <xpath expr="//group[@name='policy_2']" position="inside">
                 <field name="pass_ok" />


### PR DESCRIPTION
## Summary

- Menambahkan model `school_enrollment.product_summary` sebagai child dari `school_enrollment`, merangkum semua detail pembayaran dikelompokkan per produk
- Field `product_summary_ids` (One2many) ditambahkan ke `school_enrollment` dengan tab **Payment Summary** di form view
- Summary otomatis ter-recompute setiap ada perubahan (create/write/unlink) di `school_enrollment_payment_term` maupun `school_enrollment_payment_term_detail`
- Security access baru untuk model summary mengikuti pola enrollment (all: read-only, user: CRUD)
- Unit test 4 skenario: satu term satu produk, dua term produk sama (aggregate), hapus detail, hapus term

## Test plan

- [x] Unit test 4 skenario LULUS (0 failed, 0 error)
- [x] Pre-commit semua hook LULUS (black, flake8, pylint, prettier, isort)

🤖 Generated with [Claude Code](https://claude.ai/claude-code)