### PR TITLE
[UPD] ssi_school_admission, ssi_school

### DIFF
--- a/ssi_school/tests/test_school_homeroom.py
+++ b/ssi_school/tests/test_school_homeroom.py
@@ -67,3 +67,326 @@ class TestSchoolHomeroom(YamlTransactionCase):
         form.grade_id = grade
         form.grade_class_id = grade_class
         self.assertEqual(form.capacity, 25)
+
+    def test_fill_random_only_picks_allowed_students(self):
+        """Fill Random must only pick from allowed_student_ids, never a
+        student excluded by state, school, or grade mismatch."""
+        grade_type = self.env["school_grade_type"].create(
+            {"name": "Grade Type Fill Random 1", "code": "GTFR1", "sequence": 10}
+        )
+        school = self.env["school"].create(
+            {
+                "name": "School Fill Random 1",
+                "code": "SCHFR1",
+                "grade_type_id": grade_type.id,
+            }
+        )
+        other_school = self.env["school"].create(
+            {
+                "name": "Other School Fill Random 1",
+                "code": "SCHFR1B",
+                "grade_type_id": grade_type.id,
+            }
+        )
+        grade = self.env["school_grade"].create(
+            {
+                "name": "Grade Fill Random 1",
+                "code": "GFR1",
+                "sequence": 10,
+                "type_id": grade_type.id,
+            }
+        )
+        other_grade = self.env["school_grade"].create(
+            {
+                "name": "Other Grade Fill Random 1",
+                "code": "GFR1B",
+                "sequence": 20,
+                "type_id": grade_type.id,
+            }
+        )
+        grade_class = self.env["school_grade_class"].create(
+            {
+                "name": "Class Fill Random 1",
+                "code": "CLFR1",
+                "school_id": school.id,
+                "grade_id": grade.id,
+                "capacity": 50,
+            }
+        )
+        year = self.env["school_academic_year"].create(
+            {
+                "name": "Year Fill Random 1",
+                "code": "AYFR1",
+                "date_start": "2024-07-01",
+                "date_end": "2025-06-30",
+            }
+        )
+        term_1 = self.env["school_academic_term"].create(
+            {
+                "name": "Term 1 Fill Random 1",
+                "code": "TMFR1A",
+                "date_start": "2024-07-01",
+                "date_end": "2024-12-31",
+                "year_id": year.id,
+            }
+        )
+        term_2 = self.env["school_academic_term"].create(
+            {
+                "name": "Term 2 Fill Random 1",
+                "code": "TMFR1B",
+                "date_start": "2025-01-01",
+                "date_end": "2025-06-30",
+                "year_id": year.id,
+            }
+        )
+        self.assertTrue(term_1.first_term)
+        self.assertFalse(term_2.first_term)
+
+        def make_student(code, school_id, initial_grade_id):
+            contact = self.env["res.partner"].create({"name": "Contact %s" % code})
+            return self.env["school_student"].create(
+                {
+                    "name": "Student %s" % code,
+                    "code": code,
+                    "contact_id": contact.id,
+                    "school_id": school_id,
+                    "initial_grade_id": initial_grade_id,
+                }
+            )
+
+        student_1 = make_student("STUFR1A", school.id, grade.id)
+        student_2 = make_student("STUFR1B", school.id, grade.id)
+        student_3 = make_student("STUFR1C", school.id, grade.id)
+        allowed_students = student_1 | student_2 | student_3
+        non_draft_student = make_student("STUFR1D", school.id, grade.id)
+        non_draft_student.write({"state": "enrol"})
+        other_school_student = make_student("STUFR1E", other_school.id, grade.id)
+        other_grade_student = make_student("STUFR1F", school.id, other_grade.id)
+
+        homeroom = self.env["school_homeroom"].create(
+            {
+                "date": "2025-01-01",
+                "academic_year_id": year.id,
+                "academic_term_id": term_2.id,
+                "school_id": school.id,
+                "grade_id": grade.id,
+                "grade_class_id": grade_class.id,
+                "capacity": 50,
+            }
+        )
+        homeroom.action_fill_random()
+
+        self.assertEqual(homeroom.candidate_student_ids, allowed_students)
+        self.assertNotIn(non_draft_student, homeroom.candidate_student_ids)
+        self.assertNotIn(other_school_student, homeroom.candidate_student_ids)
+        self.assertNotIn(other_grade_student, homeroom.candidate_student_ids)
+
+    def test_fill_random_first_term_uses_next_grade(self):
+        """On the first term of an academic year, Fill Random must select
+        students whose next_grade_id matches the homeroom grade, mirroring
+        school_enrollment's allowed_student_ids algorithm."""
+        grade_type = self.env["school_grade_type"].create(
+            {"name": "Grade Type Fill Random 2", "code": "GTFR2", "sequence": 10}
+        )
+        school = self.env["school"].create(
+            {
+                "name": "School Fill Random 2",
+                "code": "SCHFR2",
+                "grade_type_id": grade_type.id,
+            }
+        )
+        grade_prev = self.env["school_grade"].create(
+            {
+                "name": "Grade Prev Fill Random 2",
+                "code": "GFR2A",
+                "sequence": 10,
+                "type_id": grade_type.id,
+            }
+        )
+        grade_target = self.env["school_grade"].create(
+            {
+                "name": "Grade Target Fill Random 2",
+                "code": "GFR2B",
+                "sequence": 20,
+                "type_id": grade_type.id,
+            }
+        )
+        self.assertEqual(grade_prev.next_grade_id, grade_target)
+        grade_class = self.env["school_grade_class"].create(
+            {
+                "name": "Class Fill Random 2",
+                "code": "CLFR2",
+                "school_id": school.id,
+                "grade_id": grade_target.id,
+                "capacity": 50,
+            }
+        )
+        year = self.env["school_academic_year"].create(
+            {
+                "name": "Year Fill Random 2",
+                "code": "AYFR2",
+                "date_start": "2024-07-01",
+                "date_end": "2025-06-30",
+            }
+        )
+        term = self.env["school_academic_term"].create(
+            {
+                "name": "Term Fill Random 2",
+                "code": "TMFR2",
+                "date_start": "2024-07-01",
+                "date_end": "2025-06-30",
+                "year_id": year.id,
+            }
+        )
+        self.assertTrue(term.first_term)
+
+        contact_a = self.env["res.partner"].create({"name": "Contact FR2 A"})
+        student_a = self.env["school_student"].create(
+            {
+                "name": "Student FR2 A",
+                "code": "STUFR2A",
+                "contact_id": contact_a.id,
+                "school_id": school.id,
+                "initial_grade_id": grade_prev.id,
+            }
+        )
+        self.assertEqual(student_a.next_grade_id, grade_target)
+
+        contact_b = self.env["res.partner"].create({"name": "Contact FR2 B"})
+        student_b = self.env["school_student"].create(
+            {
+                "name": "Student FR2 B",
+                "code": "STUFR2B",
+                "contact_id": contact_b.id,
+                "school_id": school.id,
+                "initial_grade_id": grade_target.id,
+            }
+        )
+        self.assertEqual(student_b.current_grade_id, grade_target)
+        self.assertNotEqual(student_b.next_grade_id, grade_target)
+
+        homeroom = self.env["school_homeroom"].create(
+            {
+                "date": "2024-07-01",
+                "academic_year_id": year.id,
+                "academic_term_id": term.id,
+                "school_id": school.id,
+                "grade_id": grade_target.id,
+                "grade_class_id": grade_class.id,
+                "capacity": 50,
+            }
+        )
+        homeroom.action_fill_random()
+
+        self.assertIn(student_a, homeroom.candidate_student_ids)
+        self.assertNotIn(student_b, homeroom.candidate_student_ids)
+
+    def test_fill_random_non_first_term_uses_current_grade(self):
+        """On a non-first term of an academic year, Fill Random must select
+        students whose current_grade_id matches the homeroom grade, mirroring
+        school_enrollment's allowed_student_ids algorithm."""
+        grade_type = self.env["school_grade_type"].create(
+            {"name": "Grade Type Fill Random 3", "code": "GTFR3", "sequence": 10}
+        )
+        school = self.env["school"].create(
+            {
+                "name": "School Fill Random 3",
+                "code": "SCHFR3",
+                "grade_type_id": grade_type.id,
+            }
+        )
+        grade_prev = self.env["school_grade"].create(
+            {
+                "name": "Grade Prev Fill Random 3",
+                "code": "GFR3A",
+                "sequence": 10,
+                "type_id": grade_type.id,
+            }
+        )
+        grade_target = self.env["school_grade"].create(
+            {
+                "name": "Grade Target Fill Random 3",
+                "code": "GFR3B",
+                "sequence": 20,
+                "type_id": grade_type.id,
+            }
+        )
+        self.assertEqual(grade_prev.next_grade_id, grade_target)
+        grade_class = self.env["school_grade_class"].create(
+            {
+                "name": "Class Fill Random 3",
+                "code": "CLFR3",
+                "school_id": school.id,
+                "grade_id": grade_target.id,
+                "capacity": 50,
+            }
+        )
+        year = self.env["school_academic_year"].create(
+            {
+                "name": "Year Fill Random 3",
+                "code": "AYFR3",
+                "date_start": "2024-07-01",
+                "date_end": "2025-06-30",
+            }
+        )
+        term_1 = self.env["school_academic_term"].create(
+            {
+                "name": "Term 1 Fill Random 3",
+                "code": "TMFR3A",
+                "date_start": "2024-07-01",
+                "date_end": "2024-12-31",
+                "year_id": year.id,
+            }
+        )
+        term_2 = self.env["school_academic_term"].create(
+            {
+                "name": "Term 2 Fill Random 3",
+                "code": "TMFR3B",
+                "date_start": "2025-01-01",
+                "date_end": "2025-06-30",
+                "year_id": year.id,
+            }
+        )
+        self.assertTrue(term_1.first_term)
+        self.assertFalse(term_2.first_term)
+
+        contact_a = self.env["res.partner"].create({"name": "Contact FR3 A"})
+        student_a = self.env["school_student"].create(
+            {
+                "name": "Student FR3 A",
+                "code": "STUFR3A",
+                "contact_id": contact_a.id,
+                "school_id": school.id,
+                "initial_grade_id": grade_target.id,
+            }
+        )
+        self.assertEqual(student_a.current_grade_id, grade_target)
+
+        contact_b = self.env["res.partner"].create({"name": "Contact FR3 B"})
+        student_b = self.env["school_student"].create(
+            {
+                "name": "Student FR3 B",
+                "code": "STUFR3B",
+                "contact_id": contact_b.id,
+                "school_id": school.id,
+                "initial_grade_id": grade_prev.id,
+            }
+        )
+        self.assertEqual(student_b.next_grade_id, grade_target)
+        self.assertNotEqual(student_b.current_grade_id, grade_target)
+
+        homeroom = self.env["school_homeroom"].create(
+            {
+                "date": "2025-01-01",
+                "academic_year_id": year.id,
+                "academic_term_id": term_2.id,
+                "school_id": school.id,
+                "grade_id": grade_target.id,
+                "grade_class_id": grade_class.id,
+                "capacity": 50,
+            }
+        )
+        homeroom.action_fill_random()
+
+        self.assertIn(student_a, homeroom.candidate_student_ids)
+        self.assertNotIn(student_b, homeroom.candidate_student_ids)

