### PR TITLE
[UPD] ssi_school

### DIFF
--- a/ssi_school/models/school_academic_term.py
+++ b/ssi_school/models/school_academic_term.py
@@ -3,7 +3,8 @@
 # License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl).
 
 
-from odoo import api, fields, models
+from odoo import _, api, fields, models
+from odoo.exceptions import ValidationError
 
 
 class SchoolAcademicTerm(models.Model):
@@ -102,6 +103,39 @@ class SchoolAcademicTerm(models.Model):
             if record == record.year_id.last_term_id:
                 result = True
             record.last_term = result
+
+    @api.constrains("date_start", "date_end", "year_id")
+    def _check_date_coherence(self):
+        for record in self:
+            if not (record.date_start and record.date_end and record.year_id):
+                continue
+            if record.date_end <= record.date_start:
+                error_message = (
+                    _(
+                        """
+Context: Set academic term dates
+Database ID: %s
+Problem: Date End must be after Date Start
+Solution: Set Date End to a date later than Date Start
+"""
+                    )
+                    % (record.id,)
+                )
+                raise ValidationError(error_message)
+            year = record.year_id
+            if record.date_start < year.date_start or record.date_end > year.date_end:
+                error_message = (
+                    _(
+                        """
+Context: Set academic term dates
+Database ID: %s
+Problem: Term dates fall outside the range of academic year '%s' (%s - %s)
+Solution: Set term dates within the academic year's date range
+"""
+                    )
+                    % (record.id, year.name, year.date_start, year.date_end)
+                )
+                raise ValidationError(error_message)
 
     def action_open(self):
         for record in self.sudo():

--- a/ssi_school/models/school_academic_year.py
+++ b/ssi_school/models/school_academic_year.py
@@ -3,7 +3,8 @@
 # License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl).
 
 
-from odoo import api, fields, models
+from odoo import _, api, fields, models
+from odoo.exceptions import ValidationError
 
 
 class SchoolAcademicYear(models.Model):  # pylint: disable=too-few-public-methods
@@ -66,3 +67,24 @@ class SchoolAcademicYear(models.Model):  # pylint: disable=too-few-public-method
                 last_term = record.term_ids[-1]
             record.first_term_id = first_term
             record.last_term_id = last_term
+
+    @api.constrains("date_start", "date_end")
+    def _check_date_coherence(self):
+        for record in self:
+            if (
+                record.date_start
+                and record.date_end
+                and record.date_end <= record.date_start
+            ):
+                error_message = (
+                    _(
+                        """
+Context: Set academic year dates
+Database ID: %s
+Problem: Date End must be after Date Start
+Solution: Set Date End to a date later than Date Start
+"""
+                    )
+                    % (record.id,)
+                )
+                raise ValidationError(error_message)

--- a/ssi_school/models/school_enrollment.py
+++ b/ssi_school/models/school_enrollment.py
@@ -4,7 +4,8 @@
 
 from datetime import date as datetime_date
 
-from odoo import api, fields, models
+from odoo import _, api, fields, models
+from odoo.exceptions import ValidationError
 
 from odoo.addons.ssi_decorator import ssi_decorator
 
@@ -440,6 +441,135 @@ class SchoolEnrollment(models.Model):
     )
     def onchange_grade_class_id(self):
         self.grade_class_id = False
