### PR TITLE
[UPD] ssi_school_operating_unit

### DIFF
--- a/ssi_school_operating_unit/README.rst
+++ b/ssi_school_operating_unit/README.rst
@@ -7,5 +7,7 @@ School - Operating Unit
    !!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!
 
 Operating Unit support for SSI School module.
-Adds operating unit access control for transactional (school_enrollment)
+Adds operating unit access control for transactional (school_enrollment, school_homeroom)
 and master data models (school, grade types, grades, classes, academic periods, students, teachers).
+The operating unit selected on a Homeroom batch is automatically propagated to every
+enrollment generated from it.

--- a/ssi_school_operating_unit/__manifest__.py
+++ b/ssi_school_operating_unit/__manifest__.py
@@ -23,6 +23,9 @@
         # Security - transactional (school_enrollment)
         "security/res_groups/school_enrollment.xml",
         "security/ir_rule/school_enrollment.xml",
+        # Security - transactional (school_homeroom)
+        "security/res_groups/school_homeroom.xml",
+        "security/ir_rule/school_homeroom.xml",
         # Security - master data (global OU rules)
         "security/ir_rule/school.xml",
         "security/ir_rule/school_grade_type.xml",
@@ -34,6 +37,7 @@
         "security/ir_rule/school_teacher.xml",
         # Views
         "views/school_enrollment.xml",
+        "views/school_homeroom.xml",
         "views/school.xml",
         "views/school_grade_type.xml",
         "views/school_grade.xml",

--- a/ssi_school_operating_unit/models/__init__.py
+++ b/ssi_school_operating_unit/models/__init__.py
@@ -11,6 +11,7 @@ from . import (  # noqa: F401
     school_grade,
     school_grade_class,
     school_grade_type,
+    school_homeroom,
     school_student,
     school_teacher,
 )

--- a/ssi_school_operating_unit/models/school_homeroom.py
+++ b/ssi_school_operating_unit/models/school_homeroom.py
@@ -1,0 +1,24 @@
+# Copyright 2025 OpenSynergy Indonesia
+# Copyright 2025 PT. Simetri Sinergi Indonesia
+# License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl).
+
+from odoo import models
+
+
+class SchoolHomeroom(models.Model):
+    """
+    Extends School Homeroom with single operating unit support, and
+    propagates the selected operating unit to every enrollment generated
+    from this Homeroom batch.
+    """
+
+    _name = "school_homeroom"
+    _inherit = [
+        "school_homeroom",
+        "mixin.single_operating_unit",
+    ]
+
+    def _prepare_enrollment_vals(self, student_id):
+        res = super()._prepare_enrollment_vals(student_id)
+        res["operating_unit_id"] = self.operating_unit_id.id
+        return res

--- a/ssi_school_operating_unit/security/ir_rule/school_homeroom.xml
+++ b/ssi_school_operating_unit/security/ir_rule/school_homeroom.xml
@@ -1,0 +1,20 @@
+<?xml version="1.0" encoding="utf-8" ?>
+<!-- Copyright 2025 OpenSynergy Indonesia
+     Copyright 2025 PT. Simetri Sinergi Indonesia
+     License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl). -->
+<odoo>
+
+<record id="school_homeroom_ou" model="ir.rule">
+    <field name="name">school_homeroom - Responsible to operating unit data</field>
+    <field name="model_id" ref="ssi_school.model_school_homeroom" />
+    <field name="groups" eval="[(4, ref('school_homeroom_operating_unit_group'))]" />
+    <field
+            name="domain_force"
+        >[('operating_unit_id','in',[g.id for g in user.operating_unit_ids])]</field>
+    <field name="perm_unlink" eval="1" />
+    <field name="perm_write" eval="1" />
+    <field name="perm_read" eval="1" />
+    <field name="perm_create" eval="1" />
+</record>
+
+</odoo>

--- a/ssi_school_operating_unit/security/res_groups/school_homeroom.xml
+++ b/ssi_school_operating_unit/security/res_groups/school_homeroom.xml
@@ -1,0 +1,23 @@
+<?xml version="1.0" encoding="utf-8" ?>
+<!-- Copyright 2025 OpenSynergy Indonesia
+     Copyright 2025 PT. Simetri Sinergi Indonesia
+     License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl). -->
+<odoo>
+
+<record id="school_homeroom_operating_unit_group" model="res.groups">
+    <field name="name">Operating Unit</field>
+    <field
+            name="category_id"
+            ref="ssi_school.school_homeroom_data_ownership_module_category"
+        />
+</record>
+
+<record id="ssi_school.school_homeroom_company_group" model="res.groups">
+    <field name="name">Company</field>
+    <field
+            name="implied_ids"
+            eval="[(6, 0, [ref('school_homeroom_operating_unit_group')])]"
+        />
+</record>
+
+</odoo>