--- a/ssi_school/views/school_enrollment.xml
+++ b/ssi_school/views/school_enrollment.xml
@@ -134,11 +134,7 @@
                 <field name="school_id" />
                 <field name="grade_type_id" invisible="1" />
                 <field name="grade_id" domain="[('type_id','=',grade_type_id)]" />
-                <field
-                        name="allowed_student_ids"
-                        widget="many2many_tags"
-                        invisible="1"
-                    />
+                <field name="allowed_student_ids" invisible="1" />
                 <field name="student_id" domain="[('id','=',allowed_student_ids)]" />
                 <field
                         name="grade_class_id"

--- a/ssi_school/views/school_homeroom.xml
+++ b/ssi_school/views/school_homeroom.xml
@@ -112,7 +112,6 @@
                     <field name="allowed_student_ids" invisible="1" />
                     <field
                             name="candidate_student_ids"
-                            widget="many2many_tags"
                             domain="[('id','in',allowed_student_ids)]"
                             attrs="{'readonly':[('state','not in',['draft','open'])]}"
                         />

--- a/ssi_school_admission/models/school_admission_payment_term.py
+++ b/ssi_school_admission/models/school_admission_payment_term.py
@@ -156,6 +156,20 @@ class SchoolAdmissionPaymentTerm(models.Model):
         ),
     )
 