+
+    @api.constrains("academic_term_id", "academic_year_id")
+    def _check_term_year_match(self):
+        for record in self:
+            if (
+                record.academic_term_id
+                and record.academic_year_id
+                and record.academic_term_id.year_id != record.academic_year_id
+            ):
+                error_message = (
+                    _(
+                        """
+Context: Set enrollment academic term
+Database ID: %s
+Problem: Academic Term '%s' does not belong to Academic Year '%s'
+Solution: Select an Academic Term that belongs to the selected Academic Year
+"""
+                    )
+                    % (
+                        record.id,
+                        record.academic_term_id.name,
+                        record.academic_year_id.name,
+                    )
+                )
+                raise ValidationError(error_message)
+
+    @api.constrains("grade_class_id", "grade_id", "school_id")
+    def _check_grade_class_match(self):
+        for record in self:
+            if not record.grade_class_id:
+                continue
+            if (
+                record.grade_class_id.grade_id != record.grade_id
+                or record.grade_class_id.school_id != record.school_id
+            ):
+                error_message = (
+                    _(
+                        """
+Context: Set enrollment grade class
+Database ID: %s
+Problem: Grade Class '%s' does not match the selected Grade/School
+Solution: Select a Grade Class that belongs to the selected Grade and School
+"""
+                    )
+                    % (record.id, record.grade_class_id.name)
+                )
+                raise ValidationError(error_message)
+
+    @api.constrains("state")
+    def _check_enrollment_window(self):
+        for record in self:
+            if (
+                record.state == "open"
+                and record.academic_term_id.enrollment_state != "open"
+            ):
+                error_message = (
+                    _(
+                        """
+Context: Open enrollment
+Database ID: %s
+Problem: Academic Term '%s' is not open for enrollment
+Solution: Open the enrollment window on the academic term before opening this enrollment
+"""
+                    )
+                    % (record.id, record.academic_term_id.name)
+                )
+                raise ValidationError(error_message)
+
+    @api.constrains("state", "student_id", "academic_term_id")
+    def _check_duplicate_active_enrollment(self):
+        for record in self:
+            if (
+                record.state != "open"
+                or not record.student_id
+                or not record.academic_term_id
+            ):
+                continue
+            duplicate = self.search(
+                [
+                    ("id", "!=", record.id),
+                    ("student_id", "=", record.student_id.id),
+                    ("academic_term_id", "=", record.academic_term_id.id),
+                    ("state", "=", "open"),
+                ]
+            )
+            if duplicate:
+                error_message = (
+                    _(
+                        """
+Context: Open enrollment
+Database ID: %s
+Problem: Student '%s' already has an active enrollment for term '%s'
+Solution: Cancel or close the existing enrollment before opening a new one
+"""
+                    )
+                    % (record.id, record.student_id.name, record.academic_term_id.name)
+                )
+                raise ValidationError(error_message)
+
+    @api.constrains("state", "grade_class_id")
+    def _check_grade_class_capacity(self):
+        for record in self:
+            grade_class = record.grade_class_id
+            if record.state != "open" or not grade_class or not grade_class.capacity:
+                continue
+            open_count = self.search_count(
+                [
+                    ("grade_class_id", "=", grade_class.id),
+                    ("state", "=", "open"),
+                ]
+            )
+            if open_count > grade_class.capacity:
+                error_message = (
+                    _(
+                        """
+Context: Open enrollment
+Database ID: %s
+Problem: Grade Class '%s' is at full capacity (%s/%s students)
+Solution: Choose a different Grade Class or increase its capacity
+"""
+                    )
+                    % (
+                        record.id,
+                        grade_class.name,
+                        open_count,
+                        grade_class.capacity,
+                    )
+                )
+                raise ValidationError(error_message)
 
     def action_set_result_to_passed(self):
         for record in self.sudo():

--- a/ssi_school/models/school_grade.py
+++ b/ssi_school/models/school_grade.py
@@ -37,7 +37,7 @@ class SchoolGrade(models.Model):
         help="The education level type that this grade belongs to.",
     )
     previous_grade_id = fields.Many2one(
-        strinng="Previous Grade",
+        string="Previous Grade",
         comodel_name="school_grade",
         compute=False,
         readonly=True,
@@ -81,22 +81,22 @@ class SchoolGrade(models.Model):
     @api.model
     def _recompute_next_previous(self):
         grades = self.env["school_grade"].search([])
-        for record in grades:
-            grade_index = grades.ids.index(record.id)
-            try:
+        for grade_type in grades.mapped("type_id"):
+            type_grades = grades.filtered(lambda g, t=grade_type: g.type_id == t)
+            for grade_index, record in enumerate(type_grades):
                 if grade_index - 1 < 0:
                     previous_grade = False
                 else:
-                    previous_grade = grades[grade_index - 1]
-            except BaseException:  # pylint: disable=broad-except
-                previous_grade = False
-            try:
-                next_grade = grades[grade_index + 1]
-            except BaseException:  # pylint: disable=broad-except
-                next_grade = False
-            record.write(
-                {
-                    "previous_grade_id": previous_grade and previous_grade.id or False,
-                    "next_grade_id": next_grade and next_grade.id or False,
-                }
-            )
+                    previous_grade = type_grades[grade_index - 1]
+                try:
+                    next_grade = type_grades[grade_index + 1]
+                except IndexError:
+                    next_grade = False
+                record.write(
+                    {
+                        "previous_grade_id": previous_grade
+                        and previous_grade.id
+                        or False,
+                        "next_grade_id": next_grade and next_grade.id or False,
+                    }
+                )

--- a/ssi_school/models/school_grade_class.py
+++ b/ssi_school/models/school_grade_class.py
@@ -42,9 +42,49 @@ class SchoolGradeClass(models.Model):  # pylint: disable=too-few-public-methods
             "Will be reset if the school is changed."
         ),
     )
