### PR TITLE
[UPD] ssi_school_admission

### DIFF
--- a/ssi_school_admission/__manifest__.py
+++ b/ssi_school_admission/__manifest__.py
@@ -60,6 +60,7 @@
         "ir_model_access/school_admission_product_summary.xml",
         "ir_model_access/school_admission_payment_template.xml",
         "ir_model_access/school_admission_payment_term.xml",
+        "ir_model_access/school_admission_payment_term_wizard_duplicate.xml",
         "ir_rule/school_admission.xml",
         "ir_sequence/school_admission.xml",
         "sequence_template/school_admission.xml",
@@ -69,6 +70,7 @@
         "views/school_admission_payment_template.xml",
         "views/school_admission_payment_term.xml",
         "views/school_admission.xml",
+        "wizards/school_admission_payment_term_duplicate.xml",
     ],
     "demo": [
         "demo/account_account_demo.xml",

--- a/ssi_school_admission/ir_model_access/school_admission_payment_term_wizard_duplicate.xml
+++ b/ssi_school_admission/ir_model_access/school_admission_payment_term_wizard_duplicate.xml
@@ -1,0 +1,20 @@
+<?xml version="1.0" encoding="utf-8" ?>
+<!-- Copyright 2026 OpenSynergy Indonesia
+     Copyright 2026 PT. Simetri Sinergi Indonesia
+     License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl). -->
+<odoo>
+
+<record
+        id="school_admission_payment_term_wizard_duplicate_user_access"
+        model="ir.model.access"
+    >
+    <field name="name">school_admission_payment_term.wizard_duplicate - user</field>
+    <field name="model_id" ref="model_school_admission_payment_term_wizard_duplicate" />
+    <field name="group_id" ref="school_admission_user_group" />
+    <field name="perm_read" eval="1" />
+    <field name="perm_create" eval="1" />
+    <field name="perm_write" eval="1" />
+    <field name="perm_unlink" eval="1" />
+</record>
+
+</odoo>

--- a/ssi_school_admission/models/school_admission_payment_term.py
+++ b/ssi_school_admission/models/school_admission_payment_term.py
@@ -155,6 +155,15 @@ class SchoolAdmissionPaymentTerm(models.Model):
             "Marks this term as manually controlled, " "skipping automatic invoicing."
         ),
     )
+    admission_state = fields.Selection(
+        string="Admission State",
+        related="admission_id.state",
+        store=True,
+        help=(
+            "Status of the owning admission, used to control "
+            "term-level actions such as duplication."
+        ),
+    )
 
     @api.model
     def create(self, vals):
@@ -195,6 +204,19 @@ class SchoolAdmissionPaymentTerm(models.Model):
     def action_unmark_as_manual(self):
         for record in self.sudo():
             record._unmark_as_manual()  # pylint: disable=protected-access
+
+    def action_open_duplicate_wizard(self):
+        for record in self.sudo():
+            result = record._open_duplicate_wizard()
+        return result
+
+    def _open_duplicate_wizard(self):
+        self.ensure_one()
+        waction = self.env.ref(
+            "ssi_school_admission.school_admission_payment_term_action_duplicate"
+        ).read()[0]
+        waction.update({"context": {"active_id": self.id}})
+        return waction
 
     def _mark_as_manual(self):
         self.ensure_one()

