### PR TITLE
[UPD] ssi_school_admission, ssi_school_lead

### DIFF
--- a/ssi_school_admission/demo/school_admission_payment_template_demo.xml
+++ b/ssi_school_admission/demo/school_admission_payment_template_demo.xml
@@ -11,6 +11,8 @@
         <field name="academic_term_id" ref="ssi_school.school_academic_term1" />
         <field name="school_id" ref="ssi_school.school_demo_1" />
         <field name="grade_id" ref="ssi_school.school_grade1_type" />
+        <field name="receivable_journal_id" ref="demo_journal_sale" />
+        <field name="receivable_account_id" ref="demo_account_receivable" />
         <field
             name="term_ids"
             eval="[
@@ -65,6 +67,8 @@
         <field name="academic_term_id" ref="ssi_school.school_academic_term1" />
         <field name="school_id" ref="ssi_school.school_demo_1" />
         <field name="grade_id" ref="ssi_school.school_grade2_type" />
+        <field name="receivable_journal_id" ref="demo_journal_sale" />
+        <field name="receivable_account_id" ref="demo_account_receivable" />
         <field
             name="term_ids"
             eval="[

--- a/ssi_school_admission/models/school_admission.py
+++ b/ssi_school_admission/models/school_admission.py
@@ -282,6 +282,22 @@ class SchoolAdmission(models.Model):
     def onchange_grade_id(self):
         self.grade_id = False
 
+    @api.onchange(
+        "payment_template_id",
+    )
+    def onchange_receivable_journal_id(self):
+        self.receivable_journal_id = False
+        if self.payment_template_id:
+            self.receivable_journal_id = self.payment_template_id.receivable_journal_id
+
+    @api.onchange(
+        "payment_template_id",
+    )
+    def onchange_receivable_account_id(self):
+        self.receivable_account_id = False
+        if self.payment_template_id:
+            self.receivable_account_id = self.payment_template_id.receivable_account_id
+
     def action_compute_payment(self):
         for record in self.sudo():
             record._compute_payment_from_template()  # pylint: disable=protected-access

--- a/ssi_school_admission/models/school_admission_payment_template.py
+++ b/ssi_school_admission/models/school_admission_payment_template.py
@@ -43,6 +43,24 @@ class SchoolAdmissionPaymentTemplate(
         required=False,
         help="The grade level for which this payment template applies.",
     )