+    capacity = fields.Integer(
+        string="Capacity",
+        default=0,
+        help=(
+            "Maximum number of students this class can hold. "
+            "Leave at 0 for unlimited capacity (no enrollment cap is enforced)."
+        ),
+    )
+    student_count = fields.Integer(
+        string="Student Count",
+        compute="_compute_student_count",
+        help=(
+            "Number of students currently actively enrolled (enrollment state "
+            "Open) in this class."
+        ),
+    )
+    available_seat = fields.Integer(
+        string="Available Seat",
+        compute="_compute_student_count",
+        help=(
+            "Remaining seats in this class (Capacity minus Student Count). "
+            "Not meaningful when Capacity is 0 (unlimited)."
+        ),
+    )
 
     @api.onchange(
         "school_id",
     )
     def onchange_grade_id(self):
         self.grade_id = False
+
+    # Deliberately non-store: student_count/available_seat aggregate
+    # school_enrollment records on another model, so there is no field chain
+    # to declare as a dependency. They recompute on every fresh read (e.g. a
+    # freshly opened form); actual capacity enforcement lives in
+    # school_enrollment._check_grade_class_capacity, which always runs a live
+    # search_count and is unaffected by this field's caching.
+    @api.depends("capacity")
+    def _compute_student_count(self):
+        enrollment_model = self.env["school_enrollment"]
+        for record in self:
+            count = enrollment_model.search_count(
+                [("grade_class_id", "=", record.id), ("state", "=", "open")]
+            )
+            record.student_count = count
+            record.available_seat = record.capacity - count

--- a/ssi_school/models/school_student.py
+++ b/ssi_school/models/school_student.py
@@ -3,7 +3,8 @@
 # License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl).
 
 
-from odoo import api, fields, models
+from odoo import _, api, fields, models
+from odoo.exceptions import ValidationError
 
 
 class SchoolStudent(models.Model):
@@ -190,20 +191,80 @@ class SchoolStudent(models.Model):
         selection=[
             ("draft", "Waiting for Enrollment"),
             ("enrol", "Enrolled"),
-            ("on_leave", "Cuti / Penangguhan"),
-            ("suspended", "Skorsing"),
+            ("on_leave", "On Leave"),
+            ("suspended", "Suspended"),
             ("graduate", "Graduated"),
-            ("transferred", "Mutasi Keluar"),
-            ("dropped", "Dikeluarkan / Drop Out"),
-            ("resigned", "Mengundurkan Diri"),
-            ("deceased", "Meninggal Dunia"),
+            ("transferred", "Transferred Out"),
+            ("dropped", "Dropped Out / Expelled"),
+            ("resigned", "Resigned"),
+            ("deceased", "Deceased"),
         ],
         default="draft",
+        tracking=True,
         help=(
             "Current status of the student, from waiting for enrollment "
             "to actively enrolled, graduated, or exited."
         ),
     )
+
+    # Maps each state to the set of states it may legally transition into
+    # (including itself, so no-op writes are always allowed).
+    #
+    # "draft" (registration, not yet enrolled) and "enrol" (actively enrolled)
+    # are the two normal churn states and may move to any other state directly
+    # (mirrors existing accepted usage, e.g. withdrawing before ever attending).
+    # Once a student reaches a terminal/exit state (graduate, transferred,
+    # dropped, resigned, deceased), it must go through "draft" first before it
+    # can be set back to "enrol" — this is the guard's real purpose: it blocks
+    # nonsensical direct jumps like deceased -> enrol or graduate -> enrol.
+    # "deceased" has no way out at all.
+    _ALL_STATES = {
+        "draft",
+        "enrol",
+        "on_leave",
+        "suspended",
+        "graduate",
+        "transferred",
+        "dropped",
+        "resigned",
+        "deceased",
+    }
+    _STATE_TRANSITIONS = {
+        "draft": _ALL_STATES,
+        "enrol": _ALL_STATES,
+        "on_leave": {"on_leave", "enrol", "draft"},
+        "suspended": {"suspended", "enrol", "draft", "dropped"},
+        "graduate": {"graduate", "draft"},
+        "transferred": {"transferred", "draft"},
+        "dropped": {"dropped", "draft"},
+        "resigned": {"resigned", "draft"},
+        "deceased": {"deceased"},
+    }
+
+    def write(self, values):
+        if values.get("state"):
+            new_state = values["state"]
+            state_labels = dict(self._fields["state"].selection)
+            for record in self:
+                allowed = self._STATE_TRANSITIONS.get(record.state, set())
+                if new_state not in allowed:
+                    error_message = (
+                        _(
+                            """
+Context: Change student state
+Database ID: %s
+Problem: State cannot change from '%s' to '%s'
+Solution: Follow the allowed student state transition sequence
+"""
+                        )
+                        % (
+                            record.id,
+                            state_labels.get(record.state, record.state),
+                            state_labels.get(new_state, new_state),
+                        )
+                    )
+                    raise ValidationError(error_message)
+        return super().write(values)
 
     @api.depends("enrollment_ids", "enrollment_ids.state")
     def _compute_active_enrollment_id(self):
