### PR TITLE
[UPD] ssi_school_lead: tambah button buat admission dari lead

### DIFF
--- a/ssi_school_lead/__manifest__.py
+++ b/ssi_school_lead/__manifest__.py
@@ -15,8 +15,11 @@
     "depends": [
         "ssi_lead",
         "ssi_school",
+        "ssi_school_admission",
     ],
     "data": [
+        "security/ir.model.access.csv",
+        "views/crm_lead_create_admission_view.xml",
         "views/crm_lead_views.xml",
         "views/school_views.xml",
     ],

--- a/ssi_school_lead/models/crm_lead.py
+++ b/ssi_school_lead/models/crm_lead.py
@@ -2,10 +2,10 @@
 # Copyright 2024 PT. Simetri Sinergi Indonesia
 # License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl).
 
-from odoo import fields, models
+from odoo import api, fields, models
 
 
-class CrmLead(models.Model):  # pylint: disable=too-few-public-methods
+class CrmLead(models.Model):
     """
     Extends the CRM Lead model to associate leads with schools
     and prospective students for school admissions management.
@@ -27,3 +27,49 @@ class CrmLead(models.Model):  # pylint: disable=too-few-public-methods
         ondelete="restrict",
         help="The prospective student associated with this lead.",
     )
+    admission_id = fields.Many2one(
+        comodel_name="school_admission",
+        string="Admission",
+        ondelete="restrict",
+        help="The school admission record created from this lead.",
+    )
+    create_admission_ok = fields.Boolean(
+        string="Can Create Admission",
+        compute="_compute_create_admission_ok",
+        compute_sudo=True,
+        help="Indicates whether an admission can still be created for this lead.",
+    )
+
+    @api.depends("admission_id")
+    def _compute_create_admission_ok(self):
+        for record in self:
+            record.create_admission_ok = not record.admission_id
+
+    def action_create_admission(self):
+        for record in self.sudo():
+            result = record._create_admission()
+        return result
+
+    def _create_admission(self):
+        self.ensure_one()
+        if self.admission_id:
+            return {
+                "type": "ir.actions.act_window",
+                "name": "Admission",
+                "res_model": "school_admission",
+                "res_id": self.admission_id.id,
+                "view_mode": "form",
+                "target": "current",
+            }
+        return {
+            "type": "ir.actions.act_window",
+            "name": "Create Admission",
+            "res_model": "crm.lead.create_admission",
+            "view_mode": "form",
+            "target": "new",
+            "context": {
+                "default_lead_id": self.id,
+                "default_school_id": self.school_id.id if self.school_id else False,
+                "default_student_id": self.student_id.id if self.student_id else False,
+            },
+        }

--- a/ssi_school_lead/security/ir.model.access.csv
+++ b/ssi_school_lead/security/ir.model.access.csv
@@ -1,0 +1,2 @@
+id,name,model_id:id,group_id:id,perm_read,perm_write,perm_create,perm_unlink
+access_crm_lead_create_admission_all,crm.lead.create_admission - All,model_crm_lead_create_admission,base.group_user,1,1,1,1

--- a/ssi_school_lead/tests/test_data_school_lead.yaml
+++ b/ssi_school_lead/tests/test_data_school_lead.yaml
@@ -106,3 +106,124 @@ scenarios:
           student_id:
             type: "value"
             operator: "is_falsy"
+
+  - name: "School Lead - Create Admission via Wizard"
+    steps:
+      - step: "Create grade type"
+        action: "create"
+        model: "school_grade_type"
+        save_as: "grade_type"
+        values:
+          name: "Grade Type Admission SL"
+          code: "GTADMSL"
+          sequence: 10
+
+      - step: "Create academic year"
+        action: "create"
+        model: "school_academic_year"
+        save_as: "academic_year"
+        values:
+          name: "2024/2025 Admission SL"
+          code: "AYADMSL"
+          date_start: "2024-07-01"
+          date_end: "2025-06-30"
+
+      - step: "Create academic term"
+        action: "create"
+        model: "school_academic_term"
+        save_as: "academic_term"
+        values:
+          name: "Semester Admission SL"
+          code: "SMADMSL"
+          date_start: "2024-07-01"
+          date_end: "2025-06-30"
+          year_id: "EVAL: registry['academic_year'].id"
+          enrollment_state: "open"
+
+      - step: "Create school"
+        action: "create"
+        model: "school"
+        save_as: "school"
+        values:
+          name: "School Admission SL"
+          code: "SCHADMSL"
+          grade_type_id: "EVAL: registry['grade_type'].id"
+
+      - step: "Create grade"
+        action: "create"
+        model: "school_grade"
+        save_as: "grade"
+        values:
+          name: "Grade Admission SL"
+          code: "GADMSL"
+          sequence: 10
+          type_id: "EVAL: registry['grade_type'].id"
+
+      - step: "Create student contact"
+        action: "create"
+        model: "res.partner"
+        save_as: "student"
+        values:
+          name: "Student Admission SL"
+
+      - step: "Create CRM lead"
+        action: "create"
+        model: "crm.lead"
+        save_as: "lead"
+        as_user: "base.user_admin"
+        values:
+          name: "Lead Admission SL"
+          school_id: "EVAL: registry['school'].id"
+          student_id: "EVAL: registry['student'].id"
+
+      - step: "Assert lead has no admission yet"
+        action: "assert"
+        target: "lead"
+        asserts:
+          admission_id:
+            type: "value"
+            operator: "is_falsy"
+          create_admission_ok:
+            type: "value"
+            expected: true
+
+      - step: "Create wizard to create admission"
+        action: "create"
+        model: "crm.lead.create_admission"
+        save_as: "wizard"
+        values:
+          lead_id: "EVAL: registry['lead'].id"
+          date: "2024-07-01"
+          academic_year_id: "EVAL: registry['academic_year'].id"
+          academic_term_id: "EVAL: registry['academic_term'].id"
+          school_id: "EVAL: registry['school'].id"
+          grade_id: "EVAL: registry['grade'].id"
+          student_id: "EVAL: registry['student'].id"
+
+      - step: "Confirm wizard to create admission"
+        action: "call"
+        target: "wizard"
+        method: "action_confirm"
+        as_user: "base.user_admin"
+
+      - step: "Invalidate lead cache"
+        action: "call"
+        target: "lead"
+        method: "invalidate_cache"
+
+      - step: "Assert admission created and linked to lead"
+        action: "assert"
+        target: "lead"
+        asserts:
+          admission_id:
+            type: "value"
+            operator: "is_truthy"
+          create_admission_ok:
+            type: "value"
+            expected: false
+
+      - step: "Call action_create_admission on lead (admission already exists)"
+        action: "call"
+        target: "lead"
+        method: "action_create_admission"
+        as_user: "base.user_admin"

--- a/ssi_school_lead/views/crm_lead_create_admission_view.xml
+++ b/ssi_school_lead/views/crm_lead_create_admission_view.xml
@@ -1,0 +1,42 @@
+<?xml version="1.0" encoding="utf-8" ?>
+<!-- Copyright 2024 OpenSynergy Indonesia
+     Copyright 2024 PT. Simetri Sinergi Indonesia
+     License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl). -->
+<odoo>
+
+<record id="crm_lead_create_admission_view_form" model="ir.ui.view">
+    <field name="name">crm.lead.create_admission - form</field>
+    <field name="model">crm.lead.create_admission</field>
+    <field name="arch" type="xml">
+        <form string="Create Admission">
+            <group name="main" colspan="4" col="2">
+                <group name="left" colspan="1" col="2">
+                    <field name="lead_id" />
+                    <field name="date" />
+                    <field name="academic_year_id" />
+                    <field
+                            name="academic_term_id"
+                            domain="[('year_id', '=', academic_year_id)]"
+                        />
+                </group>
+                <group name="right" colspan="1" col="2">
+                    <field name="school_id" />
+                    <field name="grade_type_id" invisible="1" />
+                    <field name="grade_id" domain="[('type_id', '=', grade_type_id)]" />
+                    <field name="student_id" />
+                </group>
+            </group>
+            <footer>
+                <button
+                        name="action_confirm"
+                        type="object"
+                        string="Create"
+                        class="btn-primary"
+                    />
+                <button string="Cancel" class="btn-secondary" special="cancel" />
+            </footer>
+        </form>
+    </field>
+</record>
+
+</odoo>

--- a/ssi_school_lead/views/crm_lead_views.xml
+++ b/ssi_school_lead/views/crm_lead_views.xml
@@ -16,6 +16,15 @@
                 >
                 <field name="school_id" />
                 <field name="student_id" />
+                <field name="admission_id" />
+                <field name="create_admission_ok" invisible="1" />
+                <button
+                        name="action_create_admission"
+                        type="object"
+                        string="Create Admission"
+                        class="btn-primary"
+                        attrs="{'invisible': [('create_admission_ok', '=', False)]}"
+                    />
             </xpath>
             <xpath
                     expr="//group[@name='lead_partner']//field[@name='partner_id']"
@@ -23,6 +32,15 @@
                 >
                 <field name="school_id" />
                 <field name="student_id" />
+                <field name="admission_id" />
+                <field name="create_admission_ok" invisible="1" />
+                <button
+                        name="action_create_admission"
+                        type="object"
+                        string="Create Admission"
+                        class="btn-primary"
+                        attrs="{'invisible': [('create_admission_ok', '=', False)]}"
+                    />
             </xpath>
         </data>
     </field>

--- a/ssi_school_lead/wizard/__init__.py
+++ b/ssi_school_lead/wizard/__init__.py
@@ -3,6 +3,5 @@
 # License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl).
 
 from . import (  # noqa: F401
-    models,
-    wizard,
+    crm_lead_create_admission,
 )

--- a/ssi_school_lead/wizard/crm_lead_create_admission.py
+++ b/ssi_school_lead/wizard/crm_lead_create_admission.py
@@ -1,0 +1,97 @@
+# Copyright 2024 OpenSynergy Indonesia
+# Copyright 2024 PT. Simetri Sinergi Indonesia
+# License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl).
+
+from datetime import date as datetime_date
+
+from odoo import api, fields, models
+
+
+class CrmLeadCreateAdmission(models.TransientModel):
+    _name = "crm.lead.create_admission"
+    _description = "Wizard - Create Admission from CRM Lead"
+
+    lead_id = fields.Many2one(
+        string="Lead",
+        comodel_name="crm.lead",
+        required=True,
+        readonly=True,
+        help="The CRM lead this admission is created from.",
+    )
+    date = fields.Date(
+        string="Date",
+        required=True,
+        default=lambda r: datetime_date.today(),
+        help="The date of the admission.",
+    )
+    academic_year_id = fields.Many2one(
+        string="Academic Year",
+        comodel_name="school_academic_year",
+        required=True,
+        help="The academic year for the admission.",
+    )
+    academic_term_id = fields.Many2one(
+        string="Academic Term",
+        comodel_name="school_academic_term",
+        required=True,
+        domain="[('year_id', '=', academic_year_id)]",
+        help="The academic term for the admission.",
+    )
+    school_id = fields.Many2one(
+        string="School",
+        comodel_name="school",
+        required=True,
+        help="The school the student is being admitted to.",
+    )
+    grade_type_id = fields.Many2one(
+        string="Grade Type",
+        comodel_name="school_grade_type",
+        related="school_id.grade_type_id",
+        help="Grade type derived from the selected school.",
+    )
+    grade_id = fields.Many2one(
+        string="Grade",
+        comodel_name="school_grade",
+        required=True,
+        domain="[('type_id', '=', grade_type_id)]",
+        help="The grade level the student is being admitted to.",
+    )
+    student_id = fields.Many2one(
+        string="Student",
+        comodel_name="res.partner",
+        required=True,
+        help="The student being admitted.",
+    )
+
+    @api.onchange("academic_year_id")
+    def _onchange_academic_year_id(self):
+        self.academic_term_id = False
+
+    @api.onchange("school_id")
+    def _onchange_school_id(self):
+        self.grade_id = False
+
+    def action_confirm(self):
+        self.ensure_one()
+        admission = self.env["school_admission"].create(self._prepare_admission_data())
+        self.lead_id.sudo().write({"admission_id": admission.id})
+        return {
+            "type": "ir.actions.act_window",
+            "name": "Admission",
+            "res_model": "school_admission",
+            "res_id": admission.id,
+            "view_mode": "form",
+            "target": "current",
+        }
+
+    def _prepare_admission_data(self):
+        self.ensure_one()
+        return {
+            "date": self.date,
+            "academic_year_id": self.academic_year_id.id,
+            "academic_term_id": self.academic_term_id.id,
+            "school_id": self.school_id.id,
+            "grade_id": self.grade_id.id,
+            "student_id": self.student_id.id,
+            "currency_id": self.env.company.currency_id.id,
+        }


### PR DESCRIPTION
## Summary

- Tambah field `admission_id` (Many2one ke `school_admission`) di `crm.lead`
- Tambah button **Create Admission** di form lead yang membuka wizard pembuatan admission
- Tambah field compute `create_admission_ok` untuk mengontrol visibilitas button (tersembunyi jika admission sudah ada)
- Tambah wizard `crm.lead.create_admission` untuk mengumpulkan data yang dibutuhkan (academic year, academic term, grade)
- Tambah dependency `ssi_school_admission`
- Revisi unittest: tambah skenario pembuatan admission via wizard

## Test plan

- [ ] Install modul `ssi_school_lead` (upgrade jika sudah terinstall)
- [ ] Buka form CRM Lead, pastikan field `School`, `Student`, dan `Admission` muncul
- [ ] Pastikan button **Create Admission** muncul saat admission belum dibuat
- [ ] Klik button, isi form wizard, klik Create — pastikan admission dibuat dan field `admission_id` terisi
- [ ] Pastikan button **Create Admission** tersembunyi setelah admission dibuat
- [ ] Klik link `admission_id` untuk memastikan redirect ke form admission

🤖 Generated with [Claude Code](https://claude.com/claude-code)