### PR TITLE
[UPD] ssi_school_admission

### DIFF
--- a/ssi_school_admission/models/school_admission.py
+++ b/ssi_school_admission/models/school_admission.py
@@ -245,7 +245,7 @@ class SchoolAdmission(models.Model):
         string="School Student",
         comodel_name="school_student",
         readonly=True,
-        help=("The student profile created after this " "admission is completed."),
+        help=("The student profile created when this " "admission is opened."),
     )
 
     def _compute_policy(self):  # pylint: disable=missing-return
@@ -350,7 +350,7 @@ class SchoolAdmission(models.Model):
                     }
                 )
 
-    @ssi_decorator.post_done_action()
+    @ssi_decorator.post_open_action()
     def _10_create_school_student(self):
         self.ensure_one()
         if self.school_student_id:

--- a/ssi_school_admission/tests/test_data_admission.yaml
+++ b/ssi_school_admission/tests/test_data_admission.yaml
@@ -213,6 +213,14 @@ scenarios:
         target: "admission"
         method: "invalidate_cache"
 
+      - step: "Assert school student created on open"
+        action: "assert"
+        target: "admission"
+        asserts:
+          school_student_id:
+            type: "value"
+            operator: "is_truthy"
+
       - step: "Done admission"
         action: "call"
         target: "admission"
@@ -227,14 +235,6 @@ scenarios:
         action: "call"
         target: "admission"
         method: "invalidate_cache"
-
-      - step: "Assert school student created"
-        action: "assert"
-        target: "admission"
-        asserts:
-          school_student_id:
-            type: "value"
-            operator: "is_truthy"
 
   - name: "Admission Simple Workflow: Confirm Approve Done Without Payment Template"
     steps:
@@ -351,6 +351,14 @@ scenarios:
         target: "admission"
         method: "invalidate_cache"
 
+      - step: "Assert school student created on open"
+        action: "assert"
+        target: "admission"
+        asserts:
+          school_student_id:
+            type: "value"
+            operator: "is_truthy"
+
       - step: "Done admission"
         action: "call"
         target: "admission"
@@ -365,11 +373,3 @@ scenarios:
         action: "call"
         target: "admission"
         method: "invalidate_cache"
-
-      - step: "Assert school student created"
-        action: "assert"
-        target: "admission"
-        asserts:
-          school_student_id:
-            type: "value"
-            operator: "is_truthy"


### PR DESCRIPTION
* Pindahkan pembuatan school_student dari aksi done ke aksi open (post_done_action -> post_open_action), sehingga student dibuat saat admission di-open, bukan saat di-done.
* Sesuaikan unittest YAML: assert school_student_id dibuat setelah approve/open pada kedua skenario.
* Perbarui teks help school_student_id agar sesuai perilaku baru.