@@ -232,12 +293,22 @@ class SchoolStudent(models.Model):
         "initial_grade_id",
         "enrollment_ids",
         "enrollment_ids.state",
+        "school_id",
     )
     def _compute_next_grade_id(self):
         for record in self:
             result = False
             if not record.initial_grade_id and not record.enrollment_ids:
-                result = self.env["school_grade"].search([])[0]
+                grade_type = record.school_id.grade_type_id
+                result = (
+                    self.env["school_grade"].search(
+                        [("type_id", "=", grade_type.id)],
+                        order="sequence asc, id",
+                        limit=1,
+                    )
+                    if grade_type
+                    else self.env["school_grade"]
+                )
             elif record.initial_grade_id and not record.enrollment_ids:
                 result = record.initial_grade_id.next_grade_id
             elif record.enrollment_ids:

--- a/ssi_school/tests/__init__.py
+++ b/ssi_school/tests/__init__.py
@@ -19,4 +19,5 @@ from . import (  # noqa: F401
     test_school_enrollment_payment_term_management,
     test_school_enrollment_product_summary,
     test_school_enrollment_payment_date_pattern,
+    test_school_enrollment_integrity,
 )

--- a/ssi_school/tests/test_data_grade.yaml
+++ b/ssi_school/tests/test_data_grade.yaml
@@ -166,3 +166,95 @@ scenarios:
           previous_grade_id:
             type: "value"
             operator: "is_truthy"
+
+  - name: "Grade Chain Scoped Per Grade Type"
+    steps:
+      - step: "Create elementary grade type"
+        action: "create"
+        model: "school_grade_type"
+        save_as: "type_elementary"
+        values:
+          name: "Elementary Scope Test"
+          code: "ELSC"
+          sequence: 10
+      - step: "Create junior high grade type"
+        action: "create"
+        model: "school_grade_type"
+        save_as: "type_junior"
+        values:
+          name: "Junior High Scope Test"
+          code: "JHSC"
+          sequence: 20
+      - step: "Create elementary grade 1"
+        action: "create"
+        model: "school_grade"
+        save_as: "el_grade_1"
+        values:
+          name: "Elementary Grade 1"
+          code: "ELG1"
+          sequence: 10
+          type_id: "EVAL: registry['type_elementary'].id"
+      - step: "Create elementary grade 2 (last of elementary)"
+        action: "create"
+        model: "school_grade"
+        save_as: "el_grade_2"
+        values:
+          name: "Elementary Grade 2"
+          code: "ELG2"
+          sequence: 20
+          type_id: "EVAL: registry['type_elementary'].id"
+      - step: "Create junior high grade 1 (first of junior high)"
+        action: "create"
+        model: "school_grade"
+        save_as: "jh_grade_1"
+        values:
+          name: "Junior High Grade 1"
+          code: "JHG1"
+          sequence: 10
+          type_id: "EVAL: registry['type_junior'].id"
+      - step: "Invalidate cache on elementary grade 1"
+        action: "call"
+        target: "el_grade_1"
+        method: "invalidate_cache"
+      - step: "Invalidate cache on elementary grade 2"
+        action: "call"
+        target: "el_grade_2"
+        method: "invalidate_cache"
+      - step: "Invalidate cache on junior high grade 1"
+        action: "call"
+        target: "jh_grade_1"
+        method: "invalidate_cache"
+      - step:
+          "Assert last elementary grade has no next grade (does not cross into junior
+          high)"
+        action: "assert"
+        target: "el_grade_2"
+        asserts:
+          next_grade_id:
+            type: "value"
+            operator: "is_falsy"
+      - step:
+          "Assert first junior high grade has no previous grade (does not cross into
+          elementary)"
+        action: "assert"
+        target: "jh_grade_1"
+        asserts:
+          previous_grade_id:
+            type: "value"
+            operator: "is_falsy"
+      - step: "Assert elementary grade 1 next grade is elementary grade 2"
+        action: "search"
+        model: "school_grade"
+        domain:
+          - ["id", "=", "EVAL: registry['el_grade_1'].next_grade_id.id"]
+          - ["id", "=", "EVAL: registry['el_grade_2'].id"]
+        save_as: "check_el_next"
+        expect_count: 1
+      - step: "Assert elementary grade 2 previous grade is elementary grade 1"
+        action: "search"
+        model: "school_grade"
+        domain:
+          - ["id", "=", "EVAL: registry['el_grade_2'].previous_grade_id.id"]
+          - ["id", "=", "EVAL: registry['el_grade_1'].id"]
+        save_as: "check_el_prev"
+        expect_count: 1