+    @api.model
+    def create(self, vals):
+        result = super().create(vals)
+        if result.admission_id:
+            result.admission_id._recompute_product_summary()  # pylint: disable=protected-access
+        return result
+
+    def write(self, vals):
+        result = super().write(vals)
+        self.mapped(
+            "admission_id"
+        )._recompute_product_summary()  # pylint: disable=protected-access
+        return result
+
     def unlink(self):
         admissions = self.mapped("admission_id")
         result = super().unlink()

--- a/ssi_school_admission/models/school_admission_payment_term_detail.py
+++ b/ssi_school_admission/models/school_admission_payment_term_detail.py
@@ -49,8 +49,6 @@ class SchoolAdmissionPaymentTermDetail(models.Model):
         help=("The invoice line linked to this detail " "after the term is invoiced."),
     )
 
-    _SUMMARY_FIELDS = {"product_id", "price_subtotal", "price_tax", "price_total"}
-
     @api.model
     def create(self, vals):
         record = super().create(vals)
@@ -61,9 +59,9 @@ class SchoolAdmissionPaymentTermDetail(models.Model):
 
     def write(self, vals):
         result = super().write(vals)
-        if self._SUMMARY_FIELDS & set(vals.keys()):
-            admissions = self.mapped("term_id.admission_id")
-            admissions._recompute_product_summary()  # pylint: disable=protected-access
+        self.mapped(
+            "term_id.admission_id"
+        )._recompute_product_summary()  # pylint: disable=protected-access
         return result
 
     def unlink(self):

--- a/ssi_school_admission/tests/__init__.py
+++ b/ssi_school_admission/tests/__init__.py
@@ -8,6 +8,7 @@ from . import (  # noqa: F401
     test_school_admission_form,
     test_school_admission_payment_date_pattern,
     test_school_admission_payment_term,
+    test_school_admission_product_summary,
     test_school_admission_test,
     test_school_admission_wizards,
 )

