### PR TITLE
[ADD] ssi_school_admission_lead_operating_unit

### DIFF
--- a/setup/ssi_school_admission_lead_operating_unit/odoo/addons/ssi_school_admission_lead_operating_unit
+++ b/setup/ssi_school_admission_lead_operating_unit/odoo/addons/ssi_school_admission_lead_operating_unit
@@ -1,0 +1,1 @@
+../../../../ssi_school_admission_lead_operating_unit

--- a/setup/ssi_school_admission_lead_operating_unit/setup.py
+++ b/setup/ssi_school_admission_lead_operating_unit/setup.py
@@ -1,0 +1,6 @@
+import setuptools
+
+setuptools.setup(
+    setup_requires=['setuptools-odoo'],
+    odoo_addon=True,
+)

--- a/ssi_school_admission_lead_operating_unit/README.rst
+++ b/ssi_school_admission_lead_operating_unit/README.rst
@@ -1,0 +1,38 @@
+.. image:: https://img.shields.io/badge/licence-AGPL--3-blue.svg
+   :target: http://www.gnu.org/licenses/agpl-3.0-standalone.html
+   :alt: License: AGPL-3
+
+=====================================
+School Admission Lead - Operating Unit
+=====================================
+
+Glue module that propagates the operating unit from a CRM lead to the
+school admission form created via the lead's action buttons.
+
+
+Bug Tracker
+===========
+
+Bugs are tracked on `GitHub Issues
+<https://github.com/open-synergy/ssi-school/issues>`_. In case of trouble, please
+check there if your issue has already been reported. If you spotted it first,
+help us smash it by providing detailed and welcomed feedback.
+
+
+Credits
+=======
+
+Contributors
+------------
+
+* Andhitia Rama <andhitia.r@gmail.com>
+* Michael Viriyananda <viriyananda.michael@gmail.com>
+
+Maintainer
+----------
+
+.. image:: https://simetri-sinergi.id/logo.png
+   :alt: PT. Simetri Sinergi Indonesia
+   :target: https://simetri-sinergi.id
+
+This module is maintained by the PT. Simetri Sinergi Indonesia.

--- a/ssi_school_admission_lead_operating_unit/README.rst
+++ b/ssi_school_admission_lead_operating_unit/README.rst
@@ -2,9 +2,9 @@
    :target: http://www.gnu.org/licenses/agpl-3.0-standalone.html
    :alt: License: AGPL-3
 
-=====================================
+======================================
 School Admission Lead - Operating Unit
-=====================================
+======================================
 
 Glue module that propagates the operating unit from a CRM lead to the
 school admission form created via the lead's action buttons.

--- a/ssi_school_admission_lead_operating_unit/__init__.py
+++ b/ssi_school_admission_lead_operating_unit/__init__.py
@@ -1,0 +1,7 @@
+# Copyright 2026 OpenSynergy Indonesia
+# Copyright 2026 PT. Simetri Sinergi Indonesia
+# License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl).
+from . import (  # noqa: F401
+    models,
+    wizard,
+)

--- a/ssi_school_admission_lead_operating_unit/__manifest__.py
+++ b/ssi_school_admission_lead_operating_unit/__manifest__.py
@@ -1,0 +1,27 @@
+# Copyright 2026 OpenSynergy Indonesia
+# Copyright 2026 PT. Simetri Sinergi Indonesia
+# License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl).
+{
+    "name": "School Admission Lead - Operating Unit",
+    "version": "14.0.1.0.0",
+    "website": "https://simetri-sinergi.id",
+    "author": (
+        "PT. Simetri Sinergi Indonesia, "
+        "OpenSynergy Indonesia, "
+        "Odoo Community Association (OCA)"
+    ),
+    "contributors": [
+        "Andhitia Rama <andhitia.r@gmail.com>",
+        "Michael Viriyananda <viriyananda.michael@gmail.com>",
+    ],
+    "license": "AGPL-3",
+    "installable": True,
+    "application": False,
+    "depends": [
+        "ssi_lead_operating_unit",
+        "ssi_school_admission_lead",
+        "ssi_school_admission_operating_unit",
+    ],
+    "data": [],
+    "demo": [],
+}

--- a/ssi_school_admission_lead_operating_unit/models/__init__.py
+++ b/ssi_school_admission_lead_operating_unit/models/__init__.py
@@ -1,0 +1,6 @@
+# Copyright 2026 OpenSynergy Indonesia
+# Copyright 2026 PT. Simetri Sinergi Indonesia
+# License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl).
+from . import (  # noqa: F401
+    crm_lead,
+)

--- a/ssi_school_admission_lead_operating_unit/models/crm_lead.py
+++ b/ssi_school_admission_lead_operating_unit/models/crm_lead.py
@@ -1,0 +1,18 @@
+# Copyright 2026 OpenSynergy Indonesia
+# Copyright 2026 PT. Simetri Sinergi Indonesia
+# License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl).
+from odoo import models
+
+
+class CrmLead(models.Model):
+    _name = "crm.lead"
+    _inherit = "crm.lead"
+
+    def action_create_admission_form(self):
+        self.ensure_one()
+        res = super().action_create_admission_form()
+        if res.get("res_model") == "crm.lead.create_admission_form":
+            context = res.get("context", {})
+            context["default_operating_unit_id"] = self.operating_unit_id.id or False
+            res["context"] = context
+        return res

--- a/ssi_school_admission_lead_operating_unit/wizard/__init__.py
+++ b/ssi_school_admission_lead_operating_unit/wizard/__init__.py
@@ -1,0 +1,6 @@
+# Copyright 2026 OpenSynergy Indonesia
+# Copyright 2026 PT. Simetri Sinergi Indonesia
+# License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl).
+from . import (  # noqa: F401
+    crm_lead_create_admission_form,
+)

--- a/ssi_school_admission_lead_operating_unit/wizard/crm_lead_create_admission_form.py
+++ b/ssi_school_admission_lead_operating_unit/wizard/crm_lead_create_admission_form.py
@@ -1,0 +1,24 @@
+# Copyright 2026 OpenSynergy Indonesia
+# Copyright 2026 PT. Simetri Sinergi Indonesia
+# License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl).
+from odoo import fields, models
+
+
+class CrmLeadCreateAdmissionForm(models.TransientModel):
+    _name = "crm.lead.create_admission_form"
+    _inherit = "crm.lead.create_admission_form"
+
+    operating_unit_id = fields.Many2one(
+        string="Operating Unit",
+        comodel_name="operating.unit",
+        help="Operating unit to assign to the created admission form.",
+    )
+
+    def action_confirm(self):
+        self.ensure_one()
+        res = super().action_confirm()
+        if self.operating_unit_id and res.get("res_id"):
+            self.env["school_admission_form"].browse(res["res_id"]).write(
+                {"operating_unit_id": self.operating_unit_id.id}
+            )
+        return res


### PR DESCRIPTION
## Summary

- Tambah modul glue `ssi_school_admission_lead_operating_unit` yang meneruskan `operating_unit_id` dari CRM lead ke `school_admission_form` saat dibuat melalui tombol di lead.
- Override `action_create_admission_form` di `crm.lead` untuk menyisipkan `default_operating_unit_id` ke context wizard.
- Extend wizard `crm.lead.create_admission_form` dengan field `operating_unit_id` dan override `action_confirm` untuk menyertakan OU saat membuat formulir penerimaan.

## Dependencies

- `ssi_lead_operating_unit`
- `ssi_school_admission_lead`
- `ssi_school_admission_operating_unit`