--- a/ssi_school/tests/test_data_grade_class.yaml
+++ b/ssi_school/tests/test_data_grade_class.yaml
@@ -252,3 +252,51 @@ scenarios:
           grade_type_id:
             type: "value"
             operator: "is_truthy"
+
+  - name: "Compute Student Count And Available Seat Without Enrollment"
+    steps:
+      - step: "Create grade type"
+        action: "create"
+        model: "school_grade_type"
+        save_as: "grade_type"
+        values:
+          name: "Grade Type Capacity Test"
+          code: "GTCAP"
+          sequence: 10
+      - step: "Create school"
+        action: "create"
+        model: "school"
+        save_as: "school"
+        values:
+          name: "School Capacity Test"
+          code: "SCHCAP"
+          grade_type_id: "EVAL: registry['grade_type'].id"
+      - step: "Create grade"
+        action: "create"
+        model: "school_grade"
+        save_as: "grade"
+        values:
+          name: "Grade Capacity Test"
+          code: "GCAP"
+          sequence: 10
+          type_id: "EVAL: registry['grade_type'].id"
+      - step: "Create grade class with capacity 5"
+        action: "create"
+        model: "school_grade_class"
+        save_as: "grade_class"
+        values:
+          name: "Class Capacity Test"
+          code: "CCAP"
+          school_id: "EVAL: registry['school'].id"
+          grade_id: "EVAL: registry['grade'].id"
+          capacity: 5
+      - step: "Assert student_count is zero and available_seat equals capacity"
+        action: "assert"
+        target: "grade_class"
+        asserts:
+          student_count:
+            type: "value"
+            expected: 0
+          available_seat:
+            type: "value"
+            expected: 5

--- a/ssi_school/tests/test_data_student.yaml
+++ b/ssi_school/tests/test_data_student.yaml
@@ -237,6 +237,123 @@ scenarios:
             type: "value"
             operator: "is_truthy"
 
+  - name: "Compute Next Grade Fallback Scoped To School Grade Type"
+    steps:
+      - step: "Create elementary grade type (sorts before junior high)"
+        action: "create"
+        model: "school_grade_type"
+        save_as: "type_elementary"
+        values:
+          name: "Elementary Fallback Test"
+          code: "ELFB"
+          sequence: 10
+      - step: "Create junior high grade type"
+        action: "create"
+        model: "school_grade_type"
+        save_as: "type_junior"
+        values:
+          name: "Junior High Fallback Test"
+          code: "JHFB"
+          sequence: 20
+      - step: "Create elementary grade (global first grade)"
+        action: "create"
+        model: "school_grade"
+        save_as: "el_grade"
+        values:
+          name: "Elementary Grade Fallback"
+          code: "ELGFB"
+          sequence: 10
+          type_id: "EVAL: registry['type_elementary'].id"
+      - step: "Create junior high grade (first grade of its own type)"
+        action: "create"
+        model: "school_grade"
+        save_as: "jh_grade"
+        values:
+          name: "Junior High Grade Fallback"
+          code: "JHGFB"
+          sequence: 10
+          type_id: "EVAL: registry['type_junior'].id"
+      - step: "Create junior high school"
+        action: "create"
+        model: "school"
+        save_as: "school"
+        values:
+          name: "Junior High School Fallback"
+          code: "SCHJHFB"
+          grade_type_id: "EVAL: registry['type_junior'].id"
+      - step: "Create contact"
+        action: "create"
+        model: "res.partner"
+        save_as: "contact"
+        values:
+          name: "Student Fallback Contact"
+      - step: "Create student without initial_grade_id or enrollment"
+        action: "create"
+        model: "school_student"
+        save_as: "student"
+        values:
+          name: "Student Fallback Test"
+          code: "STUFB"
+          contact_id: "EVAL: registry['contact'].id"
+          school_id: "EVAL: registry['school'].id"
+      - step: "Invalidate student cache"
+        action: "call"
+        target: "student"
+        method: "invalidate_cache"
+      - step: "Assert next_grade_id is the junior high grade, not the elementary one"
+        action: "search"
+        model: "school_grade"
+        domain:
+          - ["id", "=", "EVAL: registry['student'].next_grade_id.id"]
+          - ["id", "=", "EVAL: registry['jh_grade'].id"]
+        save_as: "check_fallback"
+        expect_count: 1
+
+  - name: "Compute Next Grade Fallback Without Any Grade"
+    steps:
+      - step: "Create empty grade type (no grades yet)"
+        action: "create"
+        model: "school_grade_type"
+        save_as: "type_empty"
+        values:
+          name: "Empty Grade Type Fallback"
+          code: "EGTFB"
+          sequence: 30
+      - step: "Create school using the empty grade type"
+        action: "create"
+        model: "school"
+        save_as: "school"
+        values:
+          name: "School Empty Grade Type Fallback"
+          code: "SCHEGTFB"
+          grade_type_id: "EVAL: registry['type_empty'].id"
+      - step: "Create contact"
+        action: "create"
+        model: "res.partner"
+        save_as: "contact"
+        values:
+          name: "Student Empty Fallback Contact"
+      - step: "Create student without initial_grade_id or enrollment"
+        action: "create"
+        model: "school_student"
+        save_as: "student"
+        values:
+          name: "Student Empty Fallback Test"
+          code: "STUEFB"
+          contact_id: "EVAL: registry['contact'].id"
+          school_id: "EVAL: registry['school'].id"
+      - step: "Invalidate student cache"
+        action: "call"
+        target: "student"
+        method: "invalidate_cache"
+      - step: "Assert next_grade_id is falsy (no error)"
+        action: "assert"
+        target: "student"
+        asserts:
+          next_grade_id:
+            type: "value"
+            operator: "is_falsy"
+
   - name: "Compute Active Enrollment None"
     steps:
       - step: "Create grade type"