--- a/ssi_school_admission/tests/test_data_admission_product_summary.yaml
+++ b/ssi_school_admission/tests/test_data_admission_product_summary.yaml
@@ -1,0 +1,821 @@
+scenarios:
+  - name: "Product Summary - satu produk satu term tercompute saat detail ditambah"
+    steps:
+      - step: "Setup - get account type ref"
+        action: "ref"
+        xml_id: "account.data_account_type_revenue"
+        save_as: "account_type"
+
+      - step: "Setup - create income account"
+        action: "create"
+        model: "account.account"
+        save_as: "account"
+        values:
+          name: "Admission Fee Income APS1"
+          code: "APS14200"
+          user_type_id: "EVAL: registry['account_type'].id"
+
+      - step: "Setup - create product"
+        action: "create"
+        model: "product.product"
+        save_as: "product"
+        values:
+          name: "Admission Fee APS1"
+          type: "service"
+          list_price: 1000000.0
+
+      - step: "Setup - create grade type"
+        action: "create"
+        model: "school_grade_type"
+        save_as: "grade_type"
+        values:
+          name: "Grade Type APS1"
+          code: "GTAPS1"
+          sequence: 10
+
+      - step: "Setup - create academic year"
+        action: "create"
+        model: "school_academic_year"
+        save_as: "academic_year"
+        values:
+          name: "2024/2025 APS1"
+          code: "AYAPS1"
+          date_start: "2024-07-01"
+          date_end: "2025-06-30"
+
+      - step: "Setup - create academic term"
+        action: "create"
+        model: "school_academic_term"
+        save_as: "academic_term"
+        values:
+          name: "Semester APS1"
+          code: "SMAPS1"
+          date_start: "2024-07-01"
+          date_end: "2025-06-30"
+          year_id: "EVAL: registry['academic_year'].id"
+          enrollment_state: "open"
+
+      - step: "Setup - create school"
+        action: "create"
+        model: "school"
+        save_as: "school"
+        values:
+          name: "School APS1"
+          code: "SCHAPS1"
+          grade_type_id: "EVAL: registry['grade_type'].id"
+
+      - step: "Setup - create grade"
+        action: "create"
+        model: "school_grade"
+        save_as: "grade"
+        values:
+          name: "Grade APS1"
+          code: "GAPS1"
+          sequence: 10
+          type_id: "EVAL: registry['grade_type'].id"
+
+      - step: "Setup - create student contact"
+        action: "create"
+        model: "res.partner"
+        save_as: "student_contact"
+        values:
+          name: "Student Contact APS1"
+
+      - step: "Create admission tanpa payment term"
+        action: "create"
+        model: "school_admission"
+        save_as: "admission"
+        values:
+          date: "2024-07-01"
+          academic_year_id: "EVAL: registry['academic_year'].id"
+          academic_term_id: "EVAL: registry['academic_term'].id"
+          school_id: "EVAL: registry['school'].id"
+          grade_id: "EVAL: registry['grade'].id"
+          student_id: "EVAL: registry['student_contact'].id"
+          currency_id: "EVAL: env.company.currency_id.id"
+
+      - step: "Assert product_summary_ids kosong di awal"
+        action: "assert"
+        target: "admission"
+        asserts:
+          product_summary_ids:
+            type: "o2m"
+            check: "count"
+            expected_count: 0
+
+      - step: "Tambah payment term pada admission"
+        action: "create"
+        model: "school_admission_payment_term"
+        save_as: "term"
+        values:
+          admission_id: "EVAL: registry['admission'].id"
+          name: "Term 1 APS1"
+          sequence: 10
+
+      - step: "Tambah detail pada payment term"
+        action: "create"
+        model: "school_admission_payment_term_detail"
+        save_as: "detail"
+        values:
+          term_id: "EVAL: registry['term'].id"
+          product_id: "EVAL: registry['product'].id"
+          name: "Admission Fee APS1"
+          account_id: "EVAL: registry['account'].id"
+          uom_quantity: 1.0
+          uom_id: "REF: uom.product_uom_unit"
+          price_unit: 1000000.0
+
+      - step: "Invalidate admission cache"
+        action: "call"
+        target: "admission"
+        method: "invalidate_cache"
+
+      - step: "Assert product_summary_ids berisi 1 record"
+        action: "assert"
+        target: "admission"
+        asserts:
+          product_summary_ids:
+            type: "o2m"
+            check: "count"
+            expected_count: 1
+
+      - step: "Cari summary record"
+        action: "search"
+        model: "school_admission_product_summary"
+        domain: [["admission_id", "=", "EVAL: registry['admission'].id"]]
+        save_as: "summary"
+        expect_count: 1
+
+      - step: "Assert nilai amount pada summary"
+        action: "assert"
+        target: "summary"
+        asserts:
+          amount_untaxed:
+            type: "value"
+            expected: 1000000.0
+          amount_total:
+            type: "value"
+            expected: 1000000.0
+
+  - name: "Product Summary - summary ikut berubah saat detail diubah (write)"
+    steps:
+      - step: "Setup - get account type ref"
+        action: "ref"
+        xml_id: "account.data_account_type_revenue"
+        save_as: "account_type"
+
+      - step: "Setup - create income account"
+        action: "create"
+        model: "account.account"
+        save_as: "account"
+        values:
+          name: "Admission Fee Income APS2"
+          code: "APS24200"
+          user_type_id: "EVAL: registry['account_type'].id"
+
+      - step: "Setup - create product"
+        action: "create"
+        model: "product.product"
+        save_as: "product"
+        values:
+          name: "Admission Fee APS2"
+          type: "service"
+          list_price: 500000.0
+
+      - step: "Setup - create grade type"
+        action: "create"
+        model: "school_grade_type"
+        save_as: "grade_type"
+        values:
+          name: "Grade Type APS2"
+          code: "GTAPS2"
+          sequence: 10
+
+      - step: "Setup - create academic year"
+        action: "create"
+        model: "school_academic_year"
+        save_as: "academic_year"
+        values:
+          name: "2024/2025 APS2"
+          code: "AYAPS2"
+          date_start: "2024-07-01"
+          date_end: "2025-06-30"
+
+      - step: "Setup - create academic term"
+        action: "create"
+        model: "school_academic_term"
+        save_as: "academic_term"
+        values:
+          name: "Semester APS2"
+          code: "SMAPS2"
+          date_start: "2024-07-01"
+          date_end: "2025-06-30"
+          year_id: "EVAL: registry['academic_year'].id"
+          enrollment_state: "open"
+
+      - step: "Setup - create school"
+        action: "create"
+        model: "school"
+        save_as: "school"
+        values:
+          name: "School APS2"
+          code: "SCHAPS2"
+          grade_type_id: "EVAL: registry['grade_type'].id"
+
+      - step: "Setup - create grade"
+        action: "create"
+        model: "school_grade"
+        save_as: "grade"
+        values:
+          name: "Grade APS2"
+          code: "GAPS2"
+          sequence: 10
+          type_id: "EVAL: registry['grade_type'].id"
+
+      - step: "Setup - create student contact"
+        action: "create"
+        model: "res.partner"
+        save_as: "student_contact"
+        values:
+          name: "Student Contact APS2"
+
+      - step: "Create admission"
+        action: "create"
+        model: "school_admission"
+        save_as: "admission"
+        values:
+          date: "2024-07-01"
+          academic_year_id: "EVAL: registry['academic_year'].id"
+          academic_term_id: "EVAL: registry['academic_term'].id"
+          school_id: "EVAL: registry['school'].id"
+          grade_id: "EVAL: registry['grade'].id"
+          student_id: "EVAL: registry['student_contact'].id"
+          currency_id: "EVAL: env.company.currency_id.id"
+
+      - step: "Tambah payment term"
+        action: "create"
+        model: "school_admission_payment_term"
+        save_as: "term"
+        values:
+          admission_id: "EVAL: registry['admission'].id"
+          name: "Term 1 APS2"
+          sequence: 10
+
+      - step: "Tambah detail dengan quantity 1"
+        action: "create"
+        model: "school_admission_payment_term_detail"
+        save_as: "detail"
+        values:
+          term_id: "EVAL: registry['term'].id"
+          product_id: "EVAL: registry['product'].id"
+          name: "Admission Fee APS2"
+          account_id: "EVAL: registry['account'].id"
+          uom_quantity: 1.0
+          uom_id: "REF: uom.product_uom_unit"
+          price_unit: 500000.0
+
+      - step: "Invalidate admission cache setelah create detail"
+        action: "call"
+        target: "admission"
+        method: "invalidate_cache"
+
+      - step: "Cari summary record setelah create"
+        action: "search"
+        model: "school_admission_product_summary"
+        domain: [["admission_id", "=", "EVAL: registry['admission'].id"]]
+        save_as: "summary"
+        expect_count: 1
+
+      - step: "Assert amount summary awal sesuai quantity 1"
+        action: "assert"
+        target: "summary"
+        asserts:
+          amount_untaxed:
+            type: "value"
+            expected: 500000.0
+
+      - step: "Ubah quantity detail menjadi 3 (write, bukan create)"
+        action: "write"
+        target: "detail"
+        values:
+          uom_quantity: 3.0
+
+      - step: "Invalidate admission cache setelah write quantity"
+        action: "call"
+        target: "admission"
+        method: "invalidate_cache"
+
+      - step: "Cari summary record setelah write quantity"
+        action: "search"
+        model: "school_admission_product_summary"
+        domain: [["admission_id", "=", "EVAL: registry['admission'].id"]]
+        save_as: "summary_after_qty"
+        expect_count: 1
+
+      - step: "Assert amount summary ikut naik mengikuti quantity baru"
+        action: "assert"
+        target: "summary_after_qty"
+        asserts:
+          amount_untaxed:
+            type: "value"
+            expected: 1500000.0
+          amount_total:
+            type: "value"
+            expected: 1500000.0
+
+      - step: "Ubah price_unit detail menjadi 700000"
+        action: "write"
+        target: "detail"
+        values:
+          price_unit: 700000.0
+
+      - step: "Invalidate admission cache setelah write price_unit"
+        action: "call"
+        target: "admission"
+        method: "invalidate_cache"
+
+      - step: "Cari summary record setelah write price_unit"
+        action: "search"
+        model: "school_admission_product_summary"
+        domain: [["admission_id", "=", "EVAL: registry['admission'].id"]]
+        save_as: "summary_after_price"
+        expect_count: 1
+
+      - step: "Assert amount summary ikut berubah mengikuti price_unit baru"
+        action: "assert"
+        target: "summary_after_price"
+        asserts:
+          amount_untaxed:
+            type: "value"
+            expected: 2100000.0
+          amount_total:
+            type: "value"
+            expected: 2100000.0
+
+  - name: "Product Summary - dua term produk sama diaggregate jadi satu summary"
+    steps:
+      - step: "Setup - get account type ref"
+        action: "ref"
+        xml_id: "account.data_account_type_revenue"
+        save_as: "account_type"
+
+      - step: "Setup - create income account"
+        action: "create"
+        model: "account.account"
+        save_as: "account"
+        values:
+          name: "Admission Fee Income APS3"
+          code: "APS34200"
+          user_type_id: "EVAL: registry['account_type'].id"
+
+      - step: "Setup - create product"
+        action: "create"
+        model: "product.product"
+        save_as: "product"
+        values:
+          name: "Admission Fee APS3"
+          type: "service"
+          list_price: 500000.0
+
+      - step: "Setup - create grade type"
+        action: "create"
+        model: "school_grade_type"
+        save_as: "grade_type"
+        values:
+          name: "Grade Type APS3"
+          code: "GTAPS3"
+          sequence: 10
+
+      - step: "Setup - create academic year"
+        action: "create"
+        model: "school_academic_year"
+        save_as: "academic_year"
+        values:
+          name: "2024/2025 APS3"
+          code: "AYAPS3"
+          date_start: "2024-07-01"
+          date_end: "2025-06-30"
+
+      - step: "Setup - create academic term"
+        action: "create"
+        model: "school_academic_term"
+        save_as: "academic_term"
+        values:
+          name: "Semester APS3"
+          code: "SMAPS3"
+          date_start: "2024-07-01"
+          date_end: "2025-06-30"
+          year_id: "EVAL: registry['academic_year'].id"
+          enrollment_state: "open"
+
+      - step: "Setup - create school"
+        action: "create"
+        model: "school"
+        save_as: "school"
+        values:
+          name: "School APS3"
+          code: "SCHAPS3"
+          grade_type_id: "EVAL: registry['grade_type'].id"
+
+      - step: "Setup - create grade"
+        action: "create"
+        model: "school_grade"
+        save_as: "grade"
+        values:
+          name: "Grade APS3"
+          code: "GAPS3"
+          sequence: 10
+          type_id: "EVAL: registry['grade_type'].id"
+
+      - step: "Setup - create student contact"
+        action: "create"
+        model: "res.partner"
+        save_as: "student_contact"
+        values:
+          name: "Student Contact APS3"
+
+      - step: "Create admission"
+        action: "create"
+        model: "school_admission"
+        save_as: "admission"
+        values:
+          date: "2024-07-01"
+          academic_year_id: "EVAL: registry['academic_year'].id"
+          academic_term_id: "EVAL: registry['academic_term'].id"
+          school_id: "EVAL: registry['school'].id"
+          grade_id: "EVAL: registry['grade'].id"
+          student_id: "EVAL: registry['student_contact'].id"
+          currency_id: "EVAL: env.company.currency_id.id"
+
+      - step: "Tambah term 1 dengan detail"
+        action: "create"
+        model: "school_admission_payment_term"
+        save_as: "term1"
+        values:
+          admission_id: "EVAL: registry['admission'].id"
+          name: "Term 1 APS3"
+          sequence: 10
+
+      - step: "Tambah detail term 1"
+        action: "create"
+        model: "school_admission_payment_term_detail"
+        values:
+          term_id: "EVAL: registry['term1'].id"
+          product_id: "EVAL: registry['product'].id"
+          name: "Fee Term 1 APS3"
+          account_id: "EVAL: registry['account'].id"
+          uom_quantity: 1.0
+          uom_id: "REF: uom.product_uom_unit"
+          price_unit: 500000.0
+
+      - step: "Tambah term 2 dengan detail produk yang sama"
+        action: "create"
+        model: "school_admission_payment_term"
+        save_as: "term2"
+        values:
+          admission_id: "EVAL: registry['admission'].id"
+          name: "Term 2 APS3"
+          sequence: 20
+
+      - step: "Tambah detail term 2 dengan produk sama"
+        action: "create"
+        model: "school_admission_payment_term_detail"
+        values:
+          term_id: "EVAL: registry['term2'].id"
+          product_id: "EVAL: registry['product'].id"
+          name: "Fee Term 2 APS3"
+          account_id: "EVAL: registry['account'].id"
+          uom_quantity: 1.0
+          uom_id: "REF: uom.product_uom_unit"
+          price_unit: 500000.0
+
+      - step: "Invalidate admission cache"
+        action: "call"
+        target: "admission"
+        method: "invalidate_cache"
+
+      - step: "Assert product_summary_ids hanya 1 record meski 2 term"
+        action: "assert"
+        target: "admission"
+        asserts:
+          product_summary_ids:
+            type: "o2m"
+            check: "count"
+            expected_count: 1
+
+      - step: "Cari summary record"
+        action: "search"
+        model: "school_admission_product_summary"
+        domain: [["admission_id", "=", "EVAL: registry['admission'].id"]]
+        save_as: "summary"
+        expect_count: 1
+
+      - step: "Assert total amount diaggregate dari dua term"
+        action: "assert"
+        target: "summary"
+        asserts:
+          amount_untaxed:
+            type: "value"
+            expected: 1000000.0
+          amount_total:
+            type: "value"
+            expected: 1000000.0
+
+  - name: "Product Summary - summary dihapus saat detail diunlink"
+    steps:
+      - step: "Setup - get account type ref"
+        action: "ref"
+        xml_id: "account.data_account_type_revenue"
+        save_as: "account_type"
+
+      - step: "Setup - create income account"
+        action: "create"
+        model: "account.account"
+        save_as: "account"
+        values:
+          name: "Admission Fee Income APS4"
+          code: "APS44200"
+          user_type_id: "EVAL: registry['account_type'].id"
+
+      - step: "Setup - create product"
+        action: "create"
+        model: "product.product"
+        save_as: "product"
+        values:
+          name: "Admission Fee APS4"
+          type: "service"
+          list_price: 750000.0
+
+      - step: "Setup - create grade type"
+        action: "create"
+        model: "school_grade_type"
+        save_as: "grade_type"
+        values:
+          name: "Grade Type APS4"
+          code: "GTAPS4"
+          sequence: 10
+
+      - step: "Setup - create academic year"
+        action: "create"
+        model: "school_academic_year"
+        save_as: "academic_year"
+        values:
+          name: "2024/2025 APS4"
+          code: "AYAPS4"
+          date_start: "2024-07-01"
+          date_end: "2025-06-30"
+
+      - step: "Setup - create academic term"
+        action: "create"
+        model: "school_academic_term"
+        save_as: "academic_term"
+        values:
+          name: "Semester APS4"
+          code: "SMAPS4"
+          date_start: "2024-07-01"
+          date_end: "2025-06-30"
+          year_id: "EVAL: registry['academic_year'].id"
+          enrollment_state: "open"
+
+      - step: "Setup - create school"
+        action: "create"
+        model: "school"
+        save_as: "school"
+        values:
+          name: "School APS4"
+          code: "SCHAPS4"
+          grade_type_id: "EVAL: registry['grade_type'].id"
+
+      - step: "Setup - create grade"
+        action: "create"
+        model: "school_grade"
+        save_as: "grade"
+        values:
+          name: "Grade APS4"
+          code: "GAPS4"
+          sequence: 10
+          type_id: "EVAL: registry['grade_type'].id"
+
+      - step: "Setup - create student contact"
+        action: "create"
+        model: "res.partner"
+        save_as: "student_contact"
+        values:
+          name: "Student Contact APS4"
+
+      - step: "Create admission"
+        action: "create"
+        model: "school_admission"
+        save_as: "admission"
+        values:
+          date: "2024-07-01"
+          academic_year_id: "EVAL: registry['academic_year'].id"
+          academic_term_id: "EVAL: registry['academic_term'].id"
+          school_id: "EVAL: registry['school'].id"
+          grade_id: "EVAL: registry['grade'].id"
+          student_id: "EVAL: registry['student_contact'].id"
+          currency_id: "EVAL: env.company.currency_id.id"
+
+      - step: "Tambah term"
+        action: "create"
+        model: "school_admission_payment_term"
+        save_as: "term"
+        values:
+          admission_id: "EVAL: registry['admission'].id"
+          name: "Term 1 APS4"
+          sequence: 10
+
+      - step: "Tambah detail"
+        action: "create"
+        model: "school_admission_payment_term_detail"
+        save_as: "detail"
+        values:
+          term_id: "EVAL: registry['term'].id"
+          product_id: "EVAL: registry['product'].id"
+          name: "Fee APS4"
+          account_id: "EVAL: registry['account'].id"
+          uom_quantity: 1.0
+          uom_id: "REF: uom.product_uom_unit"
+          price_unit: 750000.0
+
+      - step: "Invalidate admission cache"
+        action: "call"
+        target: "admission"
+        method: "invalidate_cache"
+
+      - step: "Assert summary ada sebelum detail dihapus"
+        action: "assert"
+        target: "admission"
+        asserts:
+          product_summary_ids:
+            type: "o2m"
+            check: "count"
+            expected_count: 1
+
+      - step: "Hapus detail"
+        action: "call"
+        target: "detail"
+        method: "unlink"
+
+      - step: "Invalidate admission cache setelah hapus detail"
+        action: "call"
+        target: "admission"
+        method: "invalidate_cache"
+
+      - step: "Assert summary kosong setelah detail dihapus"
+        action: "assert"
+        target: "admission"
+        asserts:
+          product_summary_ids:
+            type: "o2m"
+            check: "count"
+            expected_count: 0
+
+  - name: "Product Summary - summary dihapus saat term diunlink"
+    steps:
+      - step: "Setup - get account type ref"
+        action: "ref"
+        xml_id: "account.data_account_type_revenue"
+        save_as: "account_type"
+
+      - step: "Setup - create income account"
+        action: "create"
+        model: "account.account"
+        save_as: "account"
+        values:
+          name: "Admission Fee Income APS5"
+          code: "APS54200"
+          user_type_id: "EVAL: registry['account_type'].id"
+
+      - step: "Setup - create product"
+        action: "create"
+        model: "product.product"
+        save_as: "product"
+        values:
+          name: "Admission Fee APS5"
+          type: "service"
+          list_price: 250000.0
+
+      - step: "Setup - create grade type"
+        action: "create"
+        model: "school_grade_type"
+        save_as: "grade_type"
+        values:
+          name: "Grade Type APS5"
+          code: "GTAPS5"
+          sequence: 10
+
+      - step: "Setup - create academic year"
+        action: "create"
+        model: "school_academic_year"
+        save_as: "academic_year"
+        values:
+          name: "2024/2025 APS5"
+          code: "AYAPS5"
+          date_start: "2024-07-01"
+          date_end: "2025-06-30"
+
+      - step: "Setup - create academic term"
+        action: "create"
+        model: "school_academic_term"
+        save_as: "academic_term"
+        values:
+          name: "Semester APS5"
+          code: "SMAPS5"
+          date_start: "2024-07-01"
+          date_end: "2025-06-30"
+          year_id: "EVAL: registry['academic_year'].id"
+          enrollment_state: "open"
+
+      - step: "Setup - create school"
+        action: "create"
+        model: "school"
+        save_as: "school"
+        values:
+          name: "School APS5"
+          code: "SCHAPS5"
+          grade_type_id: "EVAL: registry['grade_type'].id"
+
+      - step: "Setup - create grade"
+        action: "create"
+        model: "school_grade"
+        save_as: "grade"
+        values:
+          name: "Grade APS5"
+          code: "GAPS5"
+          sequence: 10
+          type_id: "EVAL: registry['grade_type'].id"
+
+      - step: "Setup - create student contact"
+        action: "create"
+        model: "res.partner"
+        save_as: "student_contact"
+        values:
+          name: "Student Contact APS5"
+
+      - step: "Create admission"
+        action: "create"
+        model: "school_admission"
+        save_as: "admission"
+        values:
+          date: "2024-07-01"
+          academic_year_id: "EVAL: registry['academic_year'].id"
+          academic_term_id: "EVAL: registry['academic_term'].id"
+          school_id: "EVAL: registry['school'].id"
+          grade_id: "EVAL: registry['grade'].id"
+          student_id: "EVAL: registry['student_contact'].id"
+          currency_id: "EVAL: env.company.currency_id.id"
+
+      - step: "Tambah term dengan detail"
+        action: "create"
+        model: "school_admission_payment_term"
+        save_as: "term"
+        values:
+          admission_id: "EVAL: registry['admission'].id"
+          name: "Term 1 APS5"
+          sequence: 10
+
+      - step: "Tambah detail pada term"
+        action: "create"
+        model: "school_admission_payment_term_detail"
+        values:
+          term_id: "EVAL: registry['term'].id"
+          product_id: "EVAL: registry['product'].id"
+          name: "Fee APS5"
+          account_id: "EVAL: registry['account'].id"
+          uom_quantity: 2.0
+          uom_id: "REF: uom.product_uom_unit"
+          price_unit: 250000.0
+
+      - step: "Invalidate admission cache"
+        action: "call"
+        target: "admission"
+        method: "invalidate_cache"
+
+      - step: "Assert summary ada sebelum term dihapus"
+        action: "assert"
+        target: "admission"
+        asserts:
+          product_summary_ids:
+            type: "o2m"
+            check: "count"
+            expected_count: 1
+
+      - step: "Hapus term (cascade hapus detail)"
+        action: "call"
+        target: "term"
+        method: "unlink"
+
+      - step: "Invalidate admission cache setelah hapus term"
+        action: "call"
+        target: "admission"
+        method: "invalidate_cache"
+
+      - step: "Assert summary kosong setelah term dihapus"
+        action: "assert"
+        target: "admission"
+        asserts:
+          product_summary_ids:
+            type: "o2m"
+            check: "count"
+            expected_count: 0