+    receivable_journal_id = fields.Many2one(
+        string="Receivable Journal",
+        comodel_name="account.journal",
+        required=False,
+        help=(
+            "Default receivable journal copied into the admission "
+            "when this template is selected."
+        ),
+    )
+    receivable_account_id = fields.Many2one(
+        string="Receivable Account",
+        comodel_name="account.account",
+        required=False,
+        help=(
+            "Default receivable account copied into the admission "
+            "when this template is selected."
+        ),
+    )
     term_ids = fields.One2many(
         string="Payment Terms",
         comodel_name="school_admission_payment_template.term",

--- a/ssi_school_admission/tests/test_data_admission.yaml
+++ b/ssi_school_admission/tests/test_data_admission.yaml
@@ -108,6 +108,8 @@ scenarios:
           school_id: "EVAL: registry['school'].id"
           grade_id: "EVAL: registry['grade'].id"
           academic_term_id: "EVAL: registry['academic_term'].id"
+          receivable_journal_id: "EVAL: registry['receivable_journal'].id"
+          receivable_account_id: "EVAL: registry['account'].id"
           term_ids:
             - - 0
               - 0
@@ -135,6 +137,17 @@ scenarios:
                       uom_quantity: 1.0
                       uom_id: "REF: uom.product_uom_unit"
                       price_unit: 1000000.0
+
+      - step: "Assert payment template receivable defaults stored"
+        action: "assert"
+        target: "payment_template"
+        asserts:
+          receivable_journal_id:
+            type: "value"
+            operator: "is_truthy"
+          receivable_account_id:
+            type: "value"
+            operator: "is_truthy"
 
       - step: "Create admission"
         action: "create"

--- a/ssi_school_admission/tests/test_school_admission.py
+++ b/ssi_school_admission/tests/test_school_admission.py
@@ -4,7 +4,7 @@
 
 from odoo_yaml_test import YamlTransactionCase
 
-from odoo.tests import tagged
+from odoo.tests import Form, tagged
 
 
 @tagged("post_install", "-at_install")
@@ -13,3 +13,62 @@ class TestSchoolAdmissionWorkflow(
 ):  # pylint: disable=too-few-public-methods
     def test_admission_workflow(self):
         self.run_yaml_scenario("test_data_admission.yaml")
+
+    def _prepare_payment_template(self):
+        """Create a payment template carrying receivable journal/account defaults."""
+        journal = self.env["account.journal"].search([("type", "=", "sale")], limit=1)
+        account_type = self.env.ref("account.data_account_type_receivable")
+        account = self.env["account.account"].create(
+            {
+                "name": "Admission Receivable Onchange",
+                "code": "ADMREC01",
+                "user_type_id": account_type.id,
+                "reconcile": True,
+            }
+        )
+        grade_type = self.env["school_grade_type"].create(
+            {"name": "Grade Type Onchange", "code": "GTONC1", "sequence": 10}
+        )
+        school = self.env["school"].create(
+            {
+                "name": "School Onchange",
+                "code": "SCHONC1",
+                "grade_type_id": grade_type.id,
+            }
+        )
+        grade = self.env["school_grade"].create(
+            {
+                "name": "Grade Onchange",
+                "code": "GONC1",
+                "sequence": 10,
+                "type_id": grade_type.id,
+            }
+        )
+        template = self.env["school_admission_payment_template"].create(
+            {
+                "name": "Admission Payment Template Onchange",
+                "code": "ADMPMTONC1",
+                "school_id": school.id,
+                "grade_id": grade.id,
+                "receivable_journal_id": journal.id,
+                "receivable_account_id": account.id,
+            }
+        )
+        return template, journal, account
+
+    def test_onchange_payment_template_sets_receivable(self):
+        """Selecting a payment template copies its receivable journal/account."""
+        template, journal, account = self._prepare_payment_template()
+        form = Form(self.env["school_admission"])
+        form.payment_template_id = template
+        self.assertEqual(form.receivable_journal_id, journal)
+        self.assertEqual(form.receivable_account_id, account)
+
+    def test_onchange_payment_template_clears_receivable(self):
+        """Clearing the payment template clears the receivable journal/account."""
+        template, _journal, _account = self._prepare_payment_template()
+        form = Form(self.env["school_admission"])
+        form.payment_template_id = template
+        form.payment_template_id = self.env["school_admission_payment_template"]
+        self.assertFalse(form.receivable_journal_id)
+        self.assertFalse(form.receivable_account_id)

--- a/ssi_school_admission/views/school_admission_payment_template.xml
+++ b/ssi_school_admission/views/school_admission_payment_template.xml
@@ -68,6 +68,8 @@
                 <field name="school_id" />
                 <field name="grade_id" domain="[('type_id','=',grade_type_id)]" />
                 <field name="grade_type_id" invisible="1" />
+                <field name="receivable_journal_id" />
+                <field name="receivable_account_id" />
             </xpath>
             <xpath expr="//page[1]" position="before">
                 <page name="payment_terms" string="Payment Terms">

--- a/ssi_school_lead/tests/test_school_lead.py
+++ b/ssi_school_lead/tests/test_school_lead.py
@@ -142,3 +142,83 @@ class TestSchoolLead(YamlTransactionCase):
 
         form.school_id = school_b
         self.assertFalse(form.payment_template_id.id)
+
+    def test_create_admission_propagates_receivable(self):
+        """Admission created from lead inherits receivable journal/account from template."""
+        year = self.env["school_academic_year"].create(
+            {
+                "name": "Year OC3",
+                "code": "AYOC3",
+                "date_start": "2024-07-01",
+                "date_end": "2025-06-30",
+            }
+        )
+        term = self.env["school_academic_term"].create(
+            {
+                "name": "Term OC3",
+                "code": "SMOC3",
+                "date_start": "2024-07-01",
+                "date_end": "2025-06-30",
+                "year_id": year.id,
+                "is_open_admission": True,
+            }
+        )
+        grade_type = self.env["school_grade_type"].create(
+            {"name": "Grade Type OC3", "code": "GTOC3", "sequence": 10}
+        )
+        school = self.env["school"].create(
+            {"name": "School OC3", "code": "SCHOC3", "grade_type_id": grade_type.id}
+        )
+        grade = self.env["school_grade"].create(
+            {
+                "name": "Grade OC3",
+                "code": "GOC3",
+                "sequence": 10,
+                "type_id": grade_type.id,
+            }
+        )
+        journal = self.env["account.journal"].search([("type", "=", "sale")], limit=1)
+        account = self.env["account.account"].create(
+            {
+                "name": "Admission Receivable OC3",
+                "code": "ADMRECOC3",
+                "user_type_id": self.env.ref("account.data_account_type_receivable").id,
+                "reconcile": True,
+            }
+        )
+        template = self.env["school_admission_payment_template"].create(
+            {
+                "name": "PT OC3",
+                "code": "PTOC3",
+                "school_id": school.id,
+                "grade_id": grade.id,
+                "academic_term_id": term.id,
+                "receivable_journal_id": journal.id,
+                "receivable_account_id": account.id,
+            }
+        )
+        student = self.env["res.partner"].create({"name": "Student OC3"})
+        lead = (
+            self.env["crm.lead"]
+            .with_user(self.env.ref("base.user_admin"))
+            .create({"name": "Lead OC3"})
+        )
+
+        form = Form(
+            self.env["crm.lead.create_admission"].with_context(
+                default_lead_id=lead.id,
+                default_student_id=student.id,
+            )
+        )
+        form.academic_year_id = year
+        form.school_id = school
+        form.grade_id = grade
+        form.academic_term_id = term
+        self.assertEqual(form.payment_template_id.id, template.id)
+        wizard = form.save()
+        wizard.action_confirm()
+
+        admission = lead.admission_id
+        self.assertTrue(admission)
+        self.assertEqual(admission.receivable_journal_id, journal)
+        self.assertEqual(admission.receivable_account_id, account)

--- a/ssi_school_lead/wizard/crm_lead_create_admission.py
+++ b/ssi_school_lead/wizard/crm_lead_create_admission.py
@@ -140,4 +140,10 @@ class CrmLeadCreateAdmission(models.TransientModel):
             "payment_template_id": self.payment_template_id.id
             if self.payment_template_id
             else False,
+            "receivable_journal_id": self.payment_template_id.receivable_journal_id.id
+            if self.payment_template_id
+            else False,
+            "receivable_account_id": self.payment_template_id.receivable_account_id.id
+            if self.payment_template_id
+            else False,
         }


### PR DESCRIPTION
## Ringkasan

* **ssi_school_admission**: menambahkan field `receivable_journal_id` dan
  `receivable_account_id` pada `school_admission_payment_template` sebagai default
  receivable journal/account, ditampilkan di form template. Menambahkan dua onchange
  pada `school_admission` (trigger `payment_template_id`) agar kedua field tersebut
  otomatis terisi/kosong mengikuti template yang dipilih — meniru behavior yang sudah
  ada di `school_enrollment_payment_template`/`school_enrollment`.
* **ssi_school_lead**: wizard `crm.lead.create_admission` membuat admission lewat
  `create()` yang melewati onchange, sehingga `_prepare_admission_data` diperbarui
  untuk menyalin `receivable_journal_id`/`receivable_account_id` dari
  `payment_template_id` secara eksplisit.

## Test plan

- [x] Unit test YAML untuk penyimpanan field baru pada payment template
- [x] Unit test Form API untuk onchange `payment_template_id` → isi/kosongkan
      `receivable_journal_id`/`receivable_account_id`
- [x] Unit test untuk wizard lead→admission yang membuktikan penyalinan kedua field
- [x] `pre-commit run --all-files` lolos
- [ ] CI (menunggu hasil check pada PR ini)