### PR TITLE
[UPD] ssi_school, ssi_school_admission

### DIFF
--- a/ssi_school/__manifest__.py
+++ b/ssi_school/__manifest__.py
@@ -43,6 +43,7 @@
         "security/ir_model_access/school_enrollment_payment_term.xml",
         "security/ir_model_access/school_enrollment_payment_term_detail.xml",
         "security/ir_model_access/school_enrollment_payment_term_wizard_duplicate.xml",
+        "security/ir_model_access/school_enrollment_wizard_copy_payment_term.xml",
         "security/ir_model_access/school_enrollment_product_summary.xml",
         "security/ir_model_access/school_enrollment_payment_template.xml",
         "security/ir_model_access/school_homeroom.xml",
@@ -70,6 +71,7 @@
         "views/school_enrollment_payment_term_views.xml",
         "views/school_enrollment_payment_template_views.xml",
         "wizards/school_enrollment_payment_term_duplicate.xml",
+        "wizards/school_enrollment_copy_payment_term.xml",
     ],
     "demo": [
         "demo/res_partner.xml",

--- a/ssi_school/models/school_enrollment.py
+++ b/ssi_school/models/school_enrollment.py
@@ -363,6 +363,16 @@ class SchoolEnrollment(models.Model):
         compute_sudo=True,
         help="Policy that determines whether the Graduate action button is visible.",
     )
+    copy_payment_term_ok = fields.Boolean(
+        string="Can Copy Payment Term",
+        compute="_compute_policy",
+        store=False,
+        compute_sudo=True,
+        help=(
+            "Policy that determines whether payment terms may be "
+            "copied into this enrollment."
+        ),
+    )
 
     def _recompute_product_summaries(self):
         for record in self.sudo():
@@ -743,6 +753,7 @@ Solution: Choose a different Grade Class or increase its capacity
             "fail_ok",
             "drop_out_ok",
             "graduate_ok",
+            "copy_payment_term_ok",
         ]
         res += policy_field
         return res

--- a/ssi_school/policy_template/school_enrollment.xml
+++ b/ssi_school/policy_template/school_enrollment.xml
@@ -32,6 +32,27 @@
     <field name="restrict_additional" eval="0" />
 </record>
 
+<!-- Copy Payment Term -->
+<record
+        id="policy_template_school_enrollment_copy_payment_term"
+        model="policy.template_detail"
+    >
+    <field name="template_id" ref="policy_template_school_enrollment" />
+    <field
+            name="field_id"
+            search="[('model_id.model','=','school_enrollment'),('name','=','copy_payment_term_ok')]"
+        />
+    <field name="restrict_state" eval="1" />
+    <field
+            name="state_ids"
+            search="[('field_id.model_id.model','=','school_enrollment'),('value','=','draft')]"
+        />
+    <field name="restrict_user" eval="1" />
+    <field name="computation_method">use_group</field>
+    <field name="group_ids" eval="[(6,0,[ref('school_enrollment_user_group')])]" />
+    <field name="restrict_additional" eval="0" />
+</record>
+
 <!-- Done -->
 <record id="policy_template_school_enrollment_done" model="policy.template_detail">
     <field name="template_id" ref="policy_template_school_enrollment" />

--- a/ssi_school/security/ir_model_access/school_enrollment_wizard_copy_payment_term.xml
+++ b/ssi_school/security/ir_model_access/school_enrollment_wizard_copy_payment_term.xml
@@ -1,0 +1,20 @@
+<?xml version="1.0" encoding="utf-8" ?>
+<!-- Copyright 2026 OpenSynergy Indonesia
+     Copyright 2026 PT. Simetri Sinergi Indonesia
+     License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl). -->
+<odoo>
+
+<record
+        id="school_enrollment_wizard_copy_payment_term_user_access"
+        model="ir.model.access"
+    >
+    <field name="name">school_enrollment.wizard_copy_payment_term - user</field>
+    <field name="model_id" ref="model_school_enrollment_wizard_copy_payment_term" />
+    <field name="group_id" ref="school_enrollment_user_group" />
+    <field name="perm_read" eval="1" />
+    <field name="perm_create" eval="1" />
+    <field name="perm_write" eval="1" />
+    <field name="perm_unlink" eval="1" />
+</record>
+
+</odoo>

