### PR TITLE
[UPD] ssi_school

### DIFF
--- a/ssi_school/__manifest__.py
+++ b/ssi_school/__manifest__.py
@@ -21,6 +21,7 @@
         "ssi_product_line_account_mixin",
         "base_address_city",
         "ssi_financial_accounting",
+        "base_duration",
     ],
     "data": [
         "security/ir_module_category_data.xml",

--- a/ssi_school/models/school_enrollment.py
+++ b/ssi_school/models/school_enrollment.py
@@ -462,11 +462,21 @@ class SchoolEnrollment(models.Model):
             "school_enrollment_payment_term_detail"
         ]
         for tterm in template.term_ids.sorted("sequence"):
+            date_invoice = False
+            date_due = False
+            if tterm.date_invoice_duration_id:
+                date_invoice = tterm.date_invoice_duration_id.get_duration(self.date)
+            if tterm.date_due_duration_id:
+                date_due = tterm.date_due_duration_id.get_duration(
+                    date_invoice or self.date
+                )
             term = Term.create(
                 {
                     "enrollment_id": self.id,
                     "name": tterm.name,
                     "sequence": tterm.sequence,
+                    "date_invoice": date_invoice,
+                    "date_due": date_due,
                 }
             )
             for tdetail in tterm.detail_ids.sorted("sequence"):

--- a/ssi_school/models/school_enrollment_payment_template_term.py
+++ b/ssi_school/models/school_enrollment_payment_template_term.py
@@ -44,3 +44,21 @@ class SchoolEnrollmentPaymentTemplateTerm(
         copy=True,
         help="Product/fee detail lines included in this payment period.",
     )
+    date_invoice_duration_id = fields.Many2one(
+        string="Invoice Date Duration",
+        comodel_name="base.duration",
+        help=(
+            "Duration applied to the enrollment date to compute the "
+            "estimated invoice date of this term. Leave empty to skip "
+            "auto-computing the estimated invoice date."
+        ),
+    )
+    date_due_duration_id = fields.Many2one(
+        string="Due Date Duration",
+        comodel_name="base.duration",
+        help=(
+            "Duration applied to this term's estimated invoice date to "
+            "compute its estimated due date. Leave empty to skip "
+            "auto-computing the estimated due date."
+        ),
+    )

--- a/ssi_school/tests/__init__.py
+++ b/ssi_school/tests/__init__.py
@@ -18,4 +18,5 @@ from . import (  # noqa: F401
     test_school_enrollment_results,
     test_school_enrollment_payment_term_management,
     test_school_enrollment_product_summary,
+    test_school_enrollment_payment_date_pattern,
 )