--- a/ssi_school_admission/tests/test_school_admission_product_summary.py
+++ b/ssi_school_admission/tests/test_school_admission_product_summary.py
@@ -1,0 +1,15 @@
+# Copyright 2024 OpenSynergy Indonesia
+# Copyright 2024 PT. Simetri Sinergi Indonesia
+# License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl).
+
+from odoo_yaml_test import YamlTransactionCase
+
+from odoo.tests import tagged
+
+
+@tagged("post_install", "-at_install")
+class TestSchoolAdmissionProductSummary(
+    YamlTransactionCase
+):  # pylint: disable=too-few-public-methods
+    def test_admission_product_summary(self):
+        self.run_yaml_scenario("test_data_admission_product_summary.yaml")

--- a/ssi_school_admission/views/school_admission.xml
+++ b/ssi_school_admission/views/school_admission.xml
@@ -107,13 +107,7 @@
                     />
             </xpath>
             <xpath expr="//page[1]" position="before">
-                <page name="admission_source" string="Admission Source">
-                    <group name="admission_source_group" colspan="4" col="2">
-                        <field name="admission_form_id" />
-                        <field name="admission_test_id" />
-                    </group>
-                </page>
-                <page name="billing" string="Billing">
+                <page name="billing" string="Fee">
                     <group name="billing_template" colspan="4" col="2">
                         <group name="billing_template_left" colspan="1" col="2">
                             <field
