### PR TITLE
[UPD] ssi_school_admission, ssi_school_lead: is_open_admission flag & payment template wizard

### DIFF
--- a/ssi_school_admission/__manifest__.py
+++ b/ssi_school_admission/__manifest__.py
@@ -64,6 +64,7 @@
         "sequence_template/school_admission.xml",
         "policy_template/school_admission.xml",
         "approval_template/school_admission.xml",
+        "views/school_academic_term.xml",
         "views/school_admission_payment_template.xml",
         "views/school_admission_payment_term.xml",
         "views/school_admission.xml",

--- a/ssi_school_admission/models/__init__.py
+++ b/ssi_school_admission/models/__init__.py
@@ -3,6 +3,7 @@
 # License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl).
 
 from . import (  # noqa: F401
+    school_academic_term,
     school_admission_fee_template,
     school_admission_fee_template_line,
     school_admission_form,

--- a/ssi_school_admission/models/school_academic_term.py
+++ b/ssi_school_admission/models/school_academic_term.py
@@ -1,0 +1,21 @@
+# Copyright 2024 OpenSynergy Indonesia
+# Copyright 2024 PT. Simetri Sinergi Indonesia
+# License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl).
+
+from odoo import fields, models
+
+
+class SchoolAcademicTerm(models.Model):
+    _name = "school_academic_term"
+    _inherit = [
+        "school_academic_term",
+    ]
+
+    is_open_admission = fields.Boolean(
+        string="Open for Admission",
+        default=False,
+        help=(
+            "Indicates whether this academic term is open for school admission. "
+            "When enabled, this term will appear in the admission wizard."
+        ),
+    )

--- a/ssi_school_admission/tests/__init__.py
+++ b/ssi_school_admission/tests/__init__.py
@@ -3,6 +3,7 @@
 # License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl).
 
 from . import (  # noqa: F401
+    test_school_academic_term,
     test_school_admission,
     test_school_admission_form,
     test_school_admission_payment_term,

--- a/ssi_school_admission/tests/test_data_academic_term.yaml
+++ b/ssi_school_admission/tests/test_data_academic_term.yaml
@@ -1,0 +1,118 @@
+scenarios:
+  - name: "Set is_open_admission Flag on Academic Term"
+    steps:
+      - step: "Create academic year"
+        action: "create"
+        model: "school_academic_year"
+        save_as: "year"
+        values:
+          name: "2028 Term Admission Flag"
+          code: "AY2028AF"
+          date_start: "2028-07-01"
+          date_end: "2029-06-30"
+
+      - step: "Create academic term"
+        action: "create"
+        model: "school_academic_term"
+        save_as: "term"
+        values:
+          name: "Term Admission Flag"
+          code: "TAF"
+          date_start: "2028-07-01"
+          date_end: "2028-12-31"
+          year_id: "EVAL: registry['year'].id"
+
+      - step: "Assert is_open_admission defaults to false"
+        action: "assert"
+        target: "term"
+        asserts:
+          is_open_admission:
+            type: "value"
+            expected: false
+
+      - step: "Set is_open_admission to true"
+        action: "write"
+        target: "term"
+        values:
+          is_open_admission: true
+
+      - step: "Assert is_open_admission is true"
+        action: "assert"
+        target: "term"
+        asserts:
+          is_open_admission:
+            type: "value"
+            expected: true
+
+      - step: "Set is_open_admission back to false"
+        action: "write"
+        target: "term"
+        values:
+          is_open_admission: false
+
+      - step: "Assert is_open_admission is false again"
+        action: "assert"
+        target: "term"
+        asserts:
+          is_open_admission:
+            type: "value"
+            expected: false
+
+  - name: "Filter Academic Terms by is_open_admission"
+    steps:
+      - step: "Create academic year"
+        action: "create"
+        model: "school_academic_year"
+        save_as: "year"
+        values:
+          name: "2029 Filter Admission"
+          code: "AY2029FA"
+          date_start: "2029-07-01"
+          date_end: "2030-06-30"
+
+      - step: "Create term with is_open_admission true"
+        action: "create"
+        model: "school_academic_term"
+        save_as: "term_open"
+        values:
+          name: "Term Open Admission"
+          code: "TOPAD"
+          date_start: "2029-07-01"
+          date_end: "2029-12-31"
+          year_id: "EVAL: registry['year'].id"
+          is_open_admission: true
+
+      - step: "Create term with is_open_admission false"
+        action: "create"
+        model: "school_academic_term"
+        save_as: "term_closed"
+        values:
+          name: "Term Closed Admission"
+          code: "TCLAD"
+          date_start: "2030-01-01"
+          date_end: "2030-06-30"
+          year_id: "EVAL: registry['year'].id"
+          is_open_admission: false
+
+      - step: "Search for open admission terms"
+        action: "search"
+        model: "school_academic_term"
+        domain: [["code", "in", ["TOPAD", "TCLAD"]], ["is_open_admission", "=", true]]
+        save_as: "open_terms"
+        expect_count: 1
+
+      - step: "Assert term_open has is_open_admission true"
+        action: "assert"
+        target: "term_open"
+        asserts:
+          is_open_admission:
+            type: "value"
+            expected: true
+
+      - step: "Assert term_closed has is_open_admission false"
+        action: "assert"
+        target: "term_closed"
+        asserts:
+          is_open_admission:
+            type: "value"
+            expected: false

--- a/ssi_school_admission/tests/test_school_academic_term.py
+++ b/ssi_school_admission/tests/test_school_academic_term.py
@@ -1,0 +1,15 @@
+# Copyright 2024 OpenSynergy Indonesia
+# Copyright 2024 PT. Simetri Sinergi Indonesia
+# License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl).
+
+from odoo_yaml_test import YamlTransactionCase
+
+from odoo.tests import tagged
+
+
+@tagged("post_install", "-at_install")
+class TestSchoolAcademicTermAdmission(
+    YamlTransactionCase
+):  # pylint: disable=too-few-public-methods
+    def test_school_academic_term_admission(self):
+        self.run_yaml_scenario("test_data_academic_term.yaml")

--- a/ssi_school_admission/views/school_academic_term.xml
+++ b/ssi_school_admission/views/school_academic_term.xml
@@ -1,0 +1,53 @@
+<?xml version="1.0" encoding="utf-8" ?>
+<!-- Copyright 2024 OpenSynergy Indonesia
+     Copyright 2024 PT. Simetri Sinergi Indonesia
+     License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl). -->
+<odoo>
+
+<record id="school_academic_term_view_tree_admission" model="ir.ui.view">
+    <field name="name">school_academic_term - tree - admission</field>
+    <field name="model">school_academic_term</field>
+    <field name="inherit_id" ref="ssi_school.school_academic_term_view_tree" />
+    <field name="arch" type="xml">
+        <data>
+            <xpath expr="//field[@name='state']" position="before">
+                <field name="is_open_admission" />
+            </xpath>
+        </data>
+    </field>
+</record>
+
+<record id="school_academic_term_view_form_admission" model="ir.ui.view">
+    <field name="name">school_academic_term - form - admission</field>
+    <field name="model">school_academic_term</field>
+    <field name="inherit_id" ref="ssi_school.school_academic_term_view_form" />
+    <field name="arch" type="xml">
+        <data>
+            <xpath
+                    expr="//page[@name='enrollment']//field[@name='enrollment_state']"
+                    position="after"
+                >
+                <field name="is_open_admission" />
+            </xpath>
+        </data>
+    </field>
+</record>
+
+<record id="school_academic_term_view_search_admission" model="ir.ui.view">
+    <field name="name">school_academic_term - search - admission</field>
+    <field name="model">school_academic_term</field>
+    <field name="inherit_id" ref="ssi_school.school_academic_term_view_search" />
+    <field name="arch" type="xml">
+        <data>
+            <xpath expr="//filter[@name='filter_enrollment_open']" position="after">
+                <filter
+                        name="filter_open_admission"
+                        string="Open for Admission"
+                        domain="[('is_open_admission', '=', True)]"
+                    />
+            </xpath>
+        </data>
+    </field>
+</record>
+
+</odoo>

--- a/ssi_school_lead/tests/test_data_school_lead.yaml
+++ b/ssi_school_lead/tests/test_data_school_lead.yaml
@@ -227,3 +227,209 @@ scenarios:
         target: "lead"
         method: "action_create_admission"
         as_user: "base.user_admin"
+
+  - name: "School Lead - Create Admission via Wizard with Payment Template and Compute"
+    steps:
+      - step: "Setup - get account type ref"
+        action: "ref"
+        xml_id: "account.data_account_type_revenue"
+        save_as: "account_type"
+
+      - step: "Setup - create income account"
+        action: "create"
+        model: "account.account"
+        save_as: "account"
+        values:
+          name: "Admission Fee Income SLPT"
+          code: "SLPT4200"
+          user_type_id: "EVAL: registry['account_type'].id"
+
+      - step: "Setup - create product"
+        action: "create"
+        model: "product.product"
+        save_as: "product"
+        values:
+          name: "Registration Fee SLPT"
+          type: "service"
+
+      - step: "Create grade type"
+        action: "create"
+        model: "school_grade_type"
+        save_as: "grade_type"
+        values:
+          name: "Grade Type SLPT"
+          code: "GTSLPT"
+          sequence: 10
+
+      - step: "Create academic year"
+        action: "create"
+        model: "school_academic_year"
+        save_as: "academic_year"
+        values:
+          name: "2025/2026 SLPT"
+          code: "AYSLPT"
+          date_start: "2025-07-01"
+          date_end: "2026-06-30"
+
+      - step: "Create academic term with is_open_admission"
+        action: "create"
+        model: "school_academic_term"
+        save_as: "academic_term"
+        values:
+          name: "Semester SLPT"
+          code: "SMSLPT"
+          date_start: "2025-07-01"
+          date_end: "2026-06-30"
+          year_id: "EVAL: registry['academic_year'].id"
+          is_open_admission: true
+
+      - step: "Create school"
+        action: "create"
+        model: "school"
+        save_as: "school"
+        values:
+          name: "School SLPT"
+          code: "SCHSLPT"
+          grade_type_id: "EVAL: registry['grade_type'].id"
+
+      - step: "Create grade"
+        action: "create"
+        model: "school_grade"
+        save_as: "grade"
+        values:
+          name: "Grade SLPT"
+          code: "GSLPT"
+          sequence: 10
+          type_id: "EVAL: registry['grade_type'].id"
+
+      - step: "Create payment template with term and detail"
+        action: "create"
+        model: "school_admission_payment_template"
+        save_as: "payment_template"
+        values:
+          name: "Payment Template SLPT"
+          code: "PTSLPT"
+          school_id: "EVAL: registry['school'].id"
+          grade_id: "EVAL: registry['grade'].id"
+          academic_term_id: "EVAL: registry['academic_term'].id"
+          term_ids:
+            - - 0
+              - 0
+              - name: "Term 1 SLPT"
+                sequence: 5
+                detail_ids:
+                  - - 0
+                    - 0
+                    - product_id: "EVAL: registry['product'].id"
+                      name: "Registration Fee SLPT"
+                      account_id: "EVAL: registry['account'].id"
+                      uom_quantity: 1.0
+                      price_unit: 500000.0
+
+      - step: "Create student contact"
+        action: "create"
+        model: "res.partner"
+        save_as: "student"
+        values:
+          name: "Student SLPT"
+
+      - step: "Create CRM lead"
+        action: "create"
+        model: "crm.lead"
+        save_as: "lead"
+        as_user: "base.user_admin"
+        values:
+          name: "Lead SLPT"
+          school_id: "EVAL: registry['school'].id"
+          student_id: "EVAL: registry['student'].id"
+
+      - step: "Create wizard with payment template"
+        action: "create"
+        model: "crm.lead.create_admission"
+        save_as: "wizard"
+        values:
+          lead_id: "EVAL: registry['lead'].id"
+          date: "2025-07-01"
+          academic_year_id: "EVAL: registry['academic_year'].id"
+          academic_term_id: "EVAL: registry['academic_term'].id"
+          school_id: "EVAL: registry['school'].id"
+          grade_id: "EVAL: registry['grade'].id"
+          student_id: "EVAL: registry['student'].id"
+          payment_template_id: "EVAL: registry['payment_template'].id"
+
+      - step: "Confirm wizard to create admission with payment compute"
+        action: "call"
+        target: "wizard"
+        method: "action_confirm"
+        as_user: "base.user_admin"
+
+      - step: "Invalidate lead cache"
+        action: "call"
+        target: "lead"
+        method: "invalidate_cache"
+
+      - step: "Assert admission was created and linked to lead"
+        action: "assert"
+        target: "lead"
+        asserts:
+          admission_id:
+            type: "value"
+            operator: "is_truthy"
+
+      - step: "Search for created admission"
+        action: "search"
+        model: "school_admission"
+        domain: [["student_id", "=", "EVAL: registry['student'].id"]]
+        save_as: "admission"
+        expect_count: 1
+
+      - step: "Assert admission has payment template and payment terms computed"
+        action: "assert"
+        target: "admission"
+        asserts:
+          payment_template_id:
+            type: "value"
+            operator: "is_truthy"
+          payment_term_ids:
+            type: "o2m"
+            check: "count"
+            expected_count: 1
+
+  - name: "School Lead - Academic Term Default is_open_admission Filter"
+    steps:
+      - step: "Create academic year"
+        action: "create"
+        model: "school_academic_year"
+        save_as: "academic_year"
+        values:
+          name: "2030/2031 SLDF"
+          code: "AYSLDF"
+          date_start: "2030-07-01"
+          date_end: "2031-06-30"
+
+      - step: "Create academic term with is_open_admission true"
+        action: "create"
+        model: "school_academic_term"
+        save_as: "open_term"
+        values:
+          name: "Open Admission Term SLDF"
+          code: "OATSLDF"
+          date_start: "2030-07-01"
+          date_end: "2031-06-30"
+          year_id: "EVAL: registry['academic_year'].id"
+          is_open_admission: true
+
+      - step: "Assert term has is_open_admission true"
+        action: "assert"
+        target: "open_term"
+        asserts:
+          is_open_admission:
+            type: "value"
+            expected: true
+
+      - step: "Search open admission terms by is_open_admission flag"
+        action: "search"
+        model: "school_academic_term"
+        domain: [["code", "=", "OATSLDF"], ["is_open_admission", "=", true]]
+        save_as: "result"
+        expect_count: 1

--- a/ssi_school_lead/tests/test_school_lead.py
+++ b/ssi_school_lead/tests/test_school_lead.py
@@ -4,10 +4,141 @@
 
 from odoo_yaml_test import YamlTransactionCase
 
-from odoo.tests import tagged
+from odoo.tests import Form, tagged
 
 
 @tagged("post_install", "-at_install")
-class TestSchoolLead(YamlTransactionCase):  # pylint: disable=too-few-public-methods
+class TestSchoolLead(YamlTransactionCase):
     def test_school_lead(self):
         self.run_yaml_scenario("test_data_school_lead.yaml")
+
+    def test_onchange_payment_template_id_auto_populates(self):
+        """payment_template_id should auto-populate when school, grade, and term match."""
+        year = self.env["school_academic_year"].create(
+            {
+                "name": "Year OC",
+                "code": "AYOC",
+                "date_start": "2024-07-01",
+                "date_end": "2025-06-30",
+            }
+        )
+        term = self.env["school_academic_term"].create(
+            {
+                "name": "Term OC",
+                "code": "SMOC",
+                "date_start": "2024-07-01",
+                "date_end": "2025-06-30",
+                "year_id": year.id,
+                "is_open_admission": True,
+            }
+        )
+        grade_type = self.env["school_grade_type"].create(
+            {"name": "Grade Type OC", "code": "GTOC", "sequence": 10}
+        )
+        school = self.env["school"].create(
+            {"name": "School OC", "code": "SCHOC", "grade_type_id": grade_type.id}
+        )
+        grade = self.env["school_grade"].create(
+            {
+                "name": "Grade OC",
+                "code": "GOC",
+                "sequence": 10,
+                "type_id": grade_type.id,
+            }
+        )
+        template = self.env["school_admission_payment_template"].create(
+            {
+                "name": "PT OC",
+                "code": "PTOC",
+                "school_id": school.id,
+                "grade_id": grade.id,
+                "academic_term_id": term.id,
+            }
+        )
+        student = self.env["res.partner"].create({"name": "Student OC"})
+        lead = (
+            self.env["crm.lead"]
+            .with_user(self.env.ref("base.user_admin"))
+            .create({"name": "Lead OC"})
+        )
+
+        form = Form(
+            self.env["crm.lead.create_admission"].with_context(
+                default_lead_id=lead.id,
+                default_student_id=student.id,
+            )
+        )
+        form.academic_year_id = year
+        form.school_id = school
+        form.grade_id = grade
+        form.academic_term_id = term
+
+        self.assertEqual(form.payment_template_id.id, template.id)
+
+    def test_onchange_payment_template_id_clears_on_school_change(self):
+        """payment_template_id should clear when school changes."""
+        year = self.env["school_academic_year"].create(
+            {
+                "name": "Year OC2",
+                "code": "AYOC2",
+                "date_start": "2025-07-01",
+                "date_end": "2026-06-30",
+            }
+        )
+        term = self.env["school_academic_term"].create(
+            {
+                "name": "Term OC2",
+                "code": "SMOC2",
+                "date_start": "2025-07-01",
+                "date_end": "2026-06-30",
+                "year_id": year.id,
+                "is_open_admission": True,
+            }
+        )
+        grade_type = self.env["school_grade_type"].create(
+            {"name": "Grade Type OC2", "code": "GTOC2", "sequence": 10}
+        )
+        school_a = self.env["school"].create(
+            {"name": "School OC2A", "code": "SCHOC2A", "grade_type_id": grade_type.id}
+        )
+        school_b = self.env["school"].create(
+            {"name": "School OC2B", "code": "SCHOC2B", "grade_type_id": grade_type.id}
+        )
+        grade = self.env["school_grade"].create(
+            {
+                "name": "Grade OC2",
+                "code": "GOC2",
+                "sequence": 10,
+                "type_id": grade_type.id,
+            }
+        )
+        self.env["school_admission_payment_template"].create(
+            {
+                "name": "PT OC2",
+                "code": "PTOC2",
+                "school_id": school_a.id,
+                "grade_id": grade.id,
+                "academic_term_id": term.id,
+            }
+        )
+        student = self.env["res.partner"].create({"name": "Student OC2"})
+        lead = (
+            self.env["crm.lead"]
+            .with_user(self.env.ref("base.user_admin"))
+            .create({"name": "Lead OC2"})
+        )
+
+        form = Form(
+            self.env["crm.lead.create_admission"].with_context(
+                default_lead_id=lead.id,
+                default_student_id=student.id,
+            )
+        )
+        form.academic_year_id = year
+        form.school_id = school_a
+        form.grade_id = grade
+        form.academic_term_id = term
+        self.assertTrue(form.payment_template_id.id)
+
+        form.school_id = school_b
+        self.assertFalse(form.payment_template_id.id)

--- a/ssi_school_lead/views/crm_lead_create_admission_view.xml
+++ b/ssi_school_lead/views/crm_lead_create_admission_view.xml
@@ -16,7 +16,7 @@
                     <field name="academic_year_id" />
                     <field
                             name="academic_term_id"
-                            domain="[('year_id', '=', academic_year_id)]"
+                            domain="[('year_id', '=', academic_year_id), ('is_open_admission', '=', True)]"
                         />
                 </group>
                 <group name="right" colspan="1" col="2">
@@ -24,6 +24,7 @@
                     <field name="grade_type_id" invisible="1" />
                     <field name="grade_id" domain="[('type_id', '=', grade_type_id)]" />
                     <field name="student_id" />
+                    <field name="payment_template_id" />
                 </group>
             </group>
             <footer>

--- a/ssi_school_lead/wizard/crm_lead_create_admission.py
+++ b/ssi_school_lead/wizard/crm_lead_create_admission.py
@@ -34,8 +34,8 @@ class CrmLeadCreateAdmission(models.TransientModel):
         string="Academic Term",
         comodel_name="school_academic_term",
         required=True,
-        domain="[('year_id', '=', academic_year_id)]",
-        help="The academic term for the admission.",
+        domain="[('year_id', '=', academic_year_id), ('is_open_admission', '=', True)]",
+        help="The academic term for the admission. Only terms open for admission are shown.",
     )
     school_id = fields.Many2one(
         string="School",
@@ -62,6 +62,31 @@ class CrmLeadCreateAdmission(models.TransientModel):
         required=True,
         help="The student being admitted.",
     )