--- a/ssi_school/tests/__init__.py
+++ b/ssi_school/tests/__init__.py
@@ -18,6 +18,7 @@ from . import (  # noqa: F401
     test_school_enrollment_results,
     test_school_enrollment_payment_term_management,
     test_school_enrollment_payment_term_duplicate,
+    test_school_enrollment_copy_payment_term,
     test_school_enrollment_product_summary,
     test_school_enrollment_payment_date_pattern,
     test_school_enrollment_integrity,

--- a/ssi_school/tests/test_data_enrollment_copy_payment_term.yaml
+++ b/ssi_school/tests/test_data_enrollment_copy_payment_term.yaml
@@ -1,0 +1,706 @@
+scenarios:
+  - name: "Copy Payment Terms - Replace Mode"
+    steps:
+      - step: "Setup - get account type ref"
+        action: "ref"
+        xml_id: "account.data_account_type_revenue"
+        save_as: "account_type"
+
+      - step: "Setup - create income account"
+        action: "create"
+        model: "account.account"
+        save_as: "account"
+        values:
+          name: "School Fee Income CPTR1"
+          code: "CPTR14200"
+          user_type_id: "EVAL: registry['account_type'].id"
+
+      - step: "Setup - create product"
+        action: "create"
+        model: "product.product"
+        save_as: "product"
+        values:
+          name: "School Fee CPTR1"
+          type: "service"
+          list_price: 500000.0
+
+      - step: "Setup - create grade type"
+        action: "create"
+        model: "school_grade_type"
+        save_as: "grade_type"
+        values:
+          name: "Grade Type CPTR1"
+          code: "GTCPTR1"
+          sequence: 10
+
+      - step: "Setup - create academic year"
+        action: "create"
+        model: "school_academic_year"
+        save_as: "academic_year"
+        values:
+          name: "2024/2025 CPTR1"
+          code: "AYCPTR1"
+          date_start: "2024-07-01"
+          date_end: "2025-06-30"
+
+      - step: "Setup - create academic term"
+        action: "create"
+        model: "school_academic_term"
+        save_as: "academic_term"
+        values:
+          name: "Semester CPTR1"
+          code: "SMCPTR1"
+          date_start: "2024-07-01"
+          date_end: "2025-06-30"
+          year_id: "EVAL: registry['academic_year'].id"
+          enrollment_state: "open"
+
+      - step: "Setup - create school"
+        action: "create"
+        model: "school"
+        save_as: "school"
+        values:
+          name: "School CPTR1"
+          code: "SCHCPTR1"
+          grade_type_id: "EVAL: registry['grade_type'].id"
+
+      - step: "Setup - create grade"
+        action: "create"
+        model: "school_grade"
+        save_as: "grade"
+        values:
+          name: "Grade CPTR1"
+          code: "GCPTR1"
+          sequence: 10
+          type_id: "EVAL: registry['grade_type'].id"
+
+      - step: "Setup - create grade class"
+        action: "create"
+        model: "school_grade_class"
+        save_as: "grade_class"
+        values:
+          name: "Class CPTR1"
+          code: "CLACPTR1"
+          school_id: "EVAL: registry['school'].id"
+          grade_id: "EVAL: registry['grade'].id"
+
+      - step: "Setup - create source student contact"
+        action: "create"
+        model: "res.partner"
+        save_as: "source_contact"
+        values:
+          name: "Source Student Contact CPTR1"
+
+      - step: "Setup - create source student"
+        action: "create"
+        model: "school_student"
+        save_as: "source_student"
+        values:
+          name: "Source Student CPTR1"
+          code: "SSTUCPTR1"
+          contact_id: "EVAL: registry['source_contact'].id"
+          school_id: "EVAL: registry['school'].id"
+
+      - step: "Setup - create source enrollment"
+        action: "create"
+        model: "school_enrollment"
+        save_as: "source"
+        values:
+          date: "2024-07-01"
+          academic_year_id: "EVAL: registry['academic_year'].id"
+          academic_term_id: "EVAL: registry['academic_term'].id"
+          school_id: "EVAL: registry['school'].id"
+          grade_id: "EVAL: registry['grade'].id"
+          grade_class_id: "EVAL: registry['grade_class'].id"
+          student_id: "EVAL: registry['source_student'].id"
+          currency_id: "EVAL: env.company.currency_id.id"
+
+      - step: "Setup - create source payment term with detail"
+        action: "create"
+        model: "school_enrollment_payment_term"
+        save_as: "source_term"
+        values:
+          enrollment_id: "EVAL: registry['source'].id"
+          name: "Term Source CPTR1"
+          sequence: 10
+          date_invoice: "2024-08-01"
+          date_due: "2024-08-15"
+          detail_ids:
+            - - 0
+              - 0
+              - product_id: "EVAL: registry['product'].id"
+                name: "Fee CPTR1"
+                account_id: "EVAL: registry['account'].id"
+                uom_quantity: 1.0
+                uom_id: "REF: uom.product_uom_unit"
+                price_unit: 500000.0
+
+      - step: "Setup - create target student contact"
+        action: "create"
+        model: "res.partner"
+        save_as: "target_contact"
+        values:
+          name: "Target Student Contact CPTR1"
+
+      - step: "Setup - create target student"
+        action: "create"
+        model: "school_student"
+        save_as: "target_student"
+        values:
+          name: "Target Student CPTR1"
+          code: "TSTUCPTR1"
+          contact_id: "EVAL: registry['target_contact'].id"
+          school_id: "EVAL: registry['school'].id"
+
+      - step: "Setup - create target enrollment (draft, same term/school/grade)"
+        action: "create"
+        model: "school_enrollment"
+        save_as: "target"
+        values:
+          date: "2024-07-01"
+          academic_year_id: "EVAL: registry['academic_year'].id"
+          academic_term_id: "EVAL: registry['academic_term'].id"
+          school_id: "EVAL: registry['school'].id"
+          grade_id: "EVAL: registry['grade'].id"
+          grade_class_id: "EVAL: registry['grade_class'].id"
+          student_id: "EVAL: registry['target_student'].id"
+          currency_id: "EVAL: env.company.currency_id.id"
+
+      - step: "Setup - create pre-existing term on target"
+        action: "create"
+        model: "school_enrollment_payment_term"
+        save_as: "target_old_term"
+        values:
+          enrollment_id: "EVAL: registry['target'].id"
+          name: "Term Old CPTR1"
+          sequence: 5
+
+      - step: "Create copy wizard in replace mode"
+        action: "create"
+        model: "school_enrollment.wizard_copy_payment_term"
+        save_as: "wizard"
+        values:
+          target_enrollment_ids:
+            - - 6
+              - 0
+              - - "EVAL: registry['target'].id"
+          source_enrollment_id: "EVAL: registry['source'].id"
+          mode: "replace"
+
+      - step: "Run copy payment term"
+        action: "call"
+        target: "wizard"
+        method: "action_copy_payment_term"
+
+      - step: "Assert target has exactly one term (old one replaced)"
+        action: "search"
+        model: "school_enrollment_payment_term"
+        domain:
+          - ["enrollment_id", "=", "EVAL: registry['target'].id"]
+        save_as: "target_terms_after"
+        expect_count: 1
+
+      - step: "Search the copied term on target"
+        action: "search"
+        model: "school_enrollment_payment_term"
+        domain:
+          - ["enrollment_id", "=", "EVAL: registry['target'].id"]
+          - ["name", "=", "Term Source CPTR1"]
+        save_as: "copied_term"
+        expect_count: 1
+
+      - step: "Assert copied term matches source and has no invoice"
+        action: "assert"
+        target: "copied_term"
+        asserts:
+          sequence:
+            type: "value"
+            expected: 10
+          invoice_id:
+            type: "value"
+            operator: "is_falsy"
+          detail_ids:
+            type: "o2m"
+            check: "count"
+            expected_count: 1
+
+      - step: "Search copied detail line"
+        action: "search"
+        model: "school_enrollment_payment_term_detail"
+        domain:
+          - ["term_id", "=", "EVAL: registry['copied_term'].id"]
+        save_as: "copied_detail"
+        expect_count: 1
+
+      - step: "Assert copied detail matches source and has no invoice line"
+        action: "assert"
+        target: "copied_detail"
+        asserts:
+          name:
+            type: "value"
+            expected: "Fee CPTR1"
+          price_unit:
+            type: "value"
+            expected: 500000.0
+          invoice_line_id:
+            type: "value"
+            operator: "is_falsy"
+
+      - step: "Assert source term is untouched"
+        action: "assert"
+        target: "source_term"
+        asserts:
+          name:
+            type: "value"
+            expected: "Term Source CPTR1"
+
+  - name: "Copy Payment Terms - Add Mode"
+    steps:
+      - step: "Setup - get account type ref"
+        action: "ref"
+        xml_id: "account.data_account_type_revenue"
+        save_as: "account_type"
+
+      - step: "Setup - create income account"
+        action: "create"
+        model: "account.account"
+        save_as: "account"
+        values:
+          name: "School Fee Income CPTR2"
+          code: "CPTR24200"
+          user_type_id: "EVAL: registry['account_type'].id"
+
+      - step: "Setup - create product"
+        action: "create"
+        model: "product.product"
+        save_as: "product"
+        values:
+          name: "School Fee CPTR2"
+          type: "service"
+          list_price: 500000.0
+
+      - step: "Setup - create grade type"
+        action: "create"
+        model: "school_grade_type"
+        save_as: "grade_type"
+        values:
+          name: "Grade Type CPTR2"
+          code: "GTCPTR2"
+          sequence: 10
+
+      - step: "Setup - create academic year"
+        action: "create"
+        model: "school_academic_year"
+        save_as: "academic_year"
+        values:
+          name: "2024/2025 CPTR2"
+          code: "AYCPTR2"
+          date_start: "2024-07-01"
+          date_end: "2025-06-30"
+
+      - step: "Setup - create academic term"
+        action: "create"
+        model: "school_academic_term"
+        save_as: "academic_term"
+        values:
+          name: "Semester CPTR2"
+          code: "SMCPTR2"
+          date_start: "2024-07-01"
+          date_end: "2025-06-30"
+          year_id: "EVAL: registry['academic_year'].id"
+          enrollment_state: "open"
+
+      - step: "Setup - create school"
+        action: "create"
+        model: "school"
+        save_as: "school"
+        values:
+          name: "School CPTR2"
+          code: "SCHCPTR2"
+          grade_type_id: "EVAL: registry['grade_type'].id"
+
+      - step: "Setup - create grade"
+        action: "create"
+        model: "school_grade"
+        save_as: "grade"
+        values:
+          name: "Grade CPTR2"
+          code: "GCPTR2"
+          sequence: 10
+          type_id: "EVAL: registry['grade_type'].id"
+
+      - step: "Setup - create grade class"
+        action: "create"
+        model: "school_grade_class"
+        save_as: "grade_class"
+        values:
+          name: "Class CPTR2"
+          code: "CLACPTR2"
+          school_id: "EVAL: registry['school'].id"
+          grade_id: "EVAL: registry['grade'].id"
+
+      - step: "Setup - create source student contact"
+        action: "create"
+        model: "res.partner"
+        save_as: "source_contact"
+        values:
+          name: "Source Student Contact CPTR2"
+
+      - step: "Setup - create source student"
+        action: "create"
+        model: "school_student"
+        save_as: "source_student"
+        values:
+          name: "Source Student CPTR2"
+          code: "SSTUCPTR2"
+          contact_id: "EVAL: registry['source_contact'].id"
+          school_id: "EVAL: registry['school'].id"
+
+      - step: "Setup - create source enrollment"
+        action: "create"
+        model: "school_enrollment"
+        save_as: "source"
+        values:
+          date: "2024-07-01"
+          academic_year_id: "EVAL: registry['academic_year'].id"
+          academic_term_id: "EVAL: registry['academic_term'].id"
+          school_id: "EVAL: registry['school'].id"
+          grade_id: "EVAL: registry['grade'].id"
+          grade_class_id: "EVAL: registry['grade_class'].id"
+          student_id: "EVAL: registry['source_student'].id"
+          currency_id: "EVAL: env.company.currency_id.id"
+
+      - step: "Setup - create source payment term with detail"
+        action: "create"
+        model: "school_enrollment_payment_term"
+        save_as: "source_term"
+        values:
+          enrollment_id: "EVAL: registry['source'].id"
+          name: "Term Source CPTR2"
+          sequence: 10
+          detail_ids:
+            - - 0
+              - 0
+              - product_id: "EVAL: registry['product'].id"
+                name: "Fee CPTR2"
+                account_id: "EVAL: registry['account'].id"
+                uom_quantity: 1.0
+                uom_id: "REF: uom.product_uom_unit"
+                price_unit: 500000.0
+
+      - step: "Setup - create target student contact"
+        action: "create"
+        model: "res.partner"
+        save_as: "target_contact"
+        values:
+          name: "Target Student Contact CPTR2"
+
+      - step: "Setup - create target student"
+        action: "create"
+        model: "school_student"
+        save_as: "target_student"
+        values:
+          name: "Target Student CPTR2"
+          code: "TSTUCPTR2"
+          contact_id: "EVAL: registry['target_contact'].id"
+          school_id: "EVAL: registry['school'].id"
+
+      - step: "Setup - create target enrollment (draft, same term/school/grade)"
+        action: "create"
+        model: "school_enrollment"
+        save_as: "target"
+        values:
+          date: "2024-07-01"
+          academic_year_id: "EVAL: registry['academic_year'].id"
+          academic_term_id: "EVAL: registry['academic_term'].id"
+          school_id: "EVAL: registry['school'].id"
+          grade_id: "EVAL: registry['grade'].id"
+          grade_class_id: "EVAL: registry['grade_class'].id"
+          student_id: "EVAL: registry['target_student'].id"
+          currency_id: "EVAL: env.company.currency_id.id"
+
+      - step: "Setup - create pre-existing term on target"
+        action: "create"
+        model: "school_enrollment_payment_term"
+        save_as: "target_old_term"
+        values:
+          enrollment_id: "EVAL: registry['target'].id"
+          name: "Term Old CPTR2"
+          sequence: 5
+
+      - step: "Create copy wizard in add mode"
+        action: "create"
+        model: "school_enrollment.wizard_copy_payment_term"
+        save_as: "wizard"
+        values:
+          target_enrollment_ids:
+            - - 6
+              - 0
+              - - "EVAL: registry['target'].id"
+          source_enrollment_id: "EVAL: registry['source'].id"
+          mode: "add"
+
+      - step: "Run copy payment term"
+        action: "call"
+        target: "wizard"
+        method: "action_copy_payment_term"
+
+      - step: "Assert target now has two terms (old kept, source appended)"
+        action: "search"
+        model: "school_enrollment_payment_term"
+        domain:
+          - ["enrollment_id", "=", "EVAL: registry['target'].id"]
+        save_as: "target_terms_after"
+        expect_count: 2
+
+      - step: "Assert old term still present"
+        action: "assert"
+        target: "target_old_term"
+        asserts:
+          name:
+            type: "value"
+            expected: "Term Old CPTR2"
+          sequence:
+            type: "value"
+            expected: 5
+
+      - step: "Assert appended source term is present alongside the old one"
+        action: "search"
+        model: "school_enrollment_payment_term"
+        domain:
+          - ["enrollment_id", "=", "EVAL: registry['target'].id"]
+          - ["name", "=", "Term Source CPTR2"]
+        save_as: "appended_term"
+        expect_count: 1
+
+  - name: "Copy Payment Terms - Multi Target"
+    steps:
+      - step: "Setup - get account type ref"
+        action: "ref"
+        xml_id: "account.data_account_type_revenue"
+        save_as: "account_type"
+
+      - step: "Setup - create income account"
+        action: "create"
+        model: "account.account"
+        save_as: "account"
+        values:
+          name: "School Fee Income CPTR3"
+          code: "CPTR34200"
+          user_type_id: "EVAL: registry['account_type'].id"
+
+      - step: "Setup - create product"
+        action: "create"
+        model: "product.product"
+        save_as: "product"
+        values:
+          name: "School Fee CPTR3"
+          type: "service"
+          list_price: 500000.0
+
+      - step: "Setup - create grade type"
+        action: "create"
+        model: "school_grade_type"
+        save_as: "grade_type"
+        values:
+          name: "Grade Type CPTR3"
+          code: "GTCPTR3"
+          sequence: 10
+
+      - step: "Setup - create academic year"
+        action: "create"
+        model: "school_academic_year"
+        save_as: "academic_year"
+        values:
+          name: "2024/2025 CPTR3"
+          code: "AYCPTR3"
+          date_start: "2024-07-01"
+          date_end: "2025-06-30"
+
+      - step: "Setup - create academic term"
+        action: "create"
+        model: "school_academic_term"
+        save_as: "academic_term"
+        values:
+          name: "Semester CPTR3"
+          code: "SMCPTR3"
+          date_start: "2024-07-01"
+          date_end: "2025-06-30"
+          year_id: "EVAL: registry['academic_year'].id"
+          enrollment_state: "open"
+
+      - step: "Setup - create school"
+        action: "create"
+        model: "school"
+        save_as: "school"
+        values:
+          name: "School CPTR3"
+          code: "SCHCPTR3"
+          grade_type_id: "EVAL: registry['grade_type'].id"
+
+      - step: "Setup - create grade"
+        action: "create"
+        model: "school_grade"
+        save_as: "grade"
+        values:
+          name: "Grade CPTR3"
+          code: "GCPTR3"
+          sequence: 10
+          type_id: "EVAL: registry['grade_type'].id"
+
+      - step: "Setup - create grade class"
+        action: "create"
+        model: "school_grade_class"
+        save_as: "grade_class"
+        values:
+          name: "Class CPTR3"
+          code: "CLACPTR3"
+          school_id: "EVAL: registry['school'].id"
+          grade_id: "EVAL: registry['grade'].id"
+
+      - step: "Setup - create source student contact"
+        action: "create"
+        model: "res.partner"
+        save_as: "source_contact"
+        values:
+          name: "Source Student Contact CPTR3"
+
+      - step: "Setup - create source student"
+        action: "create"
+        model: "school_student"
+        save_as: "source_student"
+        values:
+          name: "Source Student CPTR3"
+          code: "SSTUCPTR3"
+          contact_id: "EVAL: registry['source_contact'].id"
+          school_id: "EVAL: registry['school'].id"
+
+      - step: "Setup - create source enrollment"
+        action: "create"
+        model: "school_enrollment"
+        save_as: "source"
+        values:
+          date: "2024-07-01"
+          academic_year_id: "EVAL: registry['academic_year'].id"
+          academic_term_id: "EVAL: registry['academic_term'].id"
+          school_id: "EVAL: registry['school'].id"
+          grade_id: "EVAL: registry['grade'].id"
+          grade_class_id: "EVAL: registry['grade_class'].id"
+          student_id: "EVAL: registry['source_student'].id"
+          currency_id: "EVAL: env.company.currency_id.id"
+
+      - step: "Setup - create source payment term with detail"
+        action: "create"
+        model: "school_enrollment_payment_term"
+        save_as: "source_term"
+        values:
+          enrollment_id: "EVAL: registry['source'].id"
+          name: "Term Source CPTR3"
+          sequence: 10
+          detail_ids:
+            - - 0
+              - 0
+              - product_id: "EVAL: registry['product'].id"
+                name: "Fee CPTR3"
+                account_id: "EVAL: registry['account'].id"
+                uom_quantity: 1.0
+                uom_id: "REF: uom.product_uom_unit"
+                price_unit: 500000.0
+
+      - step: "Setup - create target1 student contact"
+        action: "create"
+        model: "res.partner"
+        save_as: "target1_contact"
+        values:
+          name: "Target1 Student Contact CPTR3"
+
+      - step: "Setup - create target1 student"
+        action: "create"
+        model: "school_student"
+        save_as: "target1_student"
+        values:
+          name: "Target1 Student CPTR3"
+          code: "T1STUCPTR3"
+          contact_id: "EVAL: registry['target1_contact'].id"
+          school_id: "EVAL: registry['school'].id"
+
+      - step: "Setup - create target1 enrollment (draft)"
+        action: "create"
+        model: "school_enrollment"
+        save_as: "target1"
+        values:
+          date: "2024-07-01"
+          academic_year_id: "EVAL: registry['academic_year'].id"
+          academic_term_id: "EVAL: registry['academic_term'].id"
+          school_id: "EVAL: registry['school'].id"
+          grade_id: "EVAL: registry['grade'].id"
+          grade_class_id: "EVAL: registry['grade_class'].id"
+          student_id: "EVAL: registry['target1_student'].id"
+          currency_id: "EVAL: env.company.currency_id.id"
+
+      - step: "Setup - create target2 student contact"
+        action: "create"
+        model: "res.partner"
+        save_as: "target2_contact"
+        values:
+          name: "Target2 Student Contact CPTR3"
+
+      - step: "Setup - create target2 student"
+        action: "create"
+        model: "school_student"
+        save_as: "target2_student"
+        values:
+          name: "Target2 Student CPTR3"
+          code: "T2STUCPTR3"
+          contact_id: "EVAL: registry['target2_contact'].id"
+          school_id: "EVAL: registry['school'].id"
+
+      - step: "Setup - create target2 enrollment (draft)"
+        action: "create"
+        model: "school_enrollment"
+        save_as: "target2"
+        values:
+          date: "2024-07-01"
+          academic_year_id: "EVAL: registry['academic_year'].id"
+          academic_term_id: "EVAL: registry['academic_term'].id"
+          school_id: "EVAL: registry['school'].id"
+          grade_id: "EVAL: registry['grade'].id"
+          grade_class_id: "EVAL: registry['grade_class'].id"
+          student_id: "EVAL: registry['target2_student'].id"
+          currency_id: "EVAL: env.company.currency_id.id"
+
+      - step: "Create copy wizard for both targets"
+        action: "create"
+        model: "school_enrollment.wizard_copy_payment_term"
+        save_as: "wizard"
+        values:
+          target_enrollment_ids:
+            - - 6
+              - 0
+              - - "EVAL: registry['target1'].id"
+                - "EVAL: registry['target2'].id"
+          source_enrollment_id: "EVAL: registry['source'].id"
+          mode: "replace"
+
+      - step: "Run copy payment term"
+        action: "call"
+        target: "wizard"
+        method: "action_copy_payment_term"
+
+      - step: "Assert target1 received the term"
+        action: "search"
+        model: "school_enrollment_payment_term"
+        domain:
+          - ["enrollment_id", "=", "EVAL: registry['target1'].id"]
+          - ["name", "=", "Term Source CPTR3"]
+        save_as: "target1_term"
+        expect_count: 1
+
+      - step: "Assert target2 received the term"
+        action: "search"
+        model: "school_enrollment_payment_term"
+        domain:
+          - ["enrollment_id", "=", "EVAL: registry['target2'].id"]
+          - ["name", "=", "Term Source CPTR3"]
+        save_as: "target2_term"
+        expect_count: 1

--- a/ssi_school/tests/test_school_enrollment_copy_payment_term.py
+++ b/ssi_school/tests/test_school_enrollment_copy_payment_term.py
@@ -1,0 +1,201 @@
+# Copyright 2026 OpenSynergy Indonesia
+# Copyright 2026 PT. Simetri Sinergi Indonesia
+# License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl).
+
+from odoo_yaml_test import YamlTransactionCase
+
+from odoo.exceptions import UserError
+from odoo.tests import tagged
+
+
+@tagged("post_install", "-at_install")
+class TestSchoolEnrollmentCopyPaymentTerm(YamlTransactionCase):
+    def test_enrollment_copy_payment_term(self):
+        self.run_yaml_scenario("test_data_enrollment_copy_payment_term.yaml")
+
+    def _create_base_data(self, suffix):
+        account_type = self.env.ref("account.data_account_type_revenue")
+        account = self.env["account.account"].create(
+            {
+                "name": "School Fee Income %s" % suffix,
+                "code": "CPTRBLK%s4200" % suffix,
+                "user_type_id": account_type.id,
+            }
+        )
+        product = self.env["product.product"].create(
+            {
+                "name": "School Fee %s" % suffix,
+                "type": "service",
+                "list_price": 500000.0,
+            }
+        )
+        grade_type = self.env["school_grade_type"].create(
+            {
+                "name": "Grade Type %s" % suffix,
+                "code": "GT%s" % suffix,
+                "sequence": 10,
+            }
+        )
+        academic_year = self.env["school_academic_year"].create(
+            {
+                "name": "2024/2025 %s" % suffix,
+                "code": "AY%s" % suffix,
+                "date_start": "2024-07-01",
+                "date_end": "2025-06-30",
+            }
+        )
+        academic_term = self.env["school_academic_term"].create(
+            {
+                "name": "Semester %s" % suffix,
+                "code": "SM%s" % suffix,
+                "date_start": "2024-07-01",
+                "date_end": "2025-06-30",
+                "year_id": academic_year.id,
+                "enrollment_state": "open",
+            }
+        )
+        school = self.env["school"].create(
+            {
+                "name": "School %s" % suffix,
+                "code": "SCH%s" % suffix,
+                "grade_type_id": grade_type.id,
+            }
+        )
+        grade = self.env["school_grade"].create(
+            {
+                "name": "Grade %s" % suffix,
+                "code": "G%s" % suffix,
+                "sequence": 10,
+                "type_id": grade_type.id,
+            }
+        )
+        grade_class = self.env["school_grade_class"].create(
+            {
+                "name": "Class %s" % suffix,
+                "code": "CLA%s" % suffix,
+                "school_id": school.id,
+                "grade_id": grade.id,
+            }
+        )
+        return {
+            "account": account,
+            "product": product,
+            "academic_year": academic_year,
+            "academic_term": academic_term,
+            "school": school,
+            "grade": grade,
+            "grade_class": grade_class,
+        }
+
+    def _create_enrollment(self, base, name_suffix, grade=None, grade_class=None):
+        contact = self.env["res.partner"].create(
+            {"name": "Student Contact %s" % name_suffix}
+        )
+        student = self.env["school_student"].create(
+            {
+                "name": "Student %s" % name_suffix,
+                "code": "STU%s" % name_suffix,
+                "contact_id": contact.id,
+                "school_id": base["school"].id,
+            }
+        )
+        return self.env["school_enrollment"].create(
+            {
+                "date": "2024-07-01",
+                "academic_year_id": base["academic_year"].id,
+                "academic_term_id": base["academic_term"].id,
+                "school_id": base["school"].id,
+                "grade_id": (grade or base["grade"]).id,
+                "grade_class_id": (grade_class or base["grade_class"]).id,
+                "student_id": student.id,
+                "currency_id": self.env.company.currency_id.id,
+            }
+        )
+
+    def _create_source_term(self, base, source):
+        term = self.env["school_enrollment_payment_term"].create(
+            {
+                "enrollment_id": source.id,
+                "name": "Term Source %s" % source.id,
+                "sequence": 10,
+            }
+        )
+        self.env["school_enrollment_payment_term_detail"].create(
+            {
+                "term_id": term.id,
+                "product_id": base["product"].id,
+                "name": "Fee %s" % source.id,
+                "account_id": base["account"].id,
+                "uom_quantity": 1.0,
+                "uom_id": self.env.ref("uom.product_uom_unit").id,
+                "price_unit": 500000.0,
+            }
+        )
+        return term
+
+    def test_copy_payment_term_blocked_when_target_not_draft(self):
+        base = self._create_base_data("BLK1")
+        source = self._create_enrollment(base, "BLK1SRC")
+        self._create_source_term(base, source)
+        target = self._create_enrollment(base, "BLK1TGT")
+        target.write({"state": "confirm"})
+
+        wizard = (
+            self.env["school_enrollment.wizard_copy_payment_term"]
+            .with_context(active_model="school_enrollment", active_ids=target.ids)
+            .create(
+                {
+                    "source_enrollment_id": source.id,
+                    "mode": "replace",
+                }
+            )
+        )
+        self.assertEqual(wizard.target_enrollment_ids, target)
+        self.assertFalse(target.copy_payment_term_ok)
+
+        with self.assertRaises(UserError):
+            wizard.action_copy_payment_term()
+
+        self.assertFalse(target.payment_term_ids)
+
+    def test_copy_payment_term_blocked_when_grade_mismatch(self):
+        base = self._create_base_data("BLK2")
+        source = self._create_enrollment(base, "BLK2SRC")
+        self._create_source_term(base, source)
+
+        other_grade = self.env["school_grade"].create(
+            {
+                "name": "Other Grade BLK2",
+                "code": "OGBLK2",
+                "sequence": 20,
+                "type_id": base["grade"].type_id.id,
+            }
+        )
+        other_grade_class = self.env["school_grade_class"].create(
+            {
+                "name": "Other Class BLK2",
+                "code": "OCLABLK2",
+                "school_id": base["school"].id,
+                "grade_id": other_grade.id,
+            }
+        )
+        target = self._create_enrollment(
+            base, "BLK2TGT", grade=other_grade, grade_class=other_grade_class
+        )
+
+        wizard = (
+            self.env["school_enrollment.wizard_copy_payment_term"]
+            .with_context(active_model="school_enrollment", active_ids=target.ids)
+            .create(
+                {
+                    "source_enrollment_id": source.id,
+                    "mode": "replace",
+                }
+            )
+        )
+        self.assertTrue(target.copy_payment_term_ok)
+
+        with self.assertRaises(UserError):
+            wizard.action_copy_payment_term()
+
+        self.assertFalse(target.payment_term_ids)

--- a/ssi_school/wizards/__init__.py
+++ b/ssi_school/wizards/__init__.py
@@ -3,3 +3,4 @@
 # License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl).
 
 from . import school_enrollment_payment_term_duplicate  # noqa: F401
+from . import school_enrollment_copy_payment_term  # noqa: F401

--- a/ssi_school/wizards/school_enrollment_copy_payment_term.py
+++ b/ssi_school/wizards/school_enrollment_copy_payment_term.py
@@ -1,0 +1,133 @@
+# Copyright 2026 OpenSynergy Indonesia
+# Copyright 2026 PT. Simetri Sinergi Indonesia
+# License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl).
+
+from odoo import _, api, fields, models
+from odoo.exceptions import UserError
+
+
+class SchoolEnrollmentWizardCopyPaymentTerm(models.TransientModel):
+    """
+    Wizard that copies all payment terms (and their detail lines) from one source
+    enrollment to one or more target enrollments selected from the school_enrollment
+    list view. Mode "replace" deletes the existing payment terms on each target before
+    copying; mode "add" appends the source terms to each target's existing terms. Every
+    target must be allowed by the copy_payment_term_ok policy (state and group,
+    configurable via Policy Template) and must share the same academic term, school,
+    and grade as the source. All targets are validated before any change is applied.
+    """
+
+    _name = "school_enrollment.wizard_copy_payment_term"
+    _description = "Copy Payment Terms Between Enrollments"
+
+    target_enrollment_ids = fields.Many2many(
+        string="Target Enrollments",
+        comodel_name="school_enrollment",
+        readonly=True,
+        help=(
+            "Draft enrollments selected from the list view that will "
+            "receive the copied payment terms."
+        ),
+    )
+    source_enrollment_id = fields.Many2one(
+        string="Source Enrollment",
+        comodel_name="school_enrollment",
+        required=True,
+        domain="[('id', 'not in', target_enrollment_ids)]",
+        help="The enrollment whose payment terms (and detail lines) will be copied.",
+    )
+    mode = fields.Selection(
+        string="Mode",
+        selection=[
+            ("replace", "Replace"),
+            ("add", "Add"),
+        ],
+        default="replace",
+        required=True,
+        help=(
+            "Replace: delete existing payment terms on each target before copying. "
+            "Add: append source terms to each target's existing terms."
+        ),
+    )
+
+    @api.model
+    def default_get(self, fields_list):
+        res = super().default_get(fields_list)
+        if self.env.context.get("active_model") == "school_enrollment":
+            active_ids = self.env.context.get("active_ids", [])
+            res["target_enrollment_ids"] = [(6, 0, active_ids)]
+        return res
+
+    def action_copy_payment_term(self):
+        for record in self.sudo():
+            record._copy_payment_term()  # pylint: disable=protected-access
+        return {"type": "ir.actions.act_window_close"}
+
+    def _copy_payment_term(self):
+        self.ensure_one()
+        if not self.target_enrollment_ids:
+            error_message = (
+                _(
+                    """
+Context: Copy payment terms between enrollments
+Database ID: %s
+Problem: No target enrollment selected
+Solution: Select at least one draft enrollment from the list view before running this wizard
+"""
+                )
+                % (self.id,)
+            )
+            raise UserError(error_message)
+        self._check_target_enrollments()
+        source = self.source_enrollment_id
+        for target in self.target_enrollment_ids:
+            if self.mode == "replace":
+                target.payment_term_ids.unlink()
+            for term in source.payment_term_ids.sorted("sequence"):
+                new_term = term.copy(
+                    {
+                        "enrollment_id": target.id,
+                        "invoice_id": False,
+                    }
+                )
+                new_term.detail_ids.write({"invoice_line_id": False})
+
+    def _check_target_enrollments(self):
+        self.ensure_one()
+        source = self.source_enrollment_id
+        problems = []
+        for target in self.target_enrollment_ids:
+            if not target.copy_payment_term_ok:
+                problems.append(
+                    _("- %s: not allowed to receive payment terms (check state/policy)")
+                    % target.name
+                )
+            elif (
+                target.academic_term_id != source.academic_term_id
+                or target.school_id != source.school_id
+                or target.grade_id != source.grade_id
+            ):
+                problems.append(
+                    _("- %s: academic term/school/grade does not match the source")
+                    % target.name
+                )
+        if problems:
+            error_message = (
+                _(
+                    """
+Context: Copy payment terms from enrollment '%s'
+Database ID: %s
+Problem: The following target enrollment(s) cannot receive payment terms:
+%s
+Solution: Deselect the listed enrollment(s), or make sure they are draft, allowed by
+the copy payment term policy, and share the same academic term/school/grade as the
+source
+"""
+                )
+                % (
+                    source.name,
+                    self.id,
+                    "\n".join(problems),
+                )
+            )
+            raise UserError(error_message)

--- a/ssi_school/wizards/school_enrollment_copy_payment_term.py
+++ b/ssi_school/wizards/school_enrollment_copy_payment_term.py
@@ -23,6 +23,9 @@ class SchoolEnrollmentWizardCopyPaymentTerm(models.TransientModel):
     target_enrollment_ids = fields.Many2many(
         string="Target Enrollments",
         comodel_name="school_enrollment",
+        relation="rel_school_enrollment_copy_payment_term_target",
+        column1="wizard_id",
+        column2="enrollment_id",
         readonly=True,
         help=(
             "Draft enrollments selected from the list view that will "

--- a/ssi_school/wizards/school_enrollment_copy_payment_term.xml
+++ b/ssi_school/wizards/school_enrollment_copy_payment_term.xml
@@ -1,0 +1,46 @@
+<?xml version="1.0" encoding="utf-8" ?>
+<!-- Copyright 2026 OpenSynergy Indonesia
+     Copyright 2026 PT. Simetri Sinergi Indonesia
+     License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl). -->
+<odoo>
+
+<record id="school_enrollment_wizard_copy_payment_term_view_form" model="ir.ui.view">
+    <field name="name">school_enrollment.wizard_copy_payment_term - form</field>
+    <field name="model">school_enrollment.wizard_copy_payment_term</field>
+    <field name="arch" type="xml">
+        <form string="Copy Payment Terms">
+            <group name="main" colspan="4" col="2">
+                <field
+                        name="target_enrollment_ids"
+                        widget="many2many_tags"
+                        colspan="2"
+                    />
+                <field name="source_enrollment_id" />
+                <field name="mode" widget="radio" />
+            </group>
+            <footer>
+                <button
+                        name="action_copy_payment_term"
+                        type="object"
+                        string="Copy Payment Terms"
+                        class="btn-primary"
+                    />
+                <button string="Cancel" class="btn-default" special="cancel" />
+            </footer>
+        </form>
+    </field>
+</record>
+
+<record
+        id="school_enrollment_wizard_copy_payment_term_action"
+        model="ir.actions.act_window"
+    >
+    <field name="name">Copy Payment Terms</field>
+    <field name="type">ir.actions.act_window</field>
+    <field name="res_model">school_enrollment.wizard_copy_payment_term</field>
+    <field name="view_mode">form</field>
+    <field name="target">new</field>
+    <field name="binding_model_id" ref="model_school_enrollment" />
+</record>
+
+</odoo>

--- a/ssi_school_admission/__manifest__.py
+++ b/ssi_school_admission/__manifest__.py
@@ -61,6 +61,7 @@
         "ir_model_access/school_admission_payment_template.xml",
         "ir_model_access/school_admission_payment_term.xml",
         "ir_model_access/school_admission_payment_term_wizard_duplicate.xml",
+        "ir_model_access/school_admission_wizard_copy_payment_term.xml",
         "ir_rule/school_admission.xml",
         "ir_sequence/school_admission.xml",
         "sequence_template/school_admission.xml",
@@ -71,6 +72,7 @@
         "views/school_admission_payment_term.xml",
         "views/school_admission.xml",
         "wizards/school_admission_payment_term_duplicate.xml",
+        "wizards/school_admission_copy_payment_term.xml",
     ],
     "demo": [
         "demo/account_account_demo.xml",

--- a/ssi_school_admission/ir_model_access/school_admission_wizard_copy_payment_term.xml
+++ b/ssi_school_admission/ir_model_access/school_admission_wizard_copy_payment_term.xml
@@ -1,0 +1,20 @@
+<?xml version="1.0" encoding="utf-8" ?>
+<!-- Copyright 2026 OpenSynergy Indonesia
+     Copyright 2026 PT. Simetri Sinergi Indonesia
+     License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl). -->
+<odoo>
+
+<record
+        id="school_admission_wizard_copy_payment_term_user_access"
+        model="ir.model.access"
+    >
+    <field name="name">school_admission.wizard_copy_payment_term - user</field>
+    <field name="model_id" ref="model_school_admission_wizard_copy_payment_term" />
+    <field name="group_id" ref="school_admission_user_group" />
+    <field name="perm_read" eval="1" />
+    <field name="perm_create" eval="1" />
+    <field name="perm_write" eval="1" />
+    <field name="perm_unlink" eval="1" />
+</record>
+
+</odoo>

--- a/ssi_school_admission/models/school_admission.py
+++ b/ssi_school_admission/models/school_admission.py
@@ -247,6 +247,16 @@ class SchoolAdmission(models.Model):
         readonly=True,
         help=("The student profile created when this " "admission is opened."),
     )