@@ -165,14 +159,6 @@
                                 />
                         </tree>
                     </field>
-                    <group name="billing_account" colspan="4" col="2">
-                        <group name="billing_account_left" colspan="1" col="2">
-                            <field name="receivable_journal_id" />
-                            <field name="receivable_account_id" />
-                        </group>
-                    </group>
-                </page>
-                <page name="product_summary" string="Product Summary">
                     <field
                             name="product_summary_ids"
                             colspan="4"
@@ -188,6 +174,18 @@
                             <field name="amount_total" />
                         </tree>
                     </field>
+                    <group name="billing_account" colspan="4" col="2">
+                        <group name="billing_account_left" colspan="1" col="2">
+                            <field name="receivable_journal_id" />
+                            <field name="receivable_account_id" />
+                        </group>
+                    </group>
+                </page>
+                <page name="admission_source" string="Admission Source">
+                    <group name="admission_source_group" colspan="4" col="2">
+                        <field name="admission_form_id" />
+                        <field name="admission_test_id" />
+                    </group>
                 </page>
                 <page name="result" string="Result">
                     <group name="result_group" colspan="4" col="2">


### PR DESCRIPTION
## Ringkasan

### ssi_school_admission
* Menambahkan override create() dan write() pada school_admission_payment_term
  agar Product Summary ikut direkomputasi setiap payment term dibuat/diubah,
  tidak hanya saat template diterapkan atau term dihapus
* Menyederhanakan write() pada school_admission_payment_term_detail dengan
  menghapus optimasi _SUMMARY_FIELDS sehingga summary selalu direkomputasi
  secara konsisten
* Menggabungkan halaman Billing dan Product Summary pada form admission
  menjadi satu halaman Fee, dan memindahkan halaman Admission Source
  setelahnya
* Menambahkan skenario uji Product Summary

### ssi_school
* Menghapus widget many2many_tags pada field m2m siswa
  (candidate_student_ids di school_homeroom dan allowed_student_ids di
  school_enrollment) agar tampil sebagai list default, bukan tag/chip
* Menambahkan unit test yang membuktikan mekanisme Fill Random
  (_fill_random_candidate) hanya memilih siswa dari allowed_student_ids dan
  mengikuti algoritma yang sama dengan school_enrollment: term pertama
  memakai next_grade_id, term non-pertama memakai current_grade_id

## Test plan

- [x] Kedua modul ter-update lokal tanpa error.
- [x] `pre-commit run --all-files` lolos.
- [ ] CI hijau.