--- a/ssi_school/tests/test_data_enrollment_payment_date_pattern.yaml
+++ b/ssi_school/tests/test_data_enrollment_payment_date_pattern.yaml
@@ -1,0 +1,457 @@
+scenarios:
+  - name: "Compute Payment - Estimated Invoice and Due Date from Duration"
+    steps:
+      - step: "Setup - get sale journal"
+        action: "search"
+        model: "account.journal"
+        domain: [["type", "=", "sale"]]
+        save_as: "receivable_journal"
+        limit: 1
+
+      - step: "Setup - get account type ref"
+        action: "ref"
+        xml_id: "account.data_account_type_revenue"
+        save_as: "account_type"
+
+      - step: "Setup - create income account"
+        action: "create"
+        model: "account.account"
+        save_as: "account"
+        values:
+          name: "Enrollment Fee Income ENPTDUR"
+          code: "ENPTDUR4200"
+          user_type_id: "EVAL: registry['account_type'].id"
+
+      - step: "Setup - create product"
+        action: "create"
+        model: "product.product"
+        save_as: "product"
+        values:
+          name: "Enrollment Fee ENPTDUR"
+          type: "service"
+          list_price: 2000000.0
+
+      - step: "Setup - create pricelist"
+        action: "create"
+        model: "product.pricelist"
+        save_as: "pricelist"
+        values:
+          name: "Pricelist ENPTDUR"
+          currency_id: "EVAL: env.company.currency_id.id"
+
+      - step: "Setup - create grade type"
+        action: "create"
+        model: "school_grade_type"
+        save_as: "grade_type"
+        values:
+          name: "Grade Type ENPTDUR"
+          code: "GTENPTDUR"
+          sequence: 10
+
+      - step: "Setup - create academic year"
+        action: "create"
+        model: "school_academic_year"
+        save_as: "academic_year"
+        values:
+          name: "2024/2025 ENPTDUR"
+          code: "AYENPTDUR"
+          date_start: "2024-07-01"
+          date_end: "2025-06-30"
+
+      - step: "Setup - create academic term"
+        action: "create"
+        model: "school_academic_term"
+        save_as: "academic_term"
+        values:
+          name: "Semester ENPTDUR"
+          code: "SMENPTDUR"
+          date_start: "2024-07-01"
+          date_end: "2025-06-30"
+          year_id: "EVAL: registry['academic_year'].id"
+          enrollment_state: "open"
+
+      - step: "Setup - create school"
+        action: "create"
+        model: "school"
+        save_as: "school"
+        values:
+          name: "School ENPTDUR"
+          code: "SCHENPTDUR"
+          grade_type_id: "EVAL: registry['grade_type'].id"
+
+      - step: "Setup - create grade"
+        action: "create"
+        model: "school_grade"
+        save_as: "grade"
+        values:
+          name: "Grade ENPTDUR"
+          code: "GENPTDUR"
+          sequence: 10
+          type_id: "EVAL: registry['grade_type'].id"
+
+      - step: "Setup - create grade class"
+        action: "create"
+        model: "school_grade_class"
+        save_as: "grade_class"
+        values:
+          name: "Class ENPTDUR"
+          code: "CLAENPTDUR"
+          school_id: "EVAL: registry['school'].id"
+          grade_id: "EVAL: registry['grade'].id"
+
+      - step: "Setup - create student contact"
+        action: "create"
+        model: "res.partner"
+        save_as: "contact"
+        values:
+          name: "Student Contact ENPTDUR"
+
+      - step: "Setup - create student"
+        action: "create"
+        model: "school_student"
+        save_as: "student"
+        values:
+          name: "Student ENPTDUR"
+          code: "STUENPTDUR"
+          contact_id: "EVAL: registry['contact'].id"
+          school_id: "EVAL: registry['school'].id"
+
+      - step: "Setup - create invoice date duration for term 1 (no offset)"
+        action: "create"
+        model: "base.duration"
+        save_as: "dur_inv_t1"
+        values:
+          name: "Invoice Duration Term 1 ENPTDUR"
+          code: "DURINVT1ENPTDUR"
+
+      - step: "Setup - create invoice date duration for term 2 (+1 month)"
+        action: "create"
+        model: "base.duration"
+        save_as: "dur_inv_t2"
+        values:
+          name: "Invoice Duration Term 2 ENPTDUR"
+          code: "DURINVT2ENPTDUR"
+          relative_delta_months: 1
+
+      - step: "Setup - create due date duration (+14 days)"
+        action: "create"
+        model: "base.duration"
+        save_as: "dur_due"
+        values:
+          name: "Due Duration ENPTDUR"
+          code: "DURDUEENPTDUR"
+          relative_delta_days: 14
+
+      - step: "Setup - create payment template with 2 terms"
+        action: "create"
+        model: "school_enrollment_payment_template"
+        save_as: "payment_template"
+        values:
+          name: "Enrollment Payment Template ENPTDUR"
+          code: "ENPTDUR001"
+          school_id: "EVAL: registry['school'].id"
+          grade_id: "EVAL: registry['grade'].id"
+          academic_term_id: "EVAL: registry['academic_term'].id"
+          term_ids:
+            - - 0
+              - 0
+              - name: "Enrollment Term 1 ENPTDUR"
+                sequence: 10
+                date_invoice_duration_id: "EVAL: registry['dur_inv_t1'].id"
+                date_due_duration_id: "EVAL: registry['dur_due'].id"
+                detail_ids:
+                  - - 0
+                    - 0
+                    - product_id: "EVAL: registry['product'].id"
+                      name: "Enrollment Fee ENPTDUR"
+                      account_id: "EVAL: registry['account'].id"
+                      uom_quantity: 1.0
+                      uom_id: "REF: uom.product_uom_unit"
+                      price_unit: 2000000.0
+            - - 0
+              - 0
+              - name: "Enrollment Term 2 ENPTDUR"
+                sequence: 20
+                date_invoice_duration_id: "EVAL: registry['dur_inv_t2'].id"
+                date_due_duration_id: "EVAL: registry['dur_due'].id"
+                detail_ids:
+                  - - 0
+                    - 0
+                    - product_id: "EVAL: registry['product'].id"
+                      name: "Enrollment Fee ENPTDUR"
+                      account_id: "EVAL: registry['account'].id"
+                      uom_quantity: 1.0
+                      uom_id: "REF: uom.product_uom_unit"
+                      price_unit: 2000000.0
+
+      - step: "Create enrollment"
+        action: "create"
+        model: "school_enrollment"
+        save_as: "enrollment"
+        values:
+          date: "2024-07-01"
+          academic_year_id: "EVAL: registry['academic_year'].id"
+          academic_term_id: "EVAL: registry['academic_term'].id"
+          school_id: "EVAL: registry['school'].id"
+          grade_id: "EVAL: registry['grade'].id"
+          grade_class_id: "EVAL: registry['grade_class'].id"
+          student_id: "EVAL: registry['student'].id"
+          payment_template_id: "EVAL: registry['payment_template'].id"
+          pricelist_id: "EVAL: registry['pricelist'].id"
+          currency_id: "EVAL: env.company.currency_id.id"
+          receivable_journal_id: "EVAL: registry['receivable_journal'].id"
+
+      - step: "Confirm enrollment"
+        action: "call"
+        target: "enrollment"
+        method: "action_confirm"
+        as_user: "base.user_admin"
+
+      - step: "Compute payment"
+        action: "call"
+        target: "enrollment"
+        method: "action_compute_payment"
+        as_user: "base.user_admin"
+
+      - step: "Invalidate enrollment cache after compute"
+        action: "call"
+        target: "enrollment"
+        method: "invalidate_cache"
+
+      - step: "Get enrollment payment term 1"
+        action: "search"
+        model: "school_enrollment_payment_term"
+        domain:
+          [
+            ["enrollment_id", "=", "EVAL: registry['enrollment'].id"],
+            ["sequence", "=", 10],
+          ]
+        save_as: "term1"
+        expect_count: 1
+
+      - step: "Get enrollment payment term 2"
+        action: "search"
+        model: "school_enrollment_payment_term"
+        domain:
+          [
+            ["enrollment_id", "=", "EVAL: registry['enrollment'].id"],
+            ["sequence", "=", 20],
+          ]
+        save_as: "term2"
+        expect_count: 1
+
+      - step: "Assert term 1 invoice and due date"
+        action: "assert"
+        target: "term1"
+        asserts:
+          date_invoice:
+            type: "value"
+            expected: 2024-07-01
+          date_due:
+            type: "value"
+            expected: 2024-07-15
+
+      - step: "Assert term 2 invoice and due date"
+        action: "assert"
+        target: "term2"
+        asserts:
+          date_invoice:
+            type: "value"
+            expected: 2024-08-01
+          date_due:
+            type: "value"
+            expected: 2024-08-15
+
+  - name: "Compute Payment - Term without Duration leaves dates empty"
+    steps:
+      - step: "Setup - get sale journal"
+        action: "search"
+        model: "account.journal"
+        domain: [["type", "=", "sale"]]
+        save_as: "receivable_journal"
+        limit: 1
+
+      - step: "Setup - get account type ref"
+        action: "ref"
+        xml_id: "account.data_account_type_revenue"
+        save_as: "account_type"
+
+      - step: "Setup - create income account"
+        action: "create"
+        model: "account.account"
+        save_as: "account"
+        values:
+          name: "Enrollment Fee Income ENPTNODUR"
+          code: "ENPTNODUR4200"
+          user_type_id: "EVAL: registry['account_type'].id"
+
+      - step: "Setup - create product"
+        action: "create"
+        model: "product.product"
+        save_as: "product"
+        values:
+          name: "Enrollment Fee ENPTNODUR"
+          type: "service"
+          list_price: 1000000.0
+
+      - step: "Setup - create pricelist"
+        action: "create"
+        model: "product.pricelist"
+        save_as: "pricelist"
+        values:
+          name: "Pricelist ENPTNODUR"
+          currency_id: "EVAL: env.company.currency_id.id"
+
+      - step: "Setup - create grade type"
+        action: "create"
+        model: "school_grade_type"
+        save_as: "grade_type"
+        values:
+          name: "Grade Type ENPTNODUR"
+          code: "GTENPTNODUR"
+          sequence: 10
+
+      - step: "Setup - create academic year"
+        action: "create"
+        model: "school_academic_year"
+        save_as: "academic_year"
+        values:
+          name: "2024/2025 ENPTNODUR"
+          code: "AYENPTNODUR"
+          date_start: "2024-07-01"
+          date_end: "2025-06-30"
+
+      - step: "Setup - create academic term"
+        action: "create"
+        model: "school_academic_term"
+        save_as: "academic_term"
+        values:
+          name: "Semester ENPTNODUR"
+          code: "SMENPTNODUR"
+          date_start: "2024-07-01"
+          date_end: "2025-06-30"
+          year_id: "EVAL: registry['academic_year'].id"
+          enrollment_state: "open"
+
+      - step: "Setup - create school"
+        action: "create"
+        model: "school"
+        save_as: "school"
+        values:
+          name: "School ENPTNODUR"
+          code: "SCHENPTNODUR"
+          grade_type_id: "EVAL: registry['grade_type'].id"
+
+      - step: "Setup - create grade"
+        action: "create"
+        model: "school_grade"
+        save_as: "grade"
+        values:
+          name: "Grade ENPTNODUR"
+          code: "GENPTNODUR"
+          sequence: 10
+          type_id: "EVAL: registry['grade_type'].id"
+
+      - step: "Setup - create grade class"
+        action: "create"
+        model: "school_grade_class"
+        save_as: "grade_class"
+        values:
+          name: "Class ENPTNODUR"
+          code: "CLAENPTNODUR"
+          school_id: "EVAL: registry['school'].id"
+          grade_id: "EVAL: registry['grade'].id"
+
+      - step: "Setup - create student contact"
+        action: "create"
+        model: "res.partner"
+        save_as: "contact"
+        values:
+          name: "Student Contact ENPTNODUR"
+
+      - step: "Setup - create student"
+        action: "create"
+        model: "school_student"
+        save_as: "student"
+        values:
+          name: "Student ENPTNODUR"
+          code: "STUENPTNODUR"
+          contact_id: "EVAL: registry['contact'].id"
+          school_id: "EVAL: registry['school'].id"
+
+      - step: "Setup - create payment template with 1 term without duration"
+        action: "create"
+        model: "school_enrollment_payment_template"
+        save_as: "payment_template"
+        values:
+          name: "Enrollment Payment Template ENPTNODUR"
+          code: "ENPTNODUR001"
+          school_id: "EVAL: registry['school'].id"
+          grade_id: "EVAL: registry['grade'].id"
+          academic_term_id: "EVAL: registry['academic_term'].id"
+          term_ids:
+            - - 0
+              - 0
+              - name: "Enrollment Term ENPTNODUR"
+                sequence: 10
+                detail_ids:
+                  - - 0
+                    - 0
+                    - product_id: "EVAL: registry['product'].id"
+                      name: "Enrollment Fee ENPTNODUR"
+                      account_id: "EVAL: registry['account'].id"
+                      uom_quantity: 1.0
+                      uom_id: "REF: uom.product_uom_unit"
+                      price_unit: 1000000.0
+
+      - step: "Create enrollment"
+        action: "create"
+        model: "school_enrollment"
+        save_as: "enrollment"
+        values:
+          date: "2024-07-01"
+          academic_year_id: "EVAL: registry['academic_year'].id"
+          academic_term_id: "EVAL: registry['academic_term'].id"
+          school_id: "EVAL: registry['school'].id"
+          grade_id: "EVAL: registry['grade'].id"
+          grade_class_id: "EVAL: registry['grade_class'].id"
+          student_id: "EVAL: registry['student'].id"
+          payment_template_id: "EVAL: registry['payment_template'].id"
+          pricelist_id: "EVAL: registry['pricelist'].id"
+          currency_id: "EVAL: env.company.currency_id.id"
+          receivable_journal_id: "EVAL: registry['receivable_journal'].id"
+
+      - step: "Confirm enrollment"
+        action: "call"
+        target: "enrollment"
+        method: "action_confirm"
+        as_user: "base.user_admin"
+
+      - step: "Compute payment"
+        action: "call"
+        target: "enrollment"
+        method: "action_compute_payment"
+        as_user: "base.user_admin"
+
+      - step: "Invalidate enrollment cache after compute"
+        action: "call"
+        target: "enrollment"
+        method: "invalidate_cache"
+
+      - step: "Get enrollment payment term"
+        action: "search"
+        model: "school_enrollment_payment_term"
+        domain: [["enrollment_id", "=", "EVAL: registry['enrollment'].id"]]
+        save_as: "term"
+        expect_count: 1
+
+      - step: "Assert term has no invoice/due date"
+        action: "assert"
+        target: "term"
+        asserts:
+          date_invoice:
+            type: "value"
+            operator: "is_falsy"
+          date_due:
+            type: "value"
+            operator: "is_falsy"