--- a/ssi_school/tests/test_school_enrollment_integrity.py
+++ b/ssi_school/tests/test_school_enrollment_integrity.py
@@ -3,7 +3,7 @@
 # License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl).
 
 from odoo.exceptions import ValidationError
-from odoo.tests import TransactionCase, tagged
+from odoo.tests import SavepointCase, tagged
 
 # These scenarios assert that invalid data is REJECTED (ValidationError), which
 # the odoo-yaml-test YAML DSL cannot express (any exception raised by a step
@@ -12,7 +12,7 @@ from odoo.tests import TransactionCase, tagged
 
 
 @tagged("post_install", "-at_install")
-class TestSchoolEnrollmentIntegrity(TransactionCase):
+class TestSchoolEnrollmentIntegrity(SavepointCase):
     @classmethod
     def setUpClass(cls):
         super().setUpClass()

--- a/ssi_school/tests/test_school_enrollment_integrity.py
+++ b/ssi_school/tests/test_school_enrollment_integrity.py
@@ -1,0 +1,207 @@
+# Copyright 2026 OpenSynergy Indonesia
+# Copyright 2026 PT. Simetri Sinergi Indonesia
+# License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl).
+
+from odoo.exceptions import ValidationError
+from odoo.tests import TransactionCase, tagged
+
+# These scenarios assert that invalid data is REJECTED (ValidationError), which
+# the odoo-yaml-test YAML DSL cannot express (any exception raised by a step
+# simply fails the scenario). They are written as plain Python tests instead,
+# following the same precedent as the onchange tests in this test suite.
+
+
+@tagged("post_install", "-at_install")
+class TestSchoolEnrollmentIntegrity(TransactionCase):
+    @classmethod
+    def setUpClass(cls):
+        super().setUpClass()
+        cls.grade_type = cls.env["school_grade_type"].create(
+            {"name": "Grade Type Integrity", "code": "GTINT", "sequence": 10}
+        )
+        cls.school = cls.env["school"].create(
+            {
+                "name": "School Integrity",
+                "code": "SCHINT",
+                "grade_type_id": cls.grade_type.id,
+            }
+        )
+        cls.other_school = cls.env["school"].create(
+            {
+                "name": "Other School Integrity",
+                "code": "SCHINT2",
+                "grade_type_id": cls.grade_type.id,
+            }
+        )
+        cls.grade = cls.env["school_grade"].create(
+            {
+                "name": "Grade Integrity",
+                "code": "GINT",
+                "sequence": 10,
+                "type_id": cls.grade_type.id,
+            }
+        )
+        cls.other_school_grade = cls.env["school_grade"].create(
+            {
+                "name": "Grade Other School Integrity",
+                "code": "GINT2",
+                "sequence": 20,
+                "type_id": cls.grade_type.id,
+            }
+        )
+        cls.grade_class = cls.env["school_grade_class"].create(
+            {
+                "name": "Class Integrity",
+                "code": "CLINT",
+                "school_id": cls.school.id,
+                "grade_id": cls.grade.id,
+            }
+        )
+        cls.other_grade_class = cls.env["school_grade_class"].create(
+            {
+                "name": "Class Other School Integrity",
+                "code": "CLINT2",
+                "school_id": cls.other_school.id,
+                "grade_id": cls.other_school_grade.id,
+            }
+        )
+        cls.year = cls.env["school_academic_year"].create(
+            {
+                "name": "Year Integrity",
+                "code": "AYINT",
+                "date_start": "2024-07-01",
+                "date_end": "2025-06-30",
+            }
+        )
+        cls.other_year = cls.env["school_academic_year"].create(
+            {
+                "name": "Other Year Integrity",
+                "code": "AYINT2",
+                "date_start": "2025-07-01",
+                "date_end": "2026-06-30",
+            }
+        )
+        cls.term = cls.env["school_academic_term"].create(
+            {
+                "name": "Term Integrity",
+                "code": "TMINT",
+                "date_start": "2024-07-01",
+                "date_end": "2024-12-31",
+                "year_id": cls.year.id,
+                "enrollment_state": "open",
+            }
+        )
+        cls.closed_term = cls.env["school_academic_term"].create(
+            {
+                "name": "Closed Term Integrity",
+                "code": "TMINTCL",
+                "date_start": "2025-01-01",
+                "date_end": "2025-06-30",
+                "year_id": cls.year.id,
+                "enrollment_state": "close",
+            }
+        )
+        cls.contact = cls.env["res.partner"].create({"name": "Contact Integrity"})
+        cls.student = cls.env["school_student"].create(
+            {
+                "name": "Student Integrity",
+                "code": "STUINT",
+                "contact_id": cls.contact.id,
+                "school_id": cls.school.id,
+            }
+        )
+        cls.other_contact = cls.env["res.partner"].create(
+            {"name": "Other Contact Integrity"}
+        )
+        cls.other_student = cls.env["school_student"].create(
+            {
+                "name": "Other Student Integrity",
+                "code": "STUINT2",
+                "contact_id": cls.other_contact.id,
+                "school_id": cls.school.id,
+            }
+        )
+        cls.capped_grade_class = cls.env["school_grade_class"].create(
+            {
+                "name": "Class Capacity Integrity",
+                "code": "CLCAP",
+                "school_id": cls.school.id,
+                "grade_id": cls.grade.id,
+                "capacity": 1,
+            }
+        )
+
+    def _base_enrollment_vals(self, **overrides):
+        vals = {
+            "date": "2024-07-01",
+            "academic_year_id": self.year.id,
+            "academic_term_id": self.term.id,
+            "school_id": self.school.id,
+            "grade_id": self.grade.id,
+            "grade_class_id": self.grade_class.id,
+            "student_id": self.student.id,
+            "currency_id": self.env.company.currency_id.id,
+        }
+        vals.update(overrides)
+        return vals
+
+    def test_valid_enrollment_data_is_accepted(self):
+        """Sanity check: a fully consistent enrollment must NOT raise."""
+        enrollment = self.env["school_enrollment"].create(self._base_enrollment_vals())
+        enrollment.write({"state": "open"})
+        self.assertEqual(enrollment.state, "open")
+
+    def test_term_year_mismatch_raises(self):
+        with self.assertRaises(ValidationError):
+            self.env["school_enrollment"].create(
+                self._base_enrollment_vals(academic_year_id=self.other_year.id)
+            )
+
+    def test_grade_class_school_mismatch_raises(self):
+        with self.assertRaises(ValidationError):
+            self.env["school_enrollment"].create(
+                self._base_enrollment_vals(grade_class_id=self.other_grade_class.id)
+            )
+
+    def test_open_enrollment_outside_window_raises(self):
+        enrollment = self.env["school_enrollment"].create(
+            self._base_enrollment_vals(academic_term_id=self.closed_term.id)
+        )
+        with self.assertRaises(ValidationError):
+            enrollment.write({"state": "open"})
+
+    def test_duplicate_active_enrollment_raises(self):
+        first = self.env["school_enrollment"].create(self._base_enrollment_vals())
+        first.write({"state": "open"})
+        second = self.env["school_enrollment"].create(self._base_enrollment_vals())
+        with self.assertRaises(ValidationError):
+            second.write({"state": "open"})
+
+    def test_grade_class_capacity_reflects_open_enrollments(self):
+        enrollment = self.env["school_enrollment"].create(
+            self._base_enrollment_vals(
+                grade_class_id=self.capped_grade_class.id,
+                student_id=self.student.id,
+            )
+        )
+        enrollment.write({"state": "open"})
+        self.capped_grade_class.invalidate_cache()
+        self.assertEqual(self.capped_grade_class.student_count, 1)
+        self.assertEqual(self.capped_grade_class.available_seat, 0)
+
+    def test_grade_class_over_capacity_raises(self):
+        first = self.env["school_enrollment"].create(
+            self._base_enrollment_vals(
+                grade_class_id=self.capped_grade_class.id,
+                student_id=self.student.id,
+            )
+        )
+        first.write({"state": "open"})
+        second = self.env["school_enrollment"].create(
+            self._base_enrollment_vals(
+                grade_class_id=self.capped_grade_class.id,
+                student_id=self.other_student.id,
+            )
+        )
+        with self.assertRaises(ValidationError):
+            second.write({"state": "open"})