+    copy_payment_term_ok = fields.Boolean(
+        string="Can Copy Payment Term",
+        compute="_compute_policy",
+        store=False,
+        compute_sudo=True,
+        help=(
+            "Policy that determines whether payment terms may be "
+            "copied into this admission."
+        ),
+    )
 
     def _compute_policy(self):  # pylint: disable=missing-return
         _super = super()
@@ -409,6 +419,7 @@ class SchoolAdmission(models.Model):
             "restart_ok",
             "restart_approval_ok",
             "manual_number_ok",
+            "copy_payment_term_ok",
         ]
         res += policy_field
         return res

--- a/ssi_school_admission/policy_template/school_admission.xml
+++ b/ssi_school_admission/policy_template/school_admission.xml
@@ -32,6 +32,27 @@
     <field name="restrict_additional" eval="0" />
 </record>
 
+<!-- Copy Payment Term -->
+<record
+        id="policy_template_school_admission_copy_payment_term"
+        model="policy.template_detail"
+    >
+    <field name="template_id" ref="policy_template_school_admission" />
+    <field
+            name="field_id"
+            search="[('model_id.model','=','school_admission'),('name','=','copy_payment_term_ok')]"
+        />
+    <field name="restrict_state" eval="1" />
+    <field
+            name="state_ids"
+            search="[('field_id.model_id.model','=','school_admission'),('value','=','draft')]"
+        />
+    <field name="restrict_user" eval="1" />
+    <field name="computation_method">use_group</field>
+    <field name="group_ids" eval="[(6,0,[ref('school_admission_user_group')])]" />
+    <field name="restrict_additional" eval="0" />
+</record>
+
 <!-- Done -->
 <record id="policy_template_school_admission_done" model="policy.template_detail">
     <field name="template_id" ref="policy_template_school_admission" />