+    payment_template_id = fields.Many2one(
+        string="Payment Template",
+        comodel_name="school_admission_payment_template",
+        required=False,
+        help=(
+            "The payment template to apply to the admission. "
+            "Auto-populated based on school, grade, and academic term."
+        ),
+    )
+
+    @api.model
+    def default_get(self, fields_list):
+        res = super().default_get(fields_list)
+        AcademicTerm = self.env["school_academic_term"]  # pylint: disable=invalid-name
+        term = AcademicTerm.search(
+            [("is_open_admission", "=", True)],
+            limit=1,
+            order="date_start asc",
+        )
+        if term:
+            if "academic_term_id" not in res or not res.get("academic_term_id"):
+                res["academic_term_id"] = term.id
+            if "academic_year_id" not in res or not res.get("academic_year_id"):
+                res["academic_year_id"] = term.year_id.id
+        return res
 
     @api.onchange("academic_year_id")
     def _onchange_academic_year_id(self):
@@ -71,10 +96,28 @@ class CrmLeadCreateAdmission(models.TransientModel):
     def _onchange_school_id(self):
         self.grade_id = False
 
+    @api.onchange("school_id", "grade_id", "academic_term_id")
+    def _onchange_payment_template_id(self):
+        self.payment_template_id = False
+        if self.school_id and self.grade_id and self.academic_term_id:
+            PaymentTemplate = self.env[  # pylint: disable=invalid-name
+                "school_admission_payment_template"
+            ]
+            criteria = [
+                ("school_id", "=", self.school_id.id),
+                ("grade_id", "=", self.grade_id.id),
+                ("academic_term_id", "=", self.academic_term_id.id),
+            ]
+            template = PaymentTemplate.search(criteria, limit=1)
+            if template:
+                self.payment_template_id = template
+
     def action_confirm(self):
         self.ensure_one()
         admission = self.env["school_admission"].create(self._prepare_admission_data())
         self.lead_id.sudo().write({"admission_id": admission.id})