--- a/ssi_school/tests/test_school_student_states.py
+++ b/ssi_school/tests/test_school_student_states.py
@@ -4,12 +4,60 @@
 
 from odoo_yaml_test import YamlTransactionCase
 
+from odoo.exceptions import ValidationError
 from odoo.tests import tagged
 
 
 @tagged("post_install", "-at_install")
-class TestSchoolStudentStates(
-    YamlTransactionCase
-):  # pylint: disable=too-few-public-methods
+class TestSchoolStudentStates(YamlTransactionCase):
     def test_student_states(self):
         self.run_yaml_scenario("test_data_student_states.yaml")
+
+    def _create_student(self, code, state=None):
+        grade_type = self.env["school_grade_type"].create(
+            {
+                "name": f"Grade Type Transition {code}",
+                "code": f"GTT{code}",
+                "sequence": 10,
+            }
+        )
+        school = self.env["school"].create(
+            {
+                "name": f"School Transition {code}",
+                "code": f"SCHT{code}",
+                "grade_type_id": grade_type.id,
+            }
+        )
+        contact = self.env["res.partner"].create({"name": f"Transition Contact {code}"})
+        student = self.env["school_student"].create(
+            {
+                "name": f"Transition Student {code}",
+                "code": f"STUT{code}",
+                "contact_id": contact.id,
+                "school_id": school.id,
+            }
+        )
+        if state:
+            student.write({"state": state})
+        return student
+
+    def test_transition_deceased_to_enrol_raises(self):
+        """A deceased student can never transition back into any other state."""
+        student = self._create_student("DCS", state="deceased")
+        with self.assertRaises(ValidationError):
+            student.write({"state": "enrol"})
+
+    def test_transition_graduate_to_enrol_raises(self):
+        """A graduated student cannot jump straight back to enrolled; it must
+        first be reset to draft before being enrolled again."""
+        student = self._create_student("GRD", state="graduate")
+        with self.assertRaises(ValidationError):
+            student.write({"state": "enrol"})
+
+    def test_transition_dropped_to_draft_to_enrol_allowed(self):
+        """Reactivating a dropped student is a legal two-step transition:
+        dropped -> draft -> enrol."""
+        student = self._create_student("DRP", state="dropped")
+        student.write({"state": "draft"})
+        student.write({"state": "enrol"})
+        self.assertEqual(student.state, "enrol")