--- a/ssi_school_operating_unit/tests/test_data_school_operating_unit.yaml
+++ b/ssi_school_operating_unit/tests/test_data_school_operating_unit.yaml
@@ -327,3 +327,167 @@ scenarios:
           operating_unit_id:
             type: "value"
             operator: "is_truthy"
+
+  - name: "School Operating Unit - Homeroom operating unit propagates to enrollment"
+    steps:
+      - step: "Get main company operating unit"
+        action: "search"
+        model: "operating.unit"
+        domain: [["company_id", "=", "REF: base.main_company"]]
+        save_as: "operating_unit"
+        limit: 1
+
+      - step: "Create grade type"
+        action: "create"
+        model: "school_grade_type"
+        save_as: "grade_type"
+        values:
+          name: "Grade Type Homeroom OU"
+          code: "GTOU04"
+          sequence: 10
+
+      - step: "Create school"
+        action: "create"
+        model: "school"
+        save_as: "school"
+        values:
+          name: "School Homeroom OU Test"
+          code: "SCHOU04"
+          grade_type_id: "EVAL: registry['grade_type'].id"
+
+      - step: "Create grade"
+        action: "create"
+        model: "school_grade"
+        save_as: "grade"
+        values:
+          name: "Grade Homeroom OU"
+          code: "GOU04"
+          sequence: 10
+          type_id: "EVAL: registry['grade_type'].id"
+
+      - step: "Create grade class"
+        action: "create"
+        model: "school_grade_class"
+        save_as: "grade_class"
+        values:
+          name: "Grade Class Homeroom OU"
+          code: "GCOU04"
+          school_id: "EVAL: registry['school'].id"
+          grade_id: "EVAL: registry['grade'].id"
+          capacity: 5
+
+      - step: "Create academic year"
+        action: "create"
+        model: "school_academic_year"
+        save_as: "academic_year"
+        values:
+          name: "2025/2026 Homeroom OU"
+          code: "AYOU04"
+          date_start: "2025-07-01"
+          date_end: "2026-06-30"
+
+      - step: "Create academic term (first term, enrollment open)"
+        action: "create"
+        model: "school_academic_term"
+        save_as: "academic_term"
+        values:
+          name: "Semester 1 Homeroom OU"
+          code: "SMOU04"
+          date_start: "2025-07-01"
+          date_end: "2025-12-31"
+          year_id: "EVAL: registry['academic_year'].id"
+          enrollment_state: "open"
+
+      - step: "Create student contact"
+        action: "create"
+        model: "res.partner"
+        save_as: "student_contact"
+        values:
+          name: "Student Homeroom OU Test"
+
+      - step: "Create school student"
+        action: "create"
+        model: "school_student"
+        save_as: "student"
+        values:
+          name: "Student Homeroom OU"
+          code: "STOU04"
+          contact_id: "EVAL: registry['student_contact'].id"
+          school_id: "EVAL: registry['school'].id"
+
+      - step: "Create homeroom with operating unit"
+        action: "create"
+        model: "school_homeroom"
+        save_as: "homeroom"
+        values:
+          date: "2025-07-01"
+          academic_year_id: "EVAL: registry['academic_year'].id"
+          academic_term_id: "EVAL: registry['academic_term'].id"
+          school_id: "EVAL: registry['school'].id"
+          grade_id: "EVAL: registry['grade'].id"
+          grade_class_id: "EVAL: registry['grade_class'].id"
+          capacity: 5
+          operating_unit_id: "EVAL: registry['operating_unit'].id"
+
+      - step: "Assert homeroom has operating unit"
+        action: "assert"
+        target: "homeroom"
+        asserts:
+          operating_unit_id:
+            type: "value"
+            operator: "is_truthy"
+
+      - step: "Confirm homeroom"
+        action: "call"
+        target: "homeroom"
+        method: "action_confirm"
+        as_user: "base.user_admin"
+
+      - step: "Invalidate homeroom cache before approve"
+        action: "call"
+        target: "homeroom"
+        method: "invalidate_cache"
+
+      - step: "Approve homeroom"
+        action: "call"
+        target: "homeroom"
+        method: "action_approve_approval"
+        as_user: "base.user_admin"
+        asserts:
+          state:
+            type: "value"
+            expected: "open"
+
+      - step: "Select the student as candidate"
+        action: "write"
+        target: "homeroom"
+        values:
+          candidate_student_ids:
+            - - 6
+              - 0
+              - - "EVAL: registry['student'].id"
+
+      - step: "Generate enrollments synchronously"
+        action: "call"
+        target: "homeroom"
+        method: "action_generate_enrollments"
+        context:
+          queue_job__no_delay: true
+
+      - step: "Search generated enrollment for the candidate student"
+        action: "search"
+        model: "school_enrollment"
+        domain:
+          - ["homeroom_id", "=", "EVAL: registry['homeroom'].id"]
+          - ["student_id", "=", "EVAL: registry['student'].id"]
+        save_as: "enrollment"
+        expect_count: 1
+
+      - step: "Assert generated enrollment inherited the homeroom's operating unit"
+        action: "search"
+        model: "school_enrollment"
+        domain:
+          - ["id", "=", "EVAL: registry['enrollment'].id"]
+          - ["operating_unit_id", "=", "EVAL: registry['operating_unit'].id"]
+        save_as: "enrollment_with_matching_ou"
+        expect_count: 1

