### PR TITLE
[UPD] ssi_school

### DIFF
--- a/ssi_school/models/school_enrollment.py
+++ b/ssi_school/models/school_enrollment.py
@@ -457,6 +457,22 @@ class SchoolEnrollment(models.Model):
     def onchange_grade_class_id(self):
         self.grade_class_id = False
 
+    @api.onchange(
+        "payment_template_id",
+    )
+    def onchange_receivable_journal_id(self):
+        self.receivable_journal_id = False
+        if self.payment_template_id:
+            self.receivable_journal_id = self.payment_template_id.journal_id
+
+    @api.onchange(
+        "payment_template_id",
+    )
+    def onchange_receivable_account_id(self):
+        self.receivable_account_id = False
+        if self.payment_template_id:
+            self.receivable_account_id = self.payment_template_id.receivable_account_id
+
     @api.constrains("academic_term_id", "academic_year_id")
     def _check_term_year_match(self):
         for record in self:

--- a/ssi_school/models/school_enrollment_payment_template.py
+++ b/ssi_school/models/school_enrollment_payment_template.py
@@ -66,6 +66,24 @@ class SchoolEnrollmentPaymentTemplate(
             "Term/School/Grade scope."
         ),
     )
+    journal_id = fields.Many2one(
+        string="Receivable Journal",
+        comodel_name="account.journal",
+        required=False,
+        help=(
+            "Default receivable journal copied into the enrollment "
+            "when this template is selected."
+        ),
+    )
+    receivable_account_id = fields.Many2one(
+        string="Receivable Account",
+        comodel_name="account.account",
+        required=False,
+        help=(
+            "Default receivable account copied into the enrollment "
+            "when this template is selected."
+        ),
+    )
     term_ids = fields.One2many(
         string="Payment Terms",
         comodel_name="school_enrollment_payment_template.term",

--- a/ssi_school/models/school_homeroom.py
+++ b/ssi_school/models/school_homeroom.py
@@ -484,6 +484,7 @@ cancel/adjust the enrollment(s) manually before generating
 
     def _prepare_enrollment_vals(self, student_id):
         self.ensure_one()
+        template = self._get_default_payment_template()
         return {
             "date": self.date,
             "academic_year_id": self.academic_year_id.id,
@@ -493,7 +494,9 @@ cancel/adjust the enrollment(s) manually before generating
             "grade_class_id": self.grade_class_id.id,
             "student_id": student_id,
             "homeroom_id": self.id,
-            "payment_template_id": self._get_default_payment_template().id,
+            "payment_template_id": template.id,
+            "receivable_journal_id": template.journal_id.id,
+            "receivable_account_id": template.receivable_account_id.id,
         }
 
     @api.model

--- a/ssi_school/tests/test_data_enrollment_payment_template.yaml
+++ b/ssi_school/tests/test_data_enrollment_payment_template.yaml
@@ -112,6 +112,108 @@ scenarios:
             check: "count"
             expected_count: 1
 
+  - name: "Create Payment Template With Receivable Journal And Account"
+    steps:
+      - step: "Get sale journal"
+        action: "search"
+        model: "account.journal"
+        domain: [["type", "=", "sale"]]
+        save_as: "journal"
+        limit: 1
+      - step: "Get account type ref"
+        action: "ref"
+        xml_id: "account.data_account_type_revenue"
+        save_as: "account_type"
+      - step: "Create receivable account"
+        action: "create"
+        model: "account.account"
+        save_as: "account"
+        values:
+          name: "Test Receivable Account PMT"
+          code: "TESTRAPMT"
+          user_type_id: "EVAL: registry['account_type'].id"
+      - step: "Create payment template with journal and account"
+        action: "create"
+        model: "school_enrollment_payment_template"
+        save_as: "template"
+        values:
+          name: "Template Receivable Fields"
+          code: "PMTRECV"
+          journal_id: "EVAL: registry['journal'].id"
+          receivable_account_id: "EVAL: registry['account'].id"
+      - step: "Assert receivable fields stored"
+        action: "assert"
+        target: "template"
+        asserts:
+          journal_id:
+            type: "value"
+            operator: "is_truthy"
+          receivable_account_id:
+            type: "value"
+            operator: "is_truthy"
+
+  - name: "Edit Payment Template Receivable Journal"
+    steps:
+      - step: "Get sale journal"
+        action: "search"
+        model: "account.journal"
+        domain: [["type", "=", "sale"]]
+        save_as: "journal"
+        limit: 1
+      - step: "Create payment template"
+        action: "create"
+        model: "school_enrollment_payment_template"
+        save_as: "template"
+        values:
+          name: "Template Journal Edit"
+          code: "PMTJED"
+      - step: "Set receivable journal"
+        action: "write"
+        target: "template"
+        values:
+          journal_id: "EVAL: registry['journal'].id"
+      - step: "Assert journal updated"
+        action: "assert"
+        target: "template"
+        asserts:
+          journal_id:
+            type: "value"
+            operator: "is_truthy"
+
+  - name: "Edit Payment Template Receivable Account"
+    steps:
+      - step: "Get account type ref"
+        action: "ref"
+        xml_id: "account.data_account_type_revenue"
+        save_as: "account_type"
+      - step: "Create receivable account"
+        action: "create"
+        model: "account.account"
+        save_as: "account"
+        values:
+          name: "Test Receivable Account PMT Edit"
+          code: "TESTRAPMTED"
+          user_type_id: "EVAL: registry['account_type'].id"
+      - step: "Create payment template"
+        action: "create"
+        model: "school_enrollment_payment_template"
+        save_as: "template"
+        values:
+          name: "Template Account Edit"
+          code: "PMTAED"
+      - step: "Set receivable account"
+        action: "write"
+        target: "template"
+        values:
+          receivable_account_id: "EVAL: registry['account'].id"
+      - step: "Assert account updated"
+        action: "assert"
+        target: "template"
+        asserts:
+          receivable_account_id:
+            type: "value"
+            operator: "is_truthy"
+
   - name: "Edit Payment Template Name"
     steps:
       - step: "Create payment template"

--- a/ssi_school/tests/test_data_school_homeroom_generate.yaml
+++ b/ssi_school/tests/test_data_school_homeroom_generate.yaml
@@ -798,3 +798,200 @@ scenarios:
         domain: [["homeroom_id", "=", "EVAL: registry['homeroom'].id"]]
         save_as: "enrollments_after_reconcile"
         expect_count: 1
+
+  - name:
+      "Homeroom Generate Enrollment Copies Receivable Journal And Account From Default
+      Template"
+    steps:
+      - step: "Get sale journal"
+        action: "search"
+        model: "account.journal"
+        domain: [["type", "=", "sale"]]
+        save_as: "journal"
+        limit: 1
+
+      - step: "Get account type ref"
+        action: "ref"
+        xml_id: "account.data_account_type_revenue"
+        save_as: "account_type"
+
+      - step: "Create receivable account"
+        action: "create"
+        model: "account.account"
+        save_as: "account"
+        values:
+          name: "School Fee Receivable HRGEN6"
+          code: "HRGEN4206"
+          user_type_id: "EVAL: registry['account_type'].id"
+
+      - step: "Create grade type"
+        action: "create"
+        model: "school_grade_type"
+        save_as: "grade_type"
+        values:
+          name: "Grade Type Homeroom Generate 6"
+          code: "GTHG6"
+          sequence: 10
+
+      - step: "Create academic year"
+        action: "create"
+        model: "school_academic_year"
+        save_as: "academic_year"
+        values:
+          name: "2024/2025 Homeroom Generate 6"
+          code: "AYHG6"
+          date_start: "2024-07-01"
+          date_end: "2025-06-30"
+
+      - step: "Create academic term (first term, enrollment open)"
+        action: "create"
+        model: "school_academic_term"
+        save_as: "academic_term"
+        values:
+          name: "Semester 1 Homeroom Generate 6"
+          code: "SMHG6"
+          date_start: "2024-07-01"
+          date_end: "2024-12-31"
+          year_id: "EVAL: registry['academic_year'].id"
+          enrollment_state: "open"
+
+      - step: "Create school"
+        action: "create"
+        model: "school"
+        save_as: "school"
+        values:
+          name: "School Homeroom Generate 6"
+          code: "SCHHG6"
+          grade_type_id: "EVAL: registry['grade_type'].id"
+
+      - step: "Create grade"
+        action: "create"
+        model: "school_grade"
+        save_as: "grade"
+        values:
+          name: "Grade 1 Homeroom Generate 6"
+          code: "G1HG6"
+          sequence: 10
+          type_id: "EVAL: registry['grade_type'].id"
+
+      - step: "Create grade class"
+        action: "create"
+        model: "school_grade_class"
+        save_as: "grade_class"
+        values:
+          name: "Class A Homeroom Generate 6"
+          code: "CLAHG6"
+          school_id: "EVAL: registry['school'].id"
+          grade_id: "EVAL: registry['grade'].id"
+          capacity: 30
+
+      - step: "Create default payment template with receivable journal and account"
+        action: "create"
+        model: "school_enrollment_payment_template"
+        save_as: "payment_template"
+        values:
+          name: "Homeroom Generate Payment Template 6"
+          code: "HGPMT6"
+          school_id: "EVAL: registry['school'].id"
+          grade_id: "EVAL: registry['grade'].id"
+          academic_term_id: "EVAL: registry['academic_term'].id"
+          is_default: true
+          journal_id: "EVAL: registry['journal'].id"
+          receivable_account_id: "EVAL: registry['account'].id"
+
+      - step: "Create contact"
+        action: "create"
+        model: "res.partner"
+        save_as: "contact"
+        values:
+          name: "Contact Homeroom Generate 6"
+
+      - step: "Create student"
+        action: "create"
+        model: "school_student"
+        save_as: "student"
+        values:
+          name: "Student Homeroom Generate 6"
+          code: "STUHG6"
+          contact_id: "EVAL: registry['contact'].id"
+          school_id: "EVAL: registry['school'].id"
+
+      - step: "Create homeroom"
+        action: "create"
+        model: "school_homeroom"
+        save_as: "homeroom"
+        values:
+          date: "2024-07-01"
+          academic_year_id: "EVAL: registry['academic_year'].id"
+          academic_term_id: "EVAL: registry['academic_term'].id"
+          school_id: "EVAL: registry['school'].id"
+          grade_id: "EVAL: registry['grade'].id"
+          grade_class_id: "EVAL: registry['grade_class'].id"
+          capacity: 30
+          candidate_student_ids:
+            - - 6
+              - 0
+              - - "EVAL: registry['student'].id"
+
+      - step: "Confirm homeroom"
+        action: "call"
+        target: "homeroom"
+        method: "action_confirm"
+        as_user: "base.user_admin"
+
+      - step: "Invalidate homeroom cache before approve"
+        action: "call"
+        target: "homeroom"
+        method: "invalidate_cache"
+
+      - step: "Approve homeroom"
+        action: "call"
+        target: "homeroom"
+        method: "action_approve_approval"
+        as_user: "base.user_admin"
+        asserts:
+          state:
+            type: "value"
+            expected: "open"
+
+      - step: "Generate enrollment synchronously"
+        action: "call"
+        target: "homeroom"
+        method: "action_generate_enrollments"
+        context:
+          queue_job__no_delay: true
+
+      - step: "Get generated enrollment"
+        action: "search"
+        model: "school_enrollment"
+        domain:
+          - ["homeroom_id", "=", "EVAL: registry['homeroom'].id"]
+          - ["student_id", "=", "EVAL: registry['student'].id"]
+        save_as: "enrollment"
+        expect_count: 1
+
+      - step: "Assert generated enrollment has payment template set"
+        action: "assert"
+        target: "enrollment"
+        asserts:
+          payment_template_id:
+            type: "value"
+            operator: "is_truthy"
+
+      - step: "Verify enrollment receivable journal matches template journal"
+        action: "search"
+        model: "school_enrollment"
+        domain:
+          - ["id", "=", "EVAL: registry['enrollment'].id"]
+          - ["receivable_journal_id", "=", "EVAL: registry['journal'].id"]
+        save_as: "_check_journal"
+        expect_count: 1
+
+      - step: "Verify enrollment receivable account matches template account"
+        action: "search"
+        model: "school_enrollment"
+        domain:
+          - ["id", "=", "EVAL: registry['enrollment'].id"]
+          - ["receivable_account_id", "=", "EVAL: registry['account'].id"]
+        save_as: "_check_account"
+        expect_count: 1

--- a/ssi_school/tests/test_school_enrollment.py
+++ b/ssi_school/tests/test_school_enrollment.py
@@ -4,12 +4,70 @@
 
 from odoo_yaml_test import YamlTransactionCase
 
-from odoo.tests import tagged
+from odoo.tests import Form, tagged
 
 
 @tagged("post_install", "-at_install")
-class TestSchoolEnrollmentWorkflow(
-    YamlTransactionCase
-):  # pylint: disable=too-few-public-methods
+class TestSchoolEnrollmentWorkflow(YamlTransactionCase):
     def test_enrollment_workflow(self):
         self.run_yaml_scenario("test_data_enrollment.yaml")
+
+    def test_onchange_receivable_journal_id_from_template(self):
+        """Selecting payment_template_id fills receivable_journal_id from the template."""
+        journal = self.env["account.journal"].search([("type", "=", "sale")], limit=1)
+        template = self.env["school_enrollment_payment_template"].create(
+            {
+                "name": "Template Receivable Journal OC",
+                "code": "PMTRJOC",
+                "journal_id": journal.id,
+            }
+        )
+        form = Form(self.env["school_enrollment"])
+        form.payment_template_id = template
+        self.assertEqual(form.receivable_journal_id, journal)
+
+    def test_onchange_receivable_account_id_from_template(self):
+        """Selecting payment_template_id fills receivable_account_id from the template."""
+        account_type_income = self.env.ref("account.data_account_type_revenue")
+        account = self.env["account.account"].create(
+            {
+                "name": "Test Receivable Account OC",
+                "code": "TESTRAOC",
+                "user_type_id": account_type_income.id,
+            }
+        )
+        template = self.env["school_enrollment_payment_template"].create(
+            {
+                "name": "Template Receivable Account OC",
+                "code": "PMTRAOC",
+                "receivable_account_id": account.id,
+            }
+        )
+        form = Form(self.env["school_enrollment"])
+        form.payment_template_id = template
+        self.assertEqual(form.receivable_account_id, account)
+
+    def test_onchange_receivable_fields_reset_when_template_cleared(self):
+        """Clearing payment_template_id resets both receivable fields."""
+        journal = self.env["account.journal"].search([("type", "=", "sale")], limit=1)
+        account_type_income = self.env.ref("account.data_account_type_revenue")
+        account = self.env["account.account"].create(
+            {
+                "name": "Test Receivable Account Reset OC",
+                "code": "TESTRARST",
+                "user_type_id": account_type_income.id,
+            }
+        )
+        template = self.env["school_enrollment_payment_template"].create(
+            {
+                "name": "Template Receivable Reset OC",
+                "code": "PMTRRST",
+                "journal_id": journal.id,
+                "receivable_account_id": account.id,
+            }
+        )
+        form = Form(self.env["school_enrollment"])
+        form.payment_template_id = template
+        form.payment_template_id = self.env["school_enrollment_payment_template"]
+        self.assertFalse(form.receivable_journal_id)
+        self.assertFalse(form.receivable_account_id)

--- a/ssi_school/views/school_enrollment_payment_template_views.xml
+++ b/ssi_school/views/school_enrollment_payment_template_views.xml
@@ -75,6 +75,8 @@
                 <field name="grade_id" domain="[('type_id','=',grade_type_id)]" />
                 <field name="grade_type_id" invisible="1" />
                 <field name="is_default" />
+                <field name="journal_id" />
+                <field name="receivable_account_id" />
             </xpath>
             <xpath expr="//page[1]" position="before">
                 <page name="payment_terms" string="Payment Terms">


### PR DESCRIPTION
## Ringkasan

* Menambahkan field `journal_id` dan `receivable_account_id` pada `school_enrollment_payment_template` sebagai default akuntansi per template.
* Menambahkan onchange `payment_template_id` pada `school_enrollment` yang mengisi `receivable_journal_id` dan `receivable_account_id` dari template terpilih (reset ke kosong bila template dikosongkan).
* Mengisi kedua field akuntansi tersebut secara eksplisit di `_prepare_enrollment_vals` saat enrollment dibuat otomatis dari Homeroom, karena jalur `create()` programatik tidak memicu onchange.
* Menambahkan skenario uji YAML untuk field baru pada payment template dan jalur generate dari Homeroom, serta test onchange via Form API pada enrollment.

## Test plan

- [x] Modul `ssi_school` ter-update lokal tanpa error (`odoo -u ssi_school --stop-after-init`).
- [x] `pre-commit run --all-files` lolos.
- [ ] CI hijau.