### PR TITLE
[UPD] ssi_school_admission

### DIFF
--- a/ssi_school_admission/__manifest__.py
+++ b/ssi_school_admission/__manifest__.py
@@ -24,6 +24,7 @@
         "ssi_transaction_total_mixin",
         "ssi_product_line_account_mixin",
         "base_automation",
+        "base_duration",
     ],
     "data": [
         "ir_module_category/school_admission_form.xml",

--- a/ssi_school_admission/models/school_admission.py
+++ b/ssi_school_admission/models/school_admission.py
@@ -297,11 +297,21 @@ class SchoolAdmission(models.Model):
             "school_admission_payment_term_detail"
         ]  # pylint: disable=invalid-name
         for tterm in template.term_ids.sorted("sequence"):
+            date_invoice = False
+            date_due = False
+            if tterm.date_invoice_duration_id:
+                date_invoice = tterm.date_invoice_duration_id.get_duration(self.date)
+            if tterm.date_due_duration_id:
+                date_due = tterm.date_due_duration_id.get_duration(
+                    date_invoice or self.date
+                )
             term = Term.create(
                 {
                     "admission_id": self.id,
                     "name": tterm.name,
                     "sequence": tterm.sequence,
+                    "date_invoice": date_invoice,
+                    "date_due": date_due,
                 }
             )
             for tdetail in tterm.detail_ids.sorted("sequence"):

--- a/ssi_school_admission/models/school_admission_payment_template_term.py
+++ b/ssi_school_admission/models/school_admission_payment_template_term.py
@@ -42,3 +42,21 @@ class SchoolAdmissionPaymentTemplateTerm(
         copy=True,
         help="The individual fee items included in this payment term.",
     )
+    date_invoice_duration_id = fields.Many2one(
+        string="Invoice Date Duration",
+        comodel_name="base.duration",
+        help=(
+            "Duration applied to the admission date to compute the "
+            "estimated invoice date of this term. Leave empty to skip "
+            "auto-computing the estimated invoice date."
+        ),
+    )
+    date_due_duration_id = fields.Many2one(
+        string="Due Date Duration",
+        comodel_name="base.duration",
+        help=(
+            "Duration applied to this term's estimated invoice date to "
+            "compute its estimated due date. Leave empty to skip "
+            "auto-computing the estimated due date."
+        ),
+    )