--- a/ssi_school/tests/test_school_enrollment_payment_date_pattern.py
+++ b/ssi_school/tests/test_school_enrollment_payment_date_pattern.py
@@ -1,0 +1,15 @@
+# Copyright 2026 OpenSynergy Indonesia
+# Copyright 2026 PT. Simetri Sinergi Indonesia
+# License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl).
+
+from odoo_yaml_test import YamlTransactionCase
+
+from odoo.tests import tagged
+
+
+@tagged("post_install", "-at_install")
+class TestSchoolEnrollmentPaymentDatePattern(
+    YamlTransactionCase
+):  # pylint: disable=too-few-public-methods
+    def test_enrollment_payment_date_pattern(self):
+        self.run_yaml_scenario("test_data_enrollment_payment_date_pattern.yaml")

--- a/ssi_school/views/school_enrollment_payment_template_views.xml
+++ b/ssi_school/views/school_enrollment_payment_template_views.xml
@@ -85,6 +85,8 @@
                                     </group>
                                     <group name="term_header_right" colspan="1" col="2">
                                         <field name="sequence" />
+                                        <field name="date_invoice_duration_id" />
+                                        <field name="date_due_duration_id" />
                                     </group>
                                 </group>
                                 <notebook>


### PR DESCRIPTION
## Ringkasan

Port dari BL-0022 (ssi_school_admission, PR #46 merged) ke jalur enrollment: pola
tanggal invoice/due per term via base_duration.

* Tambah field `date_invoice_duration_id` & `date_due_duration_id` (Many2one
  `base.duration`) pada `school_enrollment_payment_template.term`.
* `_compute_payment_from_template` kini otomatis mengisi `date_invoice` & `date_due`
  tiap `school_enrollment_payment_term` dari `base.duration` term template terkait
  (invoice date dari tanggal enrollment, due date dari invoice date term itu).
* Tampilkan dua field duration baru di form term nested payment template.
* Tambah dependensi `base_duration` di manifest.
* Tambah unit test skenario `odoo-yaml-test` untuk pola tanggal invoice/due (dengan
  & tanpa duration).

🤖 Generated with [Claude Code](https://claude.com/claude-code)