### PR TITLE
[FIX] ssi_school_lead: filter payment_template_id berdasarkan school, grade, dan academic term

### DIFF
--- a/ssi_school_lead/views/crm_lead_create_admission_view.xml
+++ b/ssi_school_lead/views/crm_lead_create_admission_view.xml
@@ -24,7 +24,10 @@
                     <field name="grade_type_id" invisible="1" />
                     <field name="grade_id" domain="[('type_id', '=', grade_type_id)]" />
                     <field name="student_id" />
-                    <field name="payment_template_id" />
+                    <field
+                            name="payment_template_id"
+                            domain="[('school_id', '=', school_id), ('grade_id', '=', grade_id), ('academic_term_id', '=', academic_term_id)]"
+                        />
                 </group>
             </group>
             <footer>


### PR DESCRIPTION
## Summary

- Tambahkan domain filter pada field `payment_template_id` di wizard Create Admission
  agar pilihan yang muncul hanya template yang sesuai dengan school, grade, dan
  academic_term yang dipilih user.

## Test plan

- [ ] Buka wizard Create Admission dari crm.lead
- [ ] Pilih school, grade, dan academic term
- [ ] Pastikan dropdown payment_template_id hanya menampilkan template yang cocok dengan ketiga field tersebut
- [ ] Ganti salah satu dari school/grade/academic_term — pastikan dropdown berubah

🤖 Generated with [Claude Code](https://claude.ai/claude-code)