+        if self.payment_template_id:
+            admission.action_compute_payment()
         return {
             "type": "ir.actions.act_window",
             "name": "Admission",
@@ -94,4 +137,7 @@ class CrmLeadCreateAdmission(models.TransientModel):
             "grade_id": self.grade_id.id,
             "student_id": self.student_id.id,
             "currency_id": self.env.company.currency_id.id,
+            "payment_template_id": self.payment_template_id.id
+            if self.payment_template_id
+            else False,
         }

--- a/test-requirements.txt
+++ b/test-requirements.txt
@@ -1,3 +1,4 @@
+odoo-yaml-test
 odoo14-addon-ssi-stock-account
 odoo14-addon-ssi-master-data-mixin
 odoo14-addon-ssi-transaction-mixin


### PR DESCRIPTION
## Summary

- Tambah field `is_open_admission` (Boolean) ke model `school_academic_term` via model inherit di `ssi_school_admission`
- Wizard "Create Admission" di `ssi_school_lead` diupdate: filter `academic_term_id` hanya tampilkan term dengan `is_open_admission = True`, default ke term pertama yang open
- Tambah field `payment_template_id` di wizard dengan onchange otomatis berdasarkan school, grade, dan academic term
- Setelah admission dibuat, jika `payment_template_id` terisi maka `action_compute_payment()` dipanggil otomatis
- Unit test ditambahkan untuk semua perubahan di kedua modul
- Tambah `odoo-yaml-test` ke `test-requirements.txt`

## Test plan

- [ ] `is_open_admission` defaultnya `False` pada academic term baru
- [ ] Academic term dengan `is_open_admission = True` muncul di filter wizard
- [ ] Wizard auto-default ke term pertama yang open
- [ ] Onchange `payment_template_id` terisi otomatis saat school + grade + term cocok dengan template
- [ ] `payment_template_id` reset saat school berubah
- [ ] Admission terbuat dengan payment terms setelah wizard diconfirm (jika template ada)
- [ ] CI unit test lolos

🤖 Generated with [Claude Code](https://claude.ai/claude-code)