### PR TITLE
[UPD] ssi_school_admission_lead

### DIFF
--- a/ssi_school_admission_lead/tests/test_crm_lead_admission.py
+++ b/ssi_school_admission_lead/tests/test_crm_lead_admission.py
@@ -4,12 +4,62 @@
 
 from odoo_yaml_test import YamlTransactionCase
 
-from odoo.tests import tagged
+from odoo.tests import Form, tagged
 
 
 @tagged("post_install", "-at_install")
-class TestCrmLeadAdmission(
-    YamlTransactionCase
-):  # pylint: disable=too-few-public-methods
+class TestCrmLeadAdmission(YamlTransactionCase):
     def test_crm_lead_admission(self):
         self.run_yaml_scenario("test_data_admission_lead.yaml")
+
+    def test_default_academic_term_auto_filled(self):
+        """Wizard should auto-fill academic_term_id from the first term open for admission."""
+        grade_type = self.env["school_grade_type"].create(
+            {"name": "Grade Type Default AT", "code": "GTDAT", "sequence": 10}
+        )
+        academic_year = self.env["school_academic_year"].create(
+            {
+                "name": "2025/2026 Default AT",
+                "code": "AYDAT2526",
+                "date_start": "2025-07-01",
+                "date_end": "2026-06-30",
+            }
+        )
+        term = self.env["school_academic_term"].create(
+            {
+                "name": "Semester Default AT",
+                "code": "SMDAT",
+                "date_start": "2025-07-01",
+                "date_end": "2026-06-30",
+                "year_id": academic_year.id,
+                "is_open_admission": True,
+            }
+        )
+        school = self.env["school"].create(
+            {
+                "name": "School Default AT",
+                "code": "SCHDAT",
+                "grade_type_id": grade_type.id,
+            }
+        )
+        lead = self.env["crm.lead"].create(
+            {
+                "name": "Lead Default AT",
+                "school_id": school.id,
+            }
+        )
+        form = Form(
+            self.env["crm.lead.create_admission_form"].with_context(
+                default_lead_id=lead.id,
+            )
+        )
+        self.assertEqual(
+            form.academic_term_id._origin.id,
+            term.id,
+            "academic_term_id should be auto-filled with the first open admission term",
+        )
+        self.assertEqual(
+            form.academic_year_id._origin.id,
+            academic_year.id,
+            "academic_year_id should be auto-filled from the open admission term",
+        )

--- a/ssi_school_admission_lead/views/crm_lead_create_admission_form.xml
+++ b/ssi_school_admission_lead/views/crm_lead_create_admission_form.xml
@@ -16,7 +16,7 @@
                     <field name="academic_year_id" />
                     <field
                             name="academic_term_id"
-                            domain="[('year_id', '=', academic_year_id)]"
+                            domain="[('year_id', '=', academic_year_id), ('is_open_admission', '=', True)]"
                         />
                     <field name="pricelist_id" />
                 </group>

--- a/ssi_school_admission_lead/wizard/crm_lead_create_admission_form.py
+++ b/ssi_school_admission_lead/wizard/crm_lead_create_admission_form.py
@@ -7,9 +7,7 @@ from datetime import date as datetime_date
 from odoo import api, fields, models
 
 
-class CrmLeadCreateAdmissionForm(
-    models.TransientModel
-):  # pylint: disable=too-few-public-methods
+class CrmLeadCreateAdmissionForm(models.TransientModel):
     _name = "crm.lead.create_admission_form"
     _description = "Wizard - Create Admission Form from CRM Lead"
 