--- a/ssi_school_admission/tests/__init__.py
+++ b/ssi_school_admission/tests/__init__.py
@@ -6,6 +6,7 @@ from . import (  # noqa: F401
     test_school_academic_term,
     test_school_admission,
     test_school_admission_form,
+    test_school_admission_payment_date_pattern,
     test_school_admission_payment_term,
     test_school_admission_test,
     test_school_admission_wizards,

--- a/ssi_school_admission/tests/test_data_admission_payment_date_pattern.yaml
+++ b/ssi_school_admission/tests/test_data_admission_payment_date_pattern.yaml
@@ -1,0 +1,415 @@
+scenarios:
+  - name: "Compute Payment - Estimated Invoice and Due Date from Duration"
+    steps:
+      - step: "Setup - get sale journal"
+        action: "search"
+        model: "account.journal"
+        domain: [["type", "=", "sale"]]
+        save_as: "receivable_journal"
+        limit: 1
+
+      - step: "Setup - get account type ref"
+        action: "ref"
+        xml_id: "account.data_account_type_revenue"
+        save_as: "account_type"
+
+      - step: "Setup - create income account"
+        action: "create"
+        model: "account.account"
+        save_as: "account"
+        values:
+          name: "Admission Fee Income ADPTDUR"
+          code: "ADPTDUR4200"
+          user_type_id: "EVAL: registry['account_type'].id"
+
+      - step: "Setup - create product"
+        action: "create"
+        model: "product.product"
+        save_as: "product"
+        values:
+          name: "Admission Fee ADPTDUR"
+          type: "service"
+          list_price: 2000000.0
+
+      - step: "Setup - create pricelist"
+        action: "create"
+        model: "product.pricelist"
+        save_as: "pricelist"
+        values:
+          name: "Pricelist ADPTDUR"
+          currency_id: "EVAL: env.company.currency_id.id"
+
+      - step: "Setup - create grade type"
+        action: "create"
+        model: "school_grade_type"
+        save_as: "grade_type"
+        values:
+          name: "Grade Type ADPTDUR"
+          code: "GTADPTDUR"
+          sequence: 10
+
+      - step: "Setup - create academic year"
+        action: "create"
+        model: "school_academic_year"
+        save_as: "academic_year"
+        values:
+          name: "2024/2025 ADPTDUR"
+          code: "AYADPTDUR"
+          date_start: "2024-07-01"
+          date_end: "2025-06-30"
+
+      - step: "Setup - create academic term"
+        action: "create"
+        model: "school_academic_term"
+        save_as: "academic_term"
+        values:
+          name: "Semester ADPTDUR"
+          code: "SMADPTDUR"
+          date_start: "2024-07-01"
+          date_end: "2025-06-30"
+          year_id: "EVAL: registry['academic_year'].id"
+          enrollment_state: "open"
+
+      - step: "Setup - create school"
+        action: "create"
+        model: "school"
+        save_as: "school"
+        values:
+          name: "School ADPTDUR"
+          code: "SCHADPTDUR"
+          grade_type_id: "EVAL: registry['grade_type'].id"
+
+      - step: "Setup - create grade"
+        action: "create"
+        model: "school_grade"
+        save_as: "grade"
+        values:
+          name: "Grade ADPTDUR"
+          code: "GADPTDUR"
+          sequence: 10
+          type_id: "EVAL: registry['grade_type'].id"
+
+      - step: "Setup - create student contact"
+        action: "create"
+        model: "res.partner"
+        save_as: "student_contact"
+        values:
+          name: "Student Contact ADPTDUR"
+
+      - step: "Setup - create invoice date duration for term 1 (no offset)"
+        action: "create"
+        model: "base.duration"
+        save_as: "dur_inv_t1"
+        values:
+          name: "Invoice Duration Term 1 ADPTDUR"
+          code: "DURINVT1ADPTDUR"
+
+      - step: "Setup - create invoice date duration for term 2 (+1 month)"
+        action: "create"
+        model: "base.duration"
+        save_as: "dur_inv_t2"
+        values:
+          name: "Invoice Duration Term 2 ADPTDUR"
+          code: "DURINVT2ADPTDUR"
+          relative_delta_months: 1
+
+      - step: "Setup - create due date duration (+14 days)"
+        action: "create"
+        model: "base.duration"
+        save_as: "dur_due"
+        values:
+          name: "Due Duration ADPTDUR"
+          code: "DURDUEADPTDUR"
+          relative_delta_days: 14
+
+      - step: "Setup - create payment template with 2 terms"
+        action: "create"
+        model: "school_admission_payment_template"
+        save_as: "payment_template"
+        values:
+          name: "Admission Payment Template ADPTDUR"
+          code: "ADPTDUR001"
+          school_id: "EVAL: registry['school'].id"
+          grade_id: "EVAL: registry['grade'].id"
+          academic_term_id: "EVAL: registry['academic_term'].id"
+          term_ids:
+            - - 0
+              - 0
+              - name: "Admission Term 1 ADPTDUR"
+                sequence: 10
+                date_invoice_duration_id: "EVAL: registry['dur_inv_t1'].id"
+                date_due_duration_id: "EVAL: registry['dur_due'].id"
+                detail_ids:
+                  - - 0
+                    - 0
+                    - product_id: "EVAL: registry['product'].id"
+                      name: "Admission Fee ADPTDUR"
+                      account_id: "EVAL: registry['account'].id"
+                      uom_quantity: 1.0
+                      uom_id: "REF: uom.product_uom_unit"
+                      price_unit: 2000000.0
+            - - 0
+              - 0
+              - name: "Admission Term 2 ADPTDUR"
+                sequence: 20
+                date_invoice_duration_id: "EVAL: registry['dur_inv_t2'].id"
+                date_due_duration_id: "EVAL: registry['dur_due'].id"
+                detail_ids:
+                  - - 0
+                    - 0
+                    - product_id: "EVAL: registry['product'].id"
+                      name: "Admission Fee ADPTDUR"
+                      account_id: "EVAL: registry['account'].id"
+                      uom_quantity: 1.0
+                      uom_id: "REF: uom.product_uom_unit"
+                      price_unit: 2000000.0
+
+      - step: "Create admission"
+        action: "create"
+        model: "school_admission"
+        save_as: "admission"
+        values:
+          date: "2024-07-01"
+          academic_year_id: "EVAL: registry['academic_year'].id"
+          academic_term_id: "EVAL: registry['academic_term'].id"
+          school_id: "EVAL: registry['school'].id"
+          grade_id: "EVAL: registry['grade'].id"
+          student_id: "EVAL: registry['student_contact'].id"
+          payment_template_id: "EVAL: registry['payment_template'].id"
+          pricelist_id: "EVAL: registry['pricelist'].id"
+          currency_id: "EVAL: env.company.currency_id.id"
+          receivable_journal_id: "EVAL: registry['receivable_journal'].id"
+
+      - step: "Confirm admission"
+        action: "call"
+        target: "admission"
+        method: "action_confirm"
+        as_user: "base.user_admin"
+
+      - step: "Compute payment"
+        action: "call"
+        target: "admission"
+        method: "action_compute_payment"
+        as_user: "base.user_admin"
+
+      - step: "Invalidate admission cache after compute"
+        action: "call"
+        target: "admission"
+        method: "invalidate_cache"
+
+      - step: "Get admission payment term 1"
+        action: "search"
+        model: "school_admission_payment_term"
+        domain:
+          [
+            ["admission_id", "=", "EVAL: registry['admission'].id"],
+            ["sequence", "=", 10],
+          ]
+        save_as: "term1"
+        expect_count: 1
+
+      - step: "Get admission payment term 2"
+        action: "search"
+        model: "school_admission_payment_term"
+        domain:
+          [
+            ["admission_id", "=", "EVAL: registry['admission'].id"],
+            ["sequence", "=", 20],
+          ]
+        save_as: "term2"
+        expect_count: 1
+
+      - step: "Assert term 1 invoice and due date"
+        action: "assert"
+        target: "term1"
+        asserts:
+          date_invoice:
+            type: "value"
+            expected: 2024-07-01
+          date_due:
+            type: "value"
+            expected: 2024-07-15
+
+      - step: "Assert term 2 invoice and due date"
+        action: "assert"
+        target: "term2"
+        asserts:
+          date_invoice:
+            type: "value"
+            expected: 2024-08-01
+          date_due:
+            type: "value"
+            expected: 2024-08-15
+
+  - name: "Compute Payment - Term without Duration leaves dates empty"
+    steps:
+      - step: "Setup - get sale journal"
+        action: "search"
+        model: "account.journal"
+        domain: [["type", "=", "sale"]]
+        save_as: "receivable_journal"
+        limit: 1
+
+      - step: "Setup - get account type ref"
+        action: "ref"
+        xml_id: "account.data_account_type_revenue"
+        save_as: "account_type"
+
+      - step: "Setup - create income account"
+        action: "create"
+        model: "account.account"
+        save_as: "account"
+        values:
+          name: "Admission Fee Income ADPTNODUR"
+          code: "ADPTNODUR4200"
+          user_type_id: "EVAL: registry['account_type'].id"
+
+      - step: "Setup - create product"
+        action: "create"
+        model: "product.product"
+        save_as: "product"
+        values:
+          name: "Admission Fee ADPTNODUR"
+          type: "service"
+          list_price: 1000000.0
+
+      - step: "Setup - create pricelist"
+        action: "create"
+        model: "product.pricelist"
+        save_as: "pricelist"
+        values:
+          name: "Pricelist ADPTNODUR"
+          currency_id: "EVAL: env.company.currency_id.id"
+
+      - step: "Setup - create grade type"
+        action: "create"
+        model: "school_grade_type"
+        save_as: "grade_type"
+        values:
+          name: "Grade Type ADPTNODUR"
+          code: "GTADPTNODUR"
+          sequence: 10
+
+      - step: "Setup - create academic year"
+        action: "create"
+        model: "school_academic_year"
+        save_as: "academic_year"
+        values:
+          name: "2024/2025 ADPTNODUR"
+          code: "AYADPTNODUR"
+          date_start: "2024-07-01"
+          date_end: "2025-06-30"
+
+      - step: "Setup - create academic term"
+        action: "create"
+        model: "school_academic_term"
+        save_as: "academic_term"
+        values:
+          name: "Semester ADPTNODUR"
+          code: "SMADPTNODUR"
+          date_start: "2024-07-01"
+          date_end: "2025-06-30"
+          year_id: "EVAL: registry['academic_year'].id"
+          enrollment_state: "open"
+
+      - step: "Setup - create school"
+        action: "create"
+        model: "school"
+        save_as: "school"
+        values:
+          name: "School ADPTNODUR"
+          code: "SCHADPTNODUR"
+          grade_type_id: "EVAL: registry['grade_type'].id"
+
+      - step: "Setup - create grade"
+        action: "create"
+        model: "school_grade"
+        save_as: "grade"
+        values:
+          name: "Grade ADPTNODUR"
+          code: "GADPTNODUR"
+          sequence: 10
+          type_id: "EVAL: registry['grade_type'].id"
+
+      - step: "Setup - create student contact"
+        action: "create"
+        model: "res.partner"
+        save_as: "student_contact"
+        values:
+          name: "Student Contact ADPTNODUR"
+
+      - step: "Setup - create payment template with 1 term without duration"
+        action: "create"
+        model: "school_admission_payment_template"
+        save_as: "payment_template"
+        values:
+          name: "Admission Payment Template ADPTNODUR"
+          code: "ADPTNODUR001"
+          school_id: "EVAL: registry['school'].id"
+          grade_id: "EVAL: registry['grade'].id"
+          academic_term_id: "EVAL: registry['academic_term'].id"
+          term_ids:
+            - - 0
+              - 0
+              - name: "Admission Term ADPTNODUR"
+                sequence: 10
+                detail_ids:
+                  - - 0
+                    - 0
+                    - product_id: "EVAL: registry['product'].id"
+                      name: "Admission Fee ADPTNODUR"
+                      account_id: "EVAL: registry['account'].id"
+                      uom_quantity: 1.0
+                      uom_id: "REF: uom.product_uom_unit"
+                      price_unit: 1000000.0
+
+      - step: "Create admission"
+        action: "create"
+        model: "school_admission"
+        save_as: "admission"
+        values:
+          date: "2024-07-01"
+          academic_year_id: "EVAL: registry['academic_year'].id"
+          academic_term_id: "EVAL: registry['academic_term'].id"
+          school_id: "EVAL: registry['school'].id"
+          grade_id: "EVAL: registry['grade'].id"
+          student_id: "EVAL: registry['student_contact'].id"
+          payment_template_id: "EVAL: registry['payment_template'].id"
+          pricelist_id: "EVAL: registry['pricelist'].id"
+          currency_id: "EVAL: env.company.currency_id.id"
+          receivable_journal_id: "EVAL: registry['receivable_journal'].id"
+
+      - step: "Confirm admission"
+        action: "call"
+        target: "admission"
+        method: "action_confirm"
+        as_user: "base.user_admin"
+
+      - step: "Compute payment"
+        action: "call"
+        target: "admission"
+        method: "action_compute_payment"
+        as_user: "base.user_admin"
+
+      - step: "Invalidate admission cache after compute"
+        action: "call"
+        target: "admission"
+        method: "invalidate_cache"
+
+      - step: "Get admission payment term"
+        action: "search"
+        model: "school_admission_payment_term"
+        domain: [["admission_id", "=", "EVAL: registry['admission'].id"]]
+        save_as: "term"
+        expect_count: 1
+
+      - step: "Assert term has no invoice/due date"
+        action: "assert"
+        target: "term"
+        asserts:
+          date_invoice:
+            type: "value"
+            operator: "is_falsy"
+          date_due:
+            type: "value"
+            operator: "is_falsy"

--- a/ssi_school_admission/tests/test_school_admission_payment_date_pattern.py
+++ b/ssi_school_admission/tests/test_school_admission_payment_date_pattern.py
@@ -1,0 +1,15 @@
+# Copyright 2024 OpenSynergy Indonesia
+# Copyright 2024 PT. Simetri Sinergi Indonesia
+# License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl).
+
+from odoo_yaml_test import YamlTransactionCase
+
+from odoo.tests import tagged
+
+
+@tagged("post_install", "-at_install")
+class TestSchoolAdmissionPaymentDatePattern(
+    YamlTransactionCase
+):  # pylint: disable=too-few-public-methods
+    def test_admission_payment_date_pattern(self):
+        self.run_yaml_scenario("test_data_admission_payment_date_pattern.yaml")

--- a/ssi_school_admission/views/school_admission_payment_template.xml
+++ b/ssi_school_admission/views/school_admission_payment_template.xml
@@ -85,6 +85,8 @@
                                     </group>
                                     <group name="term_header_right" colspan="1" col="2">
                                         <field name="sequence" />
+                                        <field name="date_invoice_duration_id" />
+                                        <field name="date_due_duration_id" />
                                     </group>
                                 </group>
                                 <notebook>


### PR DESCRIPTION
## Ringkasan

* Menambahkan field `date_invoice_duration_id` dan `date_due_duration_id` (Many2one ke `base.duration`) pada `school_admission_payment_template.term`.
* `action_compute_payment` kini otomatis mengisi `date_invoice` (Estimated Invoice Date) dan `date_due` (Estimated Due Date) tiap payment term dari tanggal admission memakai `base.duration.get_duration()`.
* Menambahkan `base_duration` ke `depends` manifest.
* Menambahkan unit test skenario compute payment dengan pola tanggal (term dengan duration + term tanpa duration).