--- a/ssi_school_operating_unit/views/school_homeroom.xml
+++ b/ssi_school_operating_unit/views/school_homeroom.xml
@@ -1,0 +1,58 @@
+<?xml version="1.0" encoding="utf-8" ?>
+<!-- Copyright 2025 OpenSynergy Indonesia
+     Copyright 2025 PT. Simetri Sinergi Indonesia
+     License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl). -->
+<odoo>
+
+<record id="school_homeroom_view_tree_ou" model="ir.ui.view">
+    <field name="name">school_homeroom tree - operating unit</field>
+    <field name="model">school_homeroom</field>
+    <field name="inherit_id" ref="ssi_school.school_homeroom_view_tree" />
+    <field name="arch" type="xml">
+        <data>
+            <xpath expr="//field[@name='company_id']" position="after">
+                <field
+                        name="operating_unit_id"
+                        groups="operating_unit.group_multi_operating_unit"
+                        optional="hide"
+                    />
+            </xpath>
+        </data>
+    </field>
+</record>
+
+<record id="school_homeroom_view_form_ou" model="ir.ui.view">
+    <field name="name">school_homeroom form - operating unit</field>
+    <field name="model">school_homeroom</field>
+    <field name="inherit_id" ref="ssi_school.school_homeroom_view_form" />
+    <field name="arch" type="xml">
+        <data>
+            <xpath expr="//field[@name='company_id']" position="after">
+                <field
+                        name="operating_unit_id"
+                        groups="operating_unit.group_multi_operating_unit"
+                    />
+            </xpath>
+        </data>
+    </field>
+</record>
+
+<record id="school_homeroom_view_search_ou" model="ir.ui.view">
+    <field name="name">school_homeroom search - operating unit</field>
+    <field name="model">school_homeroom</field>
+    <field name="inherit_id" ref="ssi_school.school_homeroom_view_search" />
+    <field name="arch" type="xml">
+        <data>
+            <xpath expr="//group[@name='group_by']" position="inside">
+                <filter
+                        name="grp_ou"
+                        string="Operating Unit"
+                        context="{'group_by':'operating_unit_id'}"
+                        groups="operating_unit.group_multi_operating_unit"
+                    />
+            </xpath>
+        </data>
+    </field>
+</record>
+
+</odoo>


### PR DESCRIPTION
## Ringkasan

* Menambahkan dukungan Operating Unit pada `school_homeroom` (`mixin.single_operating_unit`)
* Operating Unit yang dipilih pada Homeroom otomatis diteruskan ke setiap enrollment yang di-generate dari Homeroom tersebut (`_prepare_enrollment_vals`)
* Menambahkan security (res.groups + ir.rule) dan view (tree/form/search) OU untuk `school_homeroom`
* Menambahkan skenario unit test YAML untuk memverifikasi propagasi Operating Unit dari Homeroom ke Enrollment

## Test plan

- [x] Modul berhasil di-update di lokal (`odoo -u ssi_school_operating_unit`) tanpa error
- [x] `pre-commit run --all-files` lolos
- [ ] CI (unit test) lolos