--- a/ssi_school/views/school_grade_class.xml
+++ b/ssi_school/views/school_grade_class.xml
@@ -49,6 +49,9 @@
                 <field name="school_id" />
                 <field name="grade_type_id" />
                 <field name="grade_id" />
+                <field name="capacity" />
+                <field name="student_count" />
+                <field name="available_seat" />
             </xpath>
         </data>
     </field>
@@ -65,6 +68,9 @@
                 <field name="school_id" />
                 <field name="grade_type_id" />
                 <field name="grade_id" domain="[('type_id', '=', grade_type_id)]" />
+                <field name="capacity" />
+                <field name="student_count" />
+                <field name="available_seat" />
             </xpath>
         </data>
     </field>


### PR DESCRIPTION
## Ringkasan

* Perbaiki rantai previous/next `school_grade` agar dibatasi per grade type (bukan menyambung lintas jenjang), sekaligus perbaiki typo `strinng` pada `previous_grade_id`.
* Perbaiki fallback next-grade `school_student` agar dibatasi ke grade type sekolah siswa (bukan grade pertama global), hindari `IndexError` bila grade type belum punya grade.
* Terjemahkan label selection `school_student.state` ke Bahasa Inggris (key tidak berubah).
* Tambah constraint integritas level-model pada academic year/term & enrollment (koherensi tanggal, kecocokan term/year, kecocokan grade_class, jendela waktu enrollment, cegah enrollment aktif ganda).
* Tambah kapasitas & keterisian `school_grade_class` (`capacity`, `student_count`, `available_seat`) + guard enrollment saat melebihi kapasitas.
* Tambah guard transisi state siswa (peta transisi legal di `write()`) + `tracking=True` pada `state` untuk audit chatter.

## Test plan

- [x] Skenario `odoo-yaml-test` baru/diperbarui untuk tiap perbaikan (grade chain, next-grade fallback, capacity, dsb).
- [x] Test Python `assertRaises` untuk validasi negatif (transisi ilegal, constraint integritas, kapasitas) — YAML DSL tidak bisa menguji exception.
- [x] Modul `ssi_school` ter-update lokal tanpa error (`odoo -u ssi_school --stop-after-init`).
- [x] `pre-commit run --all-files` bersih.
- [ ] CI hijau (menunggu hasil Actions).