@@ -18,58 +16,92 @@ class CrmLeadCreateAdmissionForm(
         comodel_name="crm.lead",
         required=True,
         readonly=True,
+        help="The CRM lead this admission form is created from.",
     )
     date = fields.Date(
         string="Date",
         required=True,
         default=lambda r: datetime_date.today(),
+        help="The date of the admission form.",
     )
     academic_year_id = fields.Many2one(
         string="Academic Year",
         comodel_name="school_academic_year",
         required=True,
+        help="The academic year for the admission form.",
     )
     academic_term_id = fields.Many2one(
         string="Academic Term",
         comodel_name="school_academic_term",
         required=True,
-        domain="[('year_id', '=', academic_year_id)]",
+        domain="[('year_id', '=', academic_year_id), ('is_open_admission', '=', True)]",
+        help=(
+            "The academic term for the admission form. "
+            "Only terms open for admission are shown."
+        ),
     )
     school_id = fields.Many2one(
         string="School",
         comodel_name="school",
         required=True,
+        help="The school the student is applying to.",
     )
     grade_id = fields.Many2one(
         string="Grade",
         comodel_name="school_grade",
         required=True,
+        domain="[('type_id', '=', grade_type_id)]",
+        help="The grade level the student is applying for.",
     )
     student_id = fields.Many2one(
         string="Student",
         comodel_name="res.partner",
         required=True,
+        help="The student submitting the admission form.",
     )
     parent_id = fields.Many2one(
         string="Parent",
         comodel_name="res.partner",
         required=True,
+        help="The parent or guardian of the student.",
     )
     pricelist_id = fields.Many2one(
         string="Pricelist",
         comodel_name="product.pricelist",
         required=True,
+        help="The pricelist applied to the admission fees.",
     )
     grade_type_id = fields.Many2one(
         string="Grade Type",
         comodel_name="school_grade_type",
         related="school_id.grade_type_id",
+        help="Grade type derived from the selected school.",
     )
     fee_template_id = fields.Many2one(
         string="Fee Template",
         comodel_name="school_admission_fee_template",
         required=False,
+        help=(
+            "The fee template to apply to the admission form. "
+            "Auto-populated based on school and grade."
+        ),
     )
+
+    @api.model
+    def default_get(self, fields_list):
+        res = super().default_get(fields_list)
+        AcademicTerm = self.env["school_academic_term"]  # pylint: disable=invalid-name
+        term = AcademicTerm.search(
+            [("is_open_admission", "=", True)],
+            limit=1,
+            order="date_start asc",
+        )
+        if term:
+            if "academic_term_id" not in res or not res.get("academic_term_id"):
+                res["academic_term_id"] = term.id
+            if "academic_year_id" not in res or not res.get("academic_year_id"):
+                res["academic_year_id"] = term.year_id.id
+        return res
 
     @api.onchange("academic_year_id")
     def _onchange_academic_year_id(self):

--- a/ssi_school_admission_lead/wizard/crm_lead_create_admission_form.py
+++ b/ssi_school_admission_lead/wizard/crm_lead_create_admission_form.py
@@ -105,7 +105,8 @@ class CrmLeadCreateAdmissionForm(models.TransientModel):
 
     @api.onchange("academic_year_id")
     def _onchange_academic_year_id(self):
-        self.academic_term_id = False
+        if self.academic_term_id.year_id != self.academic_year_id:
+            self.academic_term_id = False
 
     @api.onchange("school_id")
     def _onchange_school_id(self):


### PR DESCRIPTION
## Ringkasan

* Tambah `default_get` pada wizard `crm.lead.create_admission_form` untuk mengisi otomatis `academic_term_id` dan `academic_year_id` berdasarkan term pertama yang terbuka untuk penerimaan (`is_open_admission=True`, diurutkan `date_start asc`)
* Perbarui domain `academic_term_id` agar hanya menampilkan term yang terbuka untuk penerimaan (`is_open_admission=True`), konsisten dengan wizard `crm.lead.create_admission` di modul `ssi_school_lead`
* Tambah atribut `help` pada seluruh field wizard sesuai standar SSI
* Tambah domain pada field `grade_id` di wizard
* Tambah unit test `test_default_academic_term_auto_filled` via Form API untuk memverifikasi perilaku `default_get`