### PR TITLE
[UPD] ssi_school_lead, ssi_school_admission_lead: Pindahkan tombol ke header form

### DIFF
--- a/ssi_school_admission_lead/models/crm_lead.py
+++ b/ssi_school_admission_lead/models/crm_lead.py
@@ -69,3 +69,14 @@ class CrmLead(models.Model):  # pylint: disable=too-few-public-methods
                 "default_student_id": self.student_id.id if self.student_id else False,
             },
         }
+
+    def action_open_admission_test(self):
+        self.ensure_one()
+        return {
+            "type": "ir.actions.act_window",
+            "name": "Admission Test",
+            "res_model": "school_admission_test",
+            "res_id": self.admission_test_id.id,
+            "view_mode": "form",
+            "target": "current",
+        }

--- a/ssi_school_admission_lead/views/crm_lead.xml
+++ b/ssi_school_admission_lead/views/crm_lead.xml
@@ -17,13 +17,6 @@
                 <field name="admission_form_id" />
                 <field name="admission_test_id" />
                 <field name="create_admission_form_ok" invisible="1" />
-                <button
-                        name="action_create_admission_form"
-                        type="object"
-                        string="Create Admission Form"
-                        class="btn-primary"
-                        attrs="{'invisible': [('create_admission_form_ok', '=', False)]}"
-                    />
             </xpath>
             <xpath
                     expr="//group[@name='lead_partner']//field[@name='student_id']"
@@ -31,13 +24,24 @@
                 >
                 <field name="admission_form_id" />
                 <field name="admission_test_id" />
-                <field name="create_admission_form_ok" invisible="1" />
+            </xpath>
+            <xpath
+                    expr="//header/button[@name='action_create_admission']"
+                    position="before"
+                >
                 <button
                         name="action_create_admission_form"
                         type="object"
                         string="Create Admission Form"
                         class="btn-primary"
                         attrs="{'invisible': [('create_admission_form_ok', '=', False)]}"
+                    />
+                <button
+                        name="action_open_admission_test"
+                        type="object"
+                        string="Admission Test"
+                        class="btn-secondary"
+                        attrs="{'invisible': [('admission_test_id', '=', False)]}"
                     />
             </xpath>
         </data>

--- a/ssi_school_lead/views/crm_lead_views.xml
+++ b/ssi_school_lead/views/crm_lead_views.xml
@@ -18,13 +18,6 @@
                 <field name="student_id" />
                 <field name="admission_id" />
                 <field name="create_admission_ok" invisible="1" />
-                <button
-                        name="action_create_admission"
-                        type="object"
-                        string="Create Admission"
-                        class="btn-primary"
-                        attrs="{'invisible': [('create_admission_ok', '=', False)]}"
-                    />
             </xpath>
             <xpath
                     expr="//group[@name='lead_partner']//field[@name='partner_id']"
@@ -33,7 +26,8 @@
                 <field name="school_id" />
                 <field name="student_id" />
                 <field name="admission_id" />
-                <field name="create_admission_ok" invisible="1" />
+            </xpath>
+            <xpath expr="//header" position="inside">
                 <button
                         name="action_create_admission"
                         type="object"


### PR DESCRIPTION
## Summary

- **ssi_school_lead**: Pindahkan tombol *Create Admission* dari body form (di dalam grup field) ke header form CRM lead.
- **ssi_school_admission_lead**: Pindahkan tombol *Create Admission Form* dari body form ke header form CRM lead; tambahkan tombol *Admission Test* di header untuk navigasi langsung ke record admission test jika sudah terbuat.

## Test plan

- [ ] Buka CRM lead — pastikan tombol *Create Admission*, *Create Admission Form*, dan *Admission Test* muncul di header (bukan di dalam body form).
- [ ] Klik *Create Admission* → wizard terbuka dan admission terbuat.
- [ ] Klik *Create Admission Form* → wizard terbuka dan admission form terbuat.
- [ ] Setelah admission form dibuat, tombol *Admission Test* muncul di header dan mengarah ke record admission test yang benar.
- [ ] Setelah admission terbuat, tombol *Create Admission* tersembunyi.
- [ ] Setelah admission form terbuat, tombol *Create Admission Form* tersembunyi.

🤖 Generated with [Claude Code](https://claude.com/claude-code)