--- a/ssi_school_admission/tests/__init__.py
+++ b/ssi_school_admission/tests/__init__.py
@@ -8,6 +8,7 @@ from . import (  # noqa: F401
     test_school_admission_form,
     test_school_admission_payment_date_pattern,
     test_school_admission_payment_term,
+    test_school_admission_payment_term_duplicate,
     test_school_admission_product_summary,
     test_school_admission_test,
     test_school_admission_wizards,

--- a/ssi_school_admission/tests/test_data_admission_payment_term_duplicate.yaml
+++ b/ssi_school_admission/tests/test_data_admission_payment_term_duplicate.yaml
@@ -1,0 +1,284 @@
+scenarios:
+  - name: "Admission Payment Term - Duplicate via Wizard"
+    steps:
+      - step: "Setup - get receivable journal"
+        action: "search"
+        model: "account.journal"
+        domain: [["type", "=", "sale"]]
+        save_as: "receivable_journal"
+        limit: 1
+
+      - step: "Setup - get account type ref"
+        action: "ref"
+        xml_id: "account.data_account_type_revenue"
+        save_as: "account_type"
+
+      - step: "Setup - create income account"
+        action: "create"
+        model: "account.account"
+        save_as: "account"
+        values:
+          name: "Admission Fee Income ADPTDUP1"
+          code: "ADPTDUP14200"
+          user_type_id: "EVAL: registry['account_type'].id"
+
+      - step: "Setup - create first product"
+        action: "create"
+        model: "product.product"
+        save_as: "product1"
+        values:
+          name: "Admission Fee 1 ADPTDUP1"
+          type: "service"
+          list_price: 500000.0
+
+      - step: "Setup - create second product"
+        action: "create"
+        model: "product.product"
+        save_as: "product2"
+        values:
+          name: "Admission Fee 2 ADPTDUP1"
+          type: "service"
+          list_price: 700000.0
+
+      - step: "Setup - create pricelist"
+        action: "create"
+        model: "product.pricelist"
+        save_as: "pricelist"
+        values:
+          name: "Pricelist ADPTDUP1"
+          currency_id: "EVAL: env.company.currency_id.id"
+
+      - step: "Setup - create grade type"
+        action: "create"
+        model: "school_grade_type"
+        save_as: "grade_type"
+        values:
+          name: "Grade Type ADPTDUP1"
+          code: "GTADPTDUP1"
+          sequence: 10
+
+      - step: "Setup - create academic year"
+        action: "create"
+        model: "school_academic_year"
+        save_as: "academic_year"
+        values:
+          name: "2024/2025 ADPTDUP1"
+          code: "AYADPTDUP1"
+          date_start: "2024-07-01"
+          date_end: "2025-06-30"
+
+      - step: "Setup - create academic term"
+        action: "create"
+        model: "school_academic_term"
+        save_as: "academic_term"
+        values:
+          name: "Semester ADPTDUP1"
+          code: "SMADPTDUP1"
+          date_start: "2024-07-01"
+          date_end: "2025-06-30"
+          year_id: "EVAL: registry['academic_year'].id"
+          enrollment_state: "open"
+
+      - step: "Setup - create school"
+        action: "create"
+        model: "school"
+        save_as: "school"
+        values:
+          name: "School ADPTDUP1"
+          code: "SCHADPTDUP1"
+          grade_type_id: "EVAL: registry['grade_type'].id"
+
+      - step: "Setup - create grade"
+        action: "create"
+        model: "school_grade"
+        save_as: "grade"
+        values:
+          name: "Grade ADPTDUP1"
+          code: "GADPTDUP1"
+          sequence: 10
+          type_id: "EVAL: registry['grade_type'].id"
+
+      - step: "Setup - create student contact"
+        action: "create"
+        model: "res.partner"
+        save_as: "student_contact"
+        values:
+          name: "Student Contact ADPTDUP1"
+
+      - step: "Setup - create admission"
+        action: "create"
+        model: "school_admission"
+        save_as: "admission"
+        values:
+          date: "2024-07-01"
+          academic_year_id: "EVAL: registry['academic_year'].id"
+          academic_term_id: "EVAL: registry['academic_term'].id"
+          school_id: "EVAL: registry['school'].id"
+          grade_id: "EVAL: registry['grade'].id"
+          student_id: "EVAL: registry['student_contact'].id"
+          pricelist_id: "EVAL: registry['pricelist'].id"
+          currency_id: "EVAL: env.company.currency_id.id"
+          receivable_journal_id: "EVAL: registry['receivable_journal'].id"
+
+      - step: "Setup - create source payment term with two detail lines"
+        action: "create"
+        model: "school_admission_payment_term"
+        save_as: "term"
+        values:
+          admission_id: "EVAL: registry['admission'].id"
+          name: "Term Source ADPTDUP1"
+          sequence: 10
+          date_invoice: "2024-08-01"
+          date_due: "2024-08-15"
+          detail_ids:
+            - - 0
+              - 0
+              - product_id: "EVAL: registry['product1'].id"
+                name: "Fee 1 ADPTDUP1"
+                account_id: "EVAL: registry['account'].id"
+                uom_quantity: 1.0
+                uom_id: "REF: uom.product_uom_unit"
+                price_unit: 500000.0
+            - - 0
+              - 0
+              - product_id: "EVAL: registry['product2'].id"
+                name: "Fee 2 ADPTDUP1"
+                account_id: "EVAL: registry['account'].id"
+                uom_quantity: 1.0
+                uom_id: "REF: uom.product_uom_unit"
+                price_unit: 700000.0
+
+      - step: "Smoke test - open duplicate wizard action from source term"
+        action: "call"
+        target: "term"
+        method: "action_open_duplicate_wizard"
+
+      - step: "Create invoice on source term"
+        action: "call"
+        target: "term"
+        method: "action_create_invoice"
+
+      - step: "Invalidate term cache after invoice creation"
+        action: "call"
+        target: "term"
+        method: "invalidate_cache"
+
+      - step: "Assert source term has an invoice"
+        action: "assert"
+        target: "term"
+        asserts:
+          invoice_id:
+            type: "value"
+            operator: "is_truthy"
+
+      - step: "Create duplicate wizard with new header values"
+        action: "create"
+        model: "school_admission_payment_term.wizard_duplicate"
+        save_as: "wizard"
+        values:
+          term_id: "EVAL: registry['term'].id"
+          name: "Term Copy ADPTDUP1"
+          sequence: 20
+          date_invoice: "2024-09-01"
+          date_due: "2024-09-15"
+
+      - step: "Confirm duplicate"
+        action: "call"
+        target: "wizard"
+        method: "action_duplicate"
+
+      - step: "Search the newly duplicated term"
+        action: "search"
+        model: "school_admission_payment_term"
+        domain:
+          - ["admission_id", "=", "EVAL: registry['admission'].id"]
+          - ["id", "!=", "EVAL: registry['term'].id"]
+        save_as: "new_term"
+        expect_count: 1
+
+      - step: "Assert new term header comes from the wizard"
+        action: "assert"
+        target: "new_term"
+        asserts:
+          name:
+            type: "value"
+            expected: "Term Copy ADPTDUP1"
+          sequence:
+            type: "value"
+            expected: 20
+          date_invoice:
+            type: "value"
+            expected: 2024-09-01
+          date_due:
+            type: "value"
+            expected: 2024-09-15
+          invoice_id:
+            type: "value"
+            operator: "is_falsy"
+          detail_ids:
+            type: "o2m"
+            check: "count"
+            expected_count: 2
+
+      - step: "Search duplicated detail line for first product"
+        action: "search"
+        model: "school_admission_payment_term_detail"
+        domain:
+          - ["term_id", "=", "EVAL: registry['new_term'].id"]
+          - ["product_id", "=", "EVAL: registry['product1'].id"]
+        save_as: "detail1"
+        expect_count: 1
+
+      - step: "Assert first duplicated detail matches source and has no invoice line"
+        action: "assert"
+        target: "detail1"
+        asserts:
+          name:
+            type: "value"
+            expected: "Fee 1 ADPTDUP1"
+          price_unit:
+            type: "value"
+            expected: 500000.0
+          uom_quantity:
+            type: "value"
+            expected: 1.0
+          invoice_line_id:
+            type: "value"
+            operator: "is_falsy"
+
+      - step: "Search duplicated detail line for second product"
+        action: "search"
+        model: "school_admission_payment_term_detail"
+        domain:
+          - ["term_id", "=", "EVAL: registry['new_term'].id"]
+          - ["product_id", "=", "EVAL: registry['product2'].id"]
+        save_as: "detail2"
+        expect_count: 1
+
+      - step: "Assert second duplicated detail matches source and has no invoice line"
+        action: "assert"
+        target: "detail2"
+        asserts:
+          name:
+            type: "value"
+            expected: "Fee 2 ADPTDUP1"
+          price_unit:
+            type: "value"
+            expected: 700000.0
+          uom_quantity:
+            type: "value"
+            expected: 1.0
+          invoice_line_id:
+            type: "value"
+            operator: "is_falsy"
+
+      - step: "Assert source term is untouched"
+        action: "assert"
+        target: "term"
+        asserts:
+          name:
+            type: "value"
+            expected: "Term Source ADPTDUP1"
+          sequence:
+            type: "value"
+            expected: 10

--- a/ssi_school_admission/tests/test_school_admission_payment_term_duplicate.py
+++ b/ssi_school_admission/tests/test_school_admission_payment_term_duplicate.py
@@ -1,0 +1,35 @@
+# Copyright 2026 OpenSynergy Indonesia
+# Copyright 2026 PT. Simetri Sinergi Indonesia
+# License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl).
+
+from odoo_yaml_test import YamlTransactionCase
+
+from odoo.tests import tagged
+
+
+@tagged("post_install", "-at_install")
+class TestSchoolAdmissionPaymentTermDuplicate(YamlTransactionCase):
+    def test_admission_payment_term_duplicate(self):
+        self.run_yaml_scenario("test_data_admission_payment_term_duplicate.yaml")
+
+    def test_wizard_duplicate_default_get_prefill(self):
+        # Plain Python (not YAML): default_get keys off context active_id,
+        # which the YAML scenario's context: key cannot express reliably.
+        term = self.env["school_admission_payment_term"].create(
+            {
+                "name": "Term Source PREFILL",
+                "sequence": 15,
+                "date_invoice": "2024-08-01",
+                "date_due": "2024-08-15",
+            }
+        )
+        wizard = (
+            self.env["school_admission_payment_term.wizard_duplicate"]
+            .with_context(active_id=term.id)
+            .create({})
+        )
+        self.assertEqual(wizard.term_id, term)
+        self.assertEqual(wizard.name, "%s (copy)" % term.name)
+        self.assertEqual(wizard.sequence, term.sequence)
+        self.assertEqual(wizard.date_invoice, term.date_invoice)
+        self.assertEqual(wizard.date_due, term.date_due)

--- a/ssi_school_admission/views/school_admission_payment_term.xml
+++ b/ssi_school_admission/views/school_admission_payment_term.xml
@@ -40,6 +40,7 @@
             <field name="date_invoice" />
             <field name="date_due" />
             <field name="currency_id" invisible="1" />
+            <field name="admission_state" invisible="1" />
             <field name="amount_untaxed" />
             <field name="amount_tax" />
             <field name="amount_total" />
@@ -79,6 +80,13 @@
                     type="object"
                     icon="fa-check-square-o"
                     states="manual"
+                />
+            <button
+                    name="action_open_duplicate_wizard"
+                    title="Duplicate Term"
+                    type="object"
+                    icon="fa-files-o"
+                    attrs="{'invisible':[('admission_state','!=','draft')]}"
                 />
         </tree>
     </field>

--- a/ssi_school_admission/wizards/__init__.py
+++ b/ssi_school_admission/wizards/__init__.py
@@ -4,5 +4,6 @@
 
 from . import (  # noqa: F401
     school_admission_form_create_admission,
+    school_admission_payment_term_duplicate,
     school_admission_test_create_admission,
 )

--- a/ssi_school_admission/wizards/school_admission_payment_term_duplicate.py
+++ b/ssi_school_admission/wizards/school_admission_payment_term_duplicate.py
@@ -1,0 +1,81 @@
+# Copyright 2026 OpenSynergy Indonesia
+# Copyright 2026 PT. Simetri Sinergi Indonesia
+# License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl).
+
+from odoo import _, api, fields, models
+
+
+class SchoolAdmissionPaymentTermWizardDuplicate(models.TransientModel):
+    """
+    Wizard that duplicates a school_admission_payment_term record.
+    Copies every detail line (detail_ids) from the source term to a new term
+    on the same admission, while only the header fields (name, sequence,
+    date_invoice, date_due) are taken from the wizard input.
+    """
+
+    _name = "school_admission_payment_term.wizard_duplicate"
+    _description = "Duplicate School Admission Payment Term"
+
+    term_id = fields.Many2one(
+        string="Source Term",
+        comodel_name="school_admission_payment_term",
+        required=True,
+        readonly=True,
+        help="The payment term whose detail lines will be copied to the new term.",
+    )
+    name = fields.Char(
+        string="Term Name",
+        required=True,
+        help="Name of the new payment term to be created.",
+    )
+    sequence = fields.Integer(
+        string="Sequence",
+        required=True,
+        default=5,
+        help=(
+            "Order of the new payment term within the admission. "
+            "Lower values appear first."
+        ),
+    )
+    date_invoice = fields.Date(
+        string="Estimated Invoice Date",
+        help="Estimated date for issuing the invoice for the new payment term.",
+    )
+    date_due = fields.Date(
+        string="Estimated Due Date",
+        help="Estimated due date for payment of the new payment term.",
+    )
+
+    @api.model
+    def default_get(self, fields_list):
+        res = super().default_get(fields_list)
+        active_id = self.env.context.get("active_id")
+        if active_id:
+            term = self.env["school_admission_payment_term"].browse(active_id)
+            res["term_id"] = term.id
+            res["name"] = _("%s (copy)") % term.name
+            res["sequence"] = term.sequence
+            res["date_invoice"] = term.date_invoice
+            res["date_due"] = term.date_due
+        return res
+
+    def action_duplicate(self):
+        for record in self.sudo():
+            result = record._duplicate_term()
+        return result
+
+    def _duplicate_term(self):
+        self.ensure_one()
+        new_term = self.term_id.copy(self._prepare_duplicate_defaults())
+        new_term.detail_ids.write({"invoice_line_id": False})
+        return {"type": "ir.actions.act_window_close"}
+
+    def _prepare_duplicate_defaults(self):
+        self.ensure_one()
+        return {
+            "name": self.name,
+            "sequence": self.sequence,
+            "date_invoice": self.date_invoice,
+            "date_due": self.date_due,
+            "invoice_id": False,
+        }

--- a/ssi_school_admission/wizards/school_admission_payment_term_duplicate.xml
+++ b/ssi_school_admission/wizards/school_admission_payment_term_duplicate.xml
@@ -1,0 +1,47 @@
+<?xml version="1.0" encoding="utf-8" ?>
+<!-- Copyright 2026 OpenSynergy Indonesia
+     Copyright 2026 PT. Simetri Sinergi Indonesia
+     License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl). -->
+<odoo>
+
+<record
+        id="school_admission_payment_term_wizard_duplicate_view_form"
+        model="ir.ui.view"
+    >
+    <field name="name">school_admission_payment_term.wizard_duplicate - form</field>
+    <field name="model">school_admission_payment_term.wizard_duplicate</field>
+    <field name="arch" type="xml">
+        <form string="Duplicate Payment Term">
+            <group name="main" colspan="4" col="2">
+                <field name="term_id" />
+                <field name="name" />
+                <field name="sequence" />
+                <field name="date_invoice" />
+                <field name="date_due" />
+            </group>
+            <footer>
+                <button
+                        name="action_duplicate"
+                        type="object"
+                        string="Duplicate"
+                        class="btn-primary"
+                    />
+                <button string="Cancel" class="btn-default" special="cancel" />
+            </footer>
+        </form>
+    </field>
+</record>
+
+<record
+        id="school_admission_payment_term_action_duplicate"
+        model="ir.actions.act_window"
+    >
+    <field name="name">Duplicate Payment Term</field>
+    <field name="type">ir.actions.act_window</field>
+    <field name="res_model">school_admission_payment_term.wizard_duplicate</field>
+    <field name="view_mode">form</field>
+    <field name="target">new</field>
+    <field name="context">{"active_id": active_id}</field>
+</record>
+
+</odoo>


### PR DESCRIPTION
## Ringkasan

* Menambahkan wizard duplikasi payment term (`school_admission_payment_term.wizard_duplicate`), meniru pola wizard copy term yang sudah ada di `ssi_school`
* Menyalin seluruh `detail_ids` dari term sumber ke term baru, dengan field header (`name`, `sequence`, `date_invoice`, `date_due`) diambil dari input wizard
* Menambahkan field `admission_state` dan tombol "Duplicate Term" pada tree view, hanya tampil saat admission masih berstatus draft
* Menambahkan unit test skenario YAML untuk alur duplikasi serta test Python untuk prefill `default_get` berbasis context `active_id`

## Test plan

- [x] Unit test ditulis (YAML + Python), dijalankan via CI