--- a/ssi_school_admission/tests/__init__.py
+++ b/ssi_school_admission/tests/__init__.py
@@ -9,6 +9,7 @@ from . import (  # noqa: F401
     test_school_admission_payment_date_pattern,
     test_school_admission_payment_term,
     test_school_admission_payment_term_duplicate,
+    test_school_admission_copy_payment_term,
     test_school_admission_product_summary,
     test_school_admission_test,
     test_school_admission_wizards,

--- a/ssi_school_admission/tests/test_data_admission_copy_payment_term.yaml
+++ b/ssi_school_admission/tests/test_data_admission_copy_payment_term.yaml
@@ -1,0 +1,599 @@
+scenarios:
+  - name: "Copy Payment Terms - Replace Mode"
+    steps:
+      - step: "Setup - get account type ref"
+        action: "ref"
+        xml_id: "account.data_account_type_revenue"
+        save_as: "account_type"
+
+      - step: "Setup - create income account"
+        action: "create"
+        model: "account.account"
+        save_as: "account"
+        values:
+          name: "Admission Fee Income ACPTR1"
+          code: "ACPTR14200"
+          user_type_id: "EVAL: registry['account_type'].id"
+
+      - step: "Setup - create product"
+        action: "create"
+        model: "product.product"
+        save_as: "product"
+        values:
+          name: "Admission Fee ACPTR1"
+          type: "service"
+          list_price: 500000.0
+
+      - step: "Setup - create grade type"
+        action: "create"
+        model: "school_grade_type"
+        save_as: "grade_type"
+        values:
+          name: "Grade Type ACPTR1"
+          code: "GTACPTR1"
+          sequence: 10
+
+      - step: "Setup - create academic year"
+        action: "create"
+        model: "school_academic_year"
+        save_as: "academic_year"
+        values:
+          name: "2024/2025 ACPTR1"
+          code: "AYACPTR1"
+          date_start: "2024-07-01"
+          date_end: "2025-06-30"
+
+      - step: "Setup - create academic term"
+        action: "create"
+        model: "school_academic_term"
+        save_as: "academic_term"
+        values:
+          name: "Semester ACPTR1"
+          code: "SMACPTR1"
+          date_start: "2024-07-01"
+          date_end: "2025-06-30"
+          year_id: "EVAL: registry['academic_year'].id"
+          enrollment_state: "open"
+
+      - step: "Setup - create school"
+        action: "create"
+        model: "school"
+        save_as: "school"
+        values:
+          name: "School ACPTR1"
+          code: "SCHACPTR1"
+          grade_type_id: "EVAL: registry['grade_type'].id"
+
+      - step: "Setup - create grade"
+        action: "create"
+        model: "school_grade"
+        save_as: "grade"
+        values:
+          name: "Grade ACPTR1"
+          code: "GACPTR1"
+          sequence: 10
+          type_id: "EVAL: registry['grade_type'].id"
+
+      - step: "Setup - create source student contact"
+        action: "create"
+        model: "res.partner"
+        save_as: "source_contact"
+        values:
+          name: "Source Student Contact ACPTR1"
+
+      - step: "Setup - create source admission"
+        action: "create"
+        model: "school_admission"
+        save_as: "source"
+        values:
+          date: "2024-07-01"
+          academic_year_id: "EVAL: registry['academic_year'].id"
+          academic_term_id: "EVAL: registry['academic_term'].id"
+          school_id: "EVAL: registry['school'].id"
+          grade_id: "EVAL: registry['grade'].id"
+          student_id: "EVAL: registry['source_contact'].id"
+          currency_id: "EVAL: env.company.currency_id.id"
+
+      - step: "Setup - create source payment term with detail"
+        action: "create"
+        model: "school_admission_payment_term"
+        save_as: "source_term"
+        values:
+          admission_id: "EVAL: registry['source'].id"
+          name: "Term Source ACPTR1"
+          sequence: 10
+          date_invoice: "2024-08-01"
+          date_due: "2024-08-15"
+          detail_ids:
+            - - 0
+              - 0
+              - product_id: "EVAL: registry['product'].id"
+                name: "Fee ACPTR1"
+                account_id: "EVAL: registry['account'].id"
+                uom_quantity: 1.0
+                uom_id: "REF: uom.product_uom_unit"
+                price_unit: 500000.0
+
+      - step: "Setup - create target student contact"
+        action: "create"
+        model: "res.partner"
+        save_as: "target_contact"
+        values:
+          name: "Target Student Contact ACPTR1"
+
+      - step: "Setup - create target admission (draft, same term/school/grade)"
+        action: "create"
+        model: "school_admission"
+        save_as: "target"
+        values:
+          date: "2024-07-01"
+          academic_year_id: "EVAL: registry['academic_year'].id"
+          academic_term_id: "EVAL: registry['academic_term'].id"
+          school_id: "EVAL: registry['school'].id"
+          grade_id: "EVAL: registry['grade'].id"
+          student_id: "EVAL: registry['target_contact'].id"
+          currency_id: "EVAL: env.company.currency_id.id"
+
+      - step: "Setup - create pre-existing term on target"
+        action: "create"
+        model: "school_admission_payment_term"
+        save_as: "target_old_term"
+        values:
+          admission_id: "EVAL: registry['target'].id"
+          name: "Term Old ACPTR1"
+          sequence: 5
+
+      - step: "Create copy wizard in replace mode"
+        action: "create"
+        model: "school_admission.wizard_copy_payment_term"
+        save_as: "wizard"
+        values:
+          target_admission_ids:
+            - - 6
+              - 0
+              - - "EVAL: registry['target'].id"
+          source_admission_id: "EVAL: registry['source'].id"
+          mode: "replace"
+
+      - step: "Run copy payment term"
+        action: "call"
+        target: "wizard"
+        method: "action_copy_payment_term"
+
+      - step: "Assert target has exactly one term (old one replaced)"
+        action: "search"
+        model: "school_admission_payment_term"
+        domain:
+          - ["admission_id", "=", "EVAL: registry['target'].id"]
+        save_as: "target_terms_after"
+        expect_count: 1
+
+      - step: "Search the copied term on target"
+        action: "search"
+        model: "school_admission_payment_term"
+        domain:
+          - ["admission_id", "=", "EVAL: registry['target'].id"]
+          - ["name", "=", "Term Source ACPTR1"]
+        save_as: "copied_term"
+        expect_count: 1
+
+      - step: "Assert copied term matches source and has no invoice"
+        action: "assert"
+        target: "copied_term"
+        asserts:
+          sequence:
+            type: "value"
+            expected: 10
+          invoice_id:
+            type: "value"
+            operator: "is_falsy"
+          detail_ids:
+            type: "o2m"
+            check: "count"
+            expected_count: 1
+
+      - step: "Search copied detail line"
+        action: "search"
+        model: "school_admission_payment_term_detail"
+        domain:
+          - ["term_id", "=", "EVAL: registry['copied_term'].id"]
+        save_as: "copied_detail"
+        expect_count: 1
+
+      - step: "Assert copied detail matches source and has no invoice line"
+        action: "assert"
+        target: "copied_detail"
+        asserts:
+          name:
+            type: "value"
+            expected: "Fee ACPTR1"
+          price_unit:
+            type: "value"
+            expected: 500000.0
+          invoice_line_id:
+            type: "value"
+            operator: "is_falsy"
+
+      - step: "Assert source term is untouched"
+        action: "assert"
+        target: "source_term"
+        asserts:
+          name:
+            type: "value"
+            expected: "Term Source ACPTR1"
+
+  - name: "Copy Payment Terms - Add Mode"
+    steps:
+      - step: "Setup - get account type ref"
+        action: "ref"
+        xml_id: "account.data_account_type_revenue"
+        save_as: "account_type"
+
+      - step: "Setup - create income account"
+        action: "create"
+        model: "account.account"
+        save_as: "account"
+        values:
+          name: "Admission Fee Income ACPTR2"
+          code: "ACPTR24200"
+          user_type_id: "EVAL: registry['account_type'].id"
+
+      - step: "Setup - create product"
+        action: "create"
+        model: "product.product"
+        save_as: "product"
+        values:
+          name: "Admission Fee ACPTR2"
+          type: "service"
+          list_price: 500000.0
+
+      - step: "Setup - create grade type"
+        action: "create"
+        model: "school_grade_type"
+        save_as: "grade_type"
+        values:
+          name: "Grade Type ACPTR2"
+          code: "GTACPTR2"
+          sequence: 10
+
+      - step: "Setup - create academic year"
+        action: "create"
+        model: "school_academic_year"
+        save_as: "academic_year"
+        values:
+          name: "2024/2025 ACPTR2"
+          code: "AYACPTR2"
+          date_start: "2024-07-01"
+          date_end: "2025-06-30"
+
+      - step: "Setup - create academic term"
+        action: "create"
+        model: "school_academic_term"
+        save_as: "academic_term"
+        values:
+          name: "Semester ACPTR2"
+          code: "SMACPTR2"
+          date_start: "2024-07-01"
+          date_end: "2025-06-30"
+          year_id: "EVAL: registry['academic_year'].id"
+          enrollment_state: "open"
+
+      - step: "Setup - create school"
+        action: "create"
+        model: "school"
+        save_as: "school"
+        values:
+          name: "School ACPTR2"
+          code: "SCHACPTR2"
+          grade_type_id: "EVAL: registry['grade_type'].id"
+
+      - step: "Setup - create grade"
+        action: "create"
+        model: "school_grade"
+        save_as: "grade"
+        values:
+          name: "Grade ACPTR2"
+          code: "GACPTR2"
+          sequence: 10
+          type_id: "EVAL: registry['grade_type'].id"
+
+      - step: "Setup - create source student contact"
+        action: "create"
+        model: "res.partner"
+        save_as: "source_contact"
+        values:
+          name: "Source Student Contact ACPTR2"
+
+      - step: "Setup - create source admission"
+        action: "create"
+        model: "school_admission"
+        save_as: "source"
+        values:
+          date: "2024-07-01"
+          academic_year_id: "EVAL: registry['academic_year'].id"
+          academic_term_id: "EVAL: registry['academic_term'].id"
+          school_id: "EVAL: registry['school'].id"
+          grade_id: "EVAL: registry['grade'].id"
+          student_id: "EVAL: registry['source_contact'].id"
+          currency_id: "EVAL: env.company.currency_id.id"
+
+      - step: "Setup - create source payment term with detail"
+        action: "create"
+        model: "school_admission_payment_term"
+        save_as: "source_term"
+        values:
+          admission_id: "EVAL: registry['source'].id"
+          name: "Term Source ACPTR2"
+          sequence: 10
+          detail_ids:
+            - - 0
+              - 0
+              - product_id: "EVAL: registry['product'].id"
+                name: "Fee ACPTR2"
+                account_id: "EVAL: registry['account'].id"
+                uom_quantity: 1.0
+                uom_id: "REF: uom.product_uom_unit"
+                price_unit: 500000.0
+
+      - step: "Setup - create target student contact"
+        action: "create"
+        model: "res.partner"
+        save_as: "target_contact"
+        values:
+          name: "Target Student Contact ACPTR2"
+
+      - step: "Setup - create target admission (draft, same term/school/grade)"
+        action: "create"
+        model: "school_admission"
+        save_as: "target"
+        values:
+          date: "2024-07-01"
+          academic_year_id: "EVAL: registry['academic_year'].id"
+          academic_term_id: "EVAL: registry['academic_term'].id"
+          school_id: "EVAL: registry['school'].id"
+          grade_id: "EVAL: registry['grade'].id"
+          student_id: "EVAL: registry['target_contact'].id"
+          currency_id: "EVAL: env.company.currency_id.id"
+
+      - step: "Setup - create pre-existing term on target"
+        action: "create"
+        model: "school_admission_payment_term"
+        save_as: "target_old_term"
+        values:
+          admission_id: "EVAL: registry['target'].id"
+          name: "Term Old ACPTR2"
+          sequence: 5
+
+      - step: "Create copy wizard in add mode"
+        action: "create"
+        model: "school_admission.wizard_copy_payment_term"
+        save_as: "wizard"
+        values:
+          target_admission_ids:
+            - - 6
+              - 0
+              - - "EVAL: registry['target'].id"
+          source_admission_id: "EVAL: registry['source'].id"
+          mode: "add"
+
+      - step: "Run copy payment term"
+        action: "call"
+        target: "wizard"
+        method: "action_copy_payment_term"
+
+      - step: "Assert target now has two terms (old kept, source appended)"
+        action: "search"
+        model: "school_admission_payment_term"
+        domain:
+          - ["admission_id", "=", "EVAL: registry['target'].id"]
+        save_as: "target_terms_after"
+        expect_count: 2
+
+      - step: "Assert old term still present"
+        action: "assert"
+        target: "target_old_term"
+        asserts:
+          name:
+            type: "value"
+            expected: "Term Old ACPTR2"
+          sequence:
+            type: "value"
+            expected: 5
+
+      - step: "Assert appended source term is present alongside the old one"
+        action: "search"
+        model: "school_admission_payment_term"
+        domain:
+          - ["admission_id", "=", "EVAL: registry['target'].id"]
+          - ["name", "=", "Term Source ACPTR2"]
+        save_as: "appended_term"
+        expect_count: 1
+
+  - name: "Copy Payment Terms - Multi Target"
+    steps:
+      - step: "Setup - get account type ref"
+        action: "ref"
+        xml_id: "account.data_account_type_revenue"
+        save_as: "account_type"
+
+      - step: "Setup - create income account"
+        action: "create"
+        model: "account.account"
+        save_as: "account"
+        values:
+          name: "Admission Fee Income ACPTR3"
+          code: "ACPTR34200"
+          user_type_id: "EVAL: registry['account_type'].id"
+
+      - step: "Setup - create product"
+        action: "create"
+        model: "product.product"
+        save_as: "product"
+        values:
+          name: "Admission Fee ACPTR3"
+          type: "service"
+          list_price: 500000.0
+
+      - step: "Setup - create grade type"
+        action: "create"
+        model: "school_grade_type"
+        save_as: "grade_type"
+        values:
+          name: "Grade Type ACPTR3"
+          code: "GTACPTR3"
+          sequence: 10
+
+      - step: "Setup - create academic year"
+        action: "create"
+        model: "school_academic_year"
+        save_as: "academic_year"
+        values:
+          name: "2024/2025 ACPTR3"
+          code: "AYACPTR3"
+          date_start: "2024-07-01"
+          date_end: "2025-06-30"
+
+      - step: "Setup - create academic term"
+        action: "create"
+        model: "school_academic_term"
+        save_as: "academic_term"
+        values:
+          name: "Semester ACPTR3"
+          code: "SMACPTR3"
+          date_start: "2024-07-01"
+          date_end: "2025-06-30"
+          year_id: "EVAL: registry['academic_year'].id"
+          enrollment_state: "open"
+
+      - step: "Setup - create school"
+        action: "create"
+        model: "school"
+        save_as: "school"
+        values:
+          name: "School ACPTR3"
+          code: "SCHACPTR3"
+          grade_type_id: "EVAL: registry['grade_type'].id"
+
+      - step: "Setup - create grade"
+        action: "create"
+        model: "school_grade"
+        save_as: "grade"
+        values:
+          name: "Grade ACPTR3"
+          code: "GACPTR3"
+          sequence: 10
+          type_id: "EVAL: registry['grade_type'].id"
+
+      - step: "Setup - create source student contact"
+        action: "create"
+        model: "res.partner"
+        save_as: "source_contact"
+        values:
+          name: "Source Student Contact ACPTR3"
+
+      - step: "Setup - create source admission"
+        action: "create"
+        model: "school_admission"
+        save_as: "source"
+        values:
+          date: "2024-07-01"
+          academic_year_id: "EVAL: registry['academic_year'].id"
+          academic_term_id: "EVAL: registry['academic_term'].id"
+          school_id: "EVAL: registry['school'].id"
+          grade_id: "EVAL: registry['grade'].id"
+          student_id: "EVAL: registry['source_contact'].id"
+          currency_id: "EVAL: env.company.currency_id.id"
+
+      - step: "Setup - create source payment term with detail"
+        action: "create"
+        model: "school_admission_payment_term"
+        save_as: "source_term"
+        values:
+          admission_id: "EVAL: registry['source'].id"
+          name: "Term Source ACPTR3"
+          sequence: 10
+          detail_ids:
+            - - 0
+              - 0
+              - product_id: "EVAL: registry['product'].id"
+                name: "Fee ACPTR3"
+                account_id: "EVAL: registry['account'].id"
+                uom_quantity: 1.0
+                uom_id: "REF: uom.product_uom_unit"
+                price_unit: 500000.0
+
+      - step: "Setup - create target1 student contact"
+        action: "create"
+        model: "res.partner"
+        save_as: "target1_contact"
+        values:
+          name: "Target1 Student Contact ACPTR3"
+
+      - step: "Setup - create target1 admission (draft)"
+        action: "create"
+        model: "school_admission"
+        save_as: "target1"
+        values:
+          date: "2024-07-01"
+          academic_year_id: "EVAL: registry['academic_year'].id"
+          academic_term_id: "EVAL: registry['academic_term'].id"
+          school_id: "EVAL: registry['school'].id"
+          grade_id: "EVAL: registry['grade'].id"
+          student_id: "EVAL: registry['target1_contact'].id"
+          currency_id: "EVAL: env.company.currency_id.id"
+
+      - step: "Setup - create target2 student contact"
+        action: "create"
+        model: "res.partner"
+        save_as: "target2_contact"
+        values:
+          name: "Target2 Student Contact ACPTR3"
+
+      - step: "Setup - create target2 admission (draft)"
+        action: "create"
+        model: "school_admission"
+        save_as: "target2"
+        values:
+          date: "2024-07-01"
+          academic_year_id: "EVAL: registry['academic_year'].id"
+          academic_term_id: "EVAL: registry['academic_term'].id"
+          school_id: "EVAL: registry['school'].id"
+          grade_id: "EVAL: registry['grade'].id"
+          student_id: "EVAL: registry['target2_contact'].id"
+          currency_id: "EVAL: env.company.currency_id.id"
+
+      - step: "Create copy wizard for both targets"
+        action: "create"
+        model: "school_admission.wizard_copy_payment_term"
+        save_as: "wizard"
+        values:
+          target_admission_ids:
+            - - 6
+              - 0
+              - - "EVAL: registry['target1'].id"
+                - "EVAL: registry['target2'].id"
+          source_admission_id: "EVAL: registry['source'].id"
+          mode: "replace"
+
+      - step: "Run copy payment term"
+        action: "call"
+        target: "wizard"
+        method: "action_copy_payment_term"
+
+      - step: "Assert target1 received the term"
+        action: "search"
+        model: "school_admission_payment_term"
+        domain:
+          - ["admission_id", "=", "EVAL: registry['target1'].id"]
+          - ["name", "=", "Term Source ACPTR3"]
+        save_as: "target1_term"
+        expect_count: 1
+
+      - step: "Assert target2 received the term"
+        action: "search"
+        model: "school_admission_payment_term"
+        domain:
+          - ["admission_id", "=", "EVAL: registry['target2'].id"]
+          - ["name", "=", "Term Source ACPTR3"]
+        save_as: "target2_term"
+        expect_count: 1

--- a/ssi_school_admission/tests/test_school_admission_copy_payment_term.py
+++ b/ssi_school_admission/tests/test_school_admission_copy_payment_term.py
@@ -1,0 +1,173 @@
+# Copyright 2026 OpenSynergy Indonesia
+# Copyright 2026 PT. Simetri Sinergi Indonesia
+# License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl).
+
+from odoo_yaml_test import YamlTransactionCase
+
+from odoo.exceptions import UserError
+from odoo.tests import tagged
+
+
+@tagged("post_install", "-at_install")
+class TestSchoolAdmissionCopyPaymentTerm(YamlTransactionCase):
+    def test_admission_copy_payment_term(self):
+        self.run_yaml_scenario("test_data_admission_copy_payment_term.yaml")
+
+    def _create_base_data(self, suffix):
+        account_type = self.env.ref("account.data_account_type_revenue")
+        account = self.env["account.account"].create(
+            {
+                "name": "Admission Fee Income %s" % suffix,
+                "code": "ACPTRBLK%s4200" % suffix,
+                "user_type_id": account_type.id,
+            }
+        )
+        product = self.env["product.product"].create(
+            {
+                "name": "Admission Fee %s" % suffix,
+                "type": "service",
+                "list_price": 500000.0,
+            }
+        )
+        grade_type = self.env["school_grade_type"].create(
+            {
+                "name": "Grade Type %s" % suffix,
+                "code": "GT%s" % suffix,
+                "sequence": 10,
+            }
+        )
+        academic_year = self.env["school_academic_year"].create(
+            {
+                "name": "2024/2025 %s" % suffix,
+                "code": "AY%s" % suffix,
+                "date_start": "2024-07-01",
+                "date_end": "2025-06-30",
+            }
+        )
+        academic_term = self.env["school_academic_term"].create(
+            {
+                "name": "Semester %s" % suffix,
+                "code": "SM%s" % suffix,
+                "date_start": "2024-07-01",
+                "date_end": "2025-06-30",
+                "year_id": academic_year.id,
+                "enrollment_state": "open",
+            }
+        )
+        school = self.env["school"].create(
+            {
+                "name": "School %s" % suffix,
+                "code": "SCH%s" % suffix,
+                "grade_type_id": grade_type.id,
+            }
+        )
+        grade = self.env["school_grade"].create(
+            {
+                "name": "Grade %s" % suffix,
+                "code": "G%s" % suffix,
+                "sequence": 10,
+                "type_id": grade_type.id,
+            }
+        )
+        return {
+            "account": account,
+            "product": product,
+            "academic_year": academic_year,
+            "academic_term": academic_term,
+            "school": school,
+            "grade": grade,
+        }
+
+    def _create_admission(self, base, name_suffix, grade=None):
+        contact = self.env["res.partner"].create(
+            {"name": "Student Contact %s" % name_suffix}
+        )
+        return self.env["school_admission"].create(
+            {
+                "date": "2024-07-01",
+                "academic_year_id": base["academic_year"].id,
+                "academic_term_id": base["academic_term"].id,
+                "school_id": base["school"].id,
+                "grade_id": (grade or base["grade"]).id,
+                "student_id": contact.id,
+                "currency_id": self.env.company.currency_id.id,
+            }
+        )
+
+    def _create_source_term(self, base, source):
+        term = self.env["school_admission_payment_term"].create(
+            {
+                "admission_id": source.id,
+                "name": "Term Source %s" % source.id,
+                "sequence": 10,
+            }
+        )
+        self.env["school_admission_payment_term_detail"].create(
+            {
+                "term_id": term.id,
+                "product_id": base["product"].id,
+                "name": "Fee %s" % source.id,
+                "account_id": base["account"].id,
+                "uom_quantity": 1.0,
+                "uom_id": self.env.ref("uom.product_uom_unit").id,
+                "price_unit": 500000.0,
+            }
+        )
+        return term
+
+    def test_copy_payment_term_blocked_when_target_not_draft(self):
+        base = self._create_base_data("BLK1")
+        source = self._create_admission(base, "BLK1SRC")
+        self._create_source_term(base, source)
+        target = self._create_admission(base, "BLK1TGT")
+        target.write({"state": "confirm"})
+
+        wizard = (
+            self.env["school_admission.wizard_copy_payment_term"]
+            .with_context(active_model="school_admission", active_ids=target.ids)
+            .create(
+                {
+                    "source_admission_id": source.id,
+                    "mode": "replace",
+                }
+            )
+        )
+        self.assertEqual(wizard.target_admission_ids, target)
+        self.assertFalse(target.copy_payment_term_ok)
+
+        with self.assertRaises(UserError):
+            wizard.action_copy_payment_term()
+
+        self.assertFalse(target.payment_term_ids)
+
+    def test_copy_payment_term_blocked_when_grade_mismatch(self):
+        base = self._create_base_data("BLK2")
+        source = self._create_admission(base, "BLK2SRC")
+        self._create_source_term(base, source)
+
+        other_grade = self.env["school_grade"].create(
+            {
+                "name": "Other Grade BLK2",
+                "code": "OGBLK2",
+                "sequence": 20,
+                "type_id": base["grade"].type_id.id,
+            }
+        )
+        target = self._create_admission(base, "BLK2TGT", grade=other_grade)
+
+        wizard = (
+            self.env["school_admission.wizard_copy_payment_term"]
+            .with_context(active_model="school_admission", active_ids=target.ids)
+            .create(
+                {
+                    "source_admission_id": source.id,
+                    "mode": "replace",
+                }
+            )
+        )
+        self.assertTrue(target.copy_payment_term_ok)
+
+        with self.assertRaises(UserError):
+            wizard.action_copy_payment_term()
+
+        self.assertFalse(target.payment_term_ids)

--- a/ssi_school_admission/wizards/__init__.py
+++ b/ssi_school_admission/wizards/__init__.py
@@ -3,6 +3,7 @@
 # License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl).
 
 from . import (  # noqa: F401
+    school_admission_copy_payment_term,
     school_admission_form_create_admission,
     school_admission_payment_term_duplicate,
     school_admission_test_create_admission,

--- a/ssi_school_admission/wizards/school_admission_copy_payment_term.py
+++ b/ssi_school_admission/wizards/school_admission_copy_payment_term.py
@@ -1,0 +1,133 @@
+# Copyright 2026 OpenSynergy Indonesia
+# Copyright 2026 PT. Simetri Sinergi Indonesia
+# License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl).
+
+from odoo import _, api, fields, models
+from odoo.exceptions import UserError
+
+
+class SchoolAdmissionWizardCopyPaymentTerm(models.TransientModel):
+    """
+    Wizard that copies all payment terms (and their detail lines) from one source
+    admission to one or more target admissions selected from the school_admission list
+    view. Mode "replace" deletes the existing payment terms on each target before
+    copying; mode "add" appends the source terms to each target's existing terms. Every
+    target must be allowed by the copy_payment_term_ok policy (state and group,
+    configurable via Policy Template) and must share the same academic term, school,
+    and grade as the source. All targets are validated before any change is applied.
+    """
+
+    _name = "school_admission.wizard_copy_payment_term"
+    _description = "Copy Payment Terms Between Admissions"
+
+    target_admission_ids = fields.Many2many(
+        string="Target Admissions",
+        comodel_name="school_admission",
+        readonly=True,
+        help=(
+            "Draft admissions selected from the list view that will "
+            "receive the copied payment terms."
+        ),
+    )
+    source_admission_id = fields.Many2one(
+        string="Source Admission",
+        comodel_name="school_admission",
+        required=True,
+        domain="[('id', 'not in', target_admission_ids)]",
+        help="The admission whose payment terms (and detail lines) will be copied.",
+    )
+    mode = fields.Selection(
+        string="Mode",
+        selection=[
+            ("replace", "Replace"),
+            ("add", "Add"),
+        ],
+        default="replace",
+        required=True,
+        help=(
+            "Replace: delete existing payment terms on each target before copying. "
+            "Add: append source terms to each target's existing terms."
+        ),
+    )
+
+    @api.model
+    def default_get(self, fields_list):
+        res = super().default_get(fields_list)
+        if self.env.context.get("active_model") == "school_admission":
+            active_ids = self.env.context.get("active_ids", [])
+            res["target_admission_ids"] = [(6, 0, active_ids)]
+        return res
+
+    def action_copy_payment_term(self):
+        for record in self.sudo():
+            record._copy_payment_term()  # pylint: disable=protected-access
+        return {"type": "ir.actions.act_window_close"}
+
+    def _copy_payment_term(self):
+        self.ensure_one()
+        if not self.target_admission_ids:
+            error_message = (
+                _(
+                    """
+Context: Copy payment terms between admissions
+Database ID: %s
+Problem: No target admission selected
+Solution: Select at least one draft admission from the list view before running this wizard
+"""
+                )
+                % (self.id,)
+            )
+            raise UserError(error_message)
+        self._check_target_admissions()
+        source = self.source_admission_id
+        for target in self.target_admission_ids:
+            if self.mode == "replace":
+                target.payment_term_ids.unlink()
+            for term in source.payment_term_ids.sorted("sequence"):
+                new_term = term.copy(
+                    {
+                        "admission_id": target.id,
+                        "invoice_id": False,
+                    }
+                )
+                new_term.detail_ids.write({"invoice_line_id": False})
+
+    def _check_target_admissions(self):
+        self.ensure_one()
+        source = self.source_admission_id
+        problems = []
+        for target in self.target_admission_ids:
+            if not target.copy_payment_term_ok:
+                problems.append(
+                    _("- %s: not allowed to receive payment terms (check state/policy)")
+                    % target.name
+                )
+            elif (
+                target.academic_term_id != source.academic_term_id
+                or target.school_id != source.school_id
+                or target.grade_id != source.grade_id
+            ):
+                problems.append(
+                    _("- %s: academic term/school/grade does not match the source")
+                    % target.name
+                )
+        if problems:
+            error_message = (
+                _(
+                    """
+Context: Copy payment terms from admission '%s'
+Database ID: %s
+Problem: The following target admission(s) cannot receive payment terms:
+%s
+Solution: Deselect the listed admission(s), or make sure they are draft, allowed by
+the copy payment term policy, and share the same academic term/school/grade as the
+source
+"""
+                )
+                % (
+                    source.name,
+                    self.id,
+                    "\n".join(problems),
+                )
+            )
+            raise UserError(error_message)

--- a/ssi_school_admission/wizards/school_admission_copy_payment_term.py
+++ b/ssi_school_admission/wizards/school_admission_copy_payment_term.py
@@ -23,6 +23,9 @@ class SchoolAdmissionWizardCopyPaymentTerm(models.TransientModel):
     target_admission_ids = fields.Many2many(
         string="Target Admissions",
         comodel_name="school_admission",
+        relation="rel_school_admission_copy_payment_term_target",
+        column1="wizard_id",
+        column2="admission_id",
         readonly=True,
         help=(
             "Draft admissions selected from the list view that will "

--- a/ssi_school_admission/wizards/school_admission_copy_payment_term.xml
+++ b/ssi_school_admission/wizards/school_admission_copy_payment_term.xml
@@ -1,0 +1,46 @@
+<?xml version="1.0" encoding="utf-8" ?>
+<!-- Copyright 2026 OpenSynergy Indonesia
+     Copyright 2026 PT. Simetri Sinergi Indonesia
+     License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl). -->
+<odoo>
+
+<record id="school_admission_wizard_copy_payment_term_view_form" model="ir.ui.view">
+    <field name="name">school_admission.wizard_copy_payment_term - form</field>
+    <field name="model">school_admission.wizard_copy_payment_term</field>
+    <field name="arch" type="xml">
+        <form string="Copy Payment Terms">
+            <group name="main" colspan="4" col="2">
+                <field
+                        name="target_admission_ids"
+                        widget="many2many_tags"
+                        colspan="2"
+                    />
+                <field name="source_admission_id" />
+                <field name="mode" widget="radio" />
+            </group>
+            <footer>
+                <button
+                        name="action_copy_payment_term"
+                        type="object"
+                        string="Copy Payment Terms"
+                        class="btn-primary"
+                    />
+                <button string="Cancel" class="btn-default" special="cancel" />
+            </footer>
+        </form>
+    </field>
+</record>
+
+<record
+        id="school_admission_wizard_copy_payment_term_action"
+        model="ir.actions.act_window"
+    >
+    <field name="name">Copy Payment Terms</field>
+    <field name="type">ir.actions.act_window</field>
+    <field name="res_model">school_admission.wizard_copy_payment_term</field>
+    <field name="view_mode">form</field>
+    <field name="target">new</field>
+    <field name="binding_model_id" ref="model_school_admission" />
+</record>
+
+</odoo>


### PR DESCRIPTION
## Ringkasan

Menambahkan wizard "Copy Payment Terms" untuk `ssi_school` (`school_enrollment`) dan
`ssi_school_admission` (`school_admission`) — pola identik di kedua modul.

- Wizard dipicu dari menu Action di list view, mendukung multi-select enrollment/admission
  tujuan (draft), menyalin seluruh payment term + detail dari satu enrollment/admission
  sumber.
- Mode **Replace** (ganti semua term tujuan) atau **Add** (tambahkan term sumber ke term
  yang sudah ada).
- Validasi sebelum eksekusi (semua-atau-tidak-sama-sekali per klik tombol):
  - Target harus diizinkan oleh policy `copy_payment_term_ok` baru (state draft + group,
    dikontrol lewat Policy Template — bukan hardcode).
  - `academic_term_id`/`school_id`/`grade_id` target harus sama dengan sumber.
- Detail hasil copy selalu mereset `invoice_line_id`/`invoice_id` agar tidak nyangkut ke
  invoice milik sumber.
- Unit test: 3 skenario YAML (replace/add/multi-target) + 2 test Python negative-path
  (policy-blocked, grade-mismatch) per modul.

Referensi backlog: BL-0059 (`ssi_school`), BL-0060 (`ssi_school_admission`) di store
backlog internal.

## Test plan

- [x] `pre-commit run` lolos (flake8/black/prettier/pylint_odoo) untuk semua file baru/diubah.
- [ ] CI hijau.