### PR TITLE
[UPD] ssi_school_operating_unit

### DIFF
--- a/ssi_school_operating_unit/__manifest__.py
+++ b/ssi_school_operating_unit/__manifest__.py
@@ -4,7 +4,7 @@
 
 {
     "name": "School - Operating Unit",
-    "version": "14.0.1.3.0",
+    "version": "14.0.1.4.0",
     "website": "https://simetri-sinergi.id",
     "author": (
         "OpenSynergy Indonesia, "
@@ -26,6 +26,9 @@
         # Security - transactional (school_homeroom)
         "security/res_groups/school_homeroom.xml",
         "security/ir_rule/school_homeroom.xml",
+        # Security - transactional (school_student_mutation)
+        "security/res_groups/school_student_mutation.xml",
+        "security/ir_rule/school_student_mutation.xml",
         # Security - master data (global OU rules)
         "security/ir_rule/school.xml",
         "security/ir_rule/school_grade_type.xml",
@@ -38,6 +41,7 @@
         # Views
         "views/school_enrollment.xml",
         "views/school_homeroom.xml",
+        "views/school_student_mutation.xml",
         "views/school.xml",
         "views/school_grade_type.xml",
         "views/school_grade.xml",

--- a/ssi_school_operating_unit/models/__init__.py
+++ b/ssi_school_operating_unit/models/__init__.py
@@ -13,5 +13,6 @@ from . import (  # noqa: F401
     school_grade_type,
     school_homeroom,
     school_student,
+    school_student_mutation,
     school_teacher,
 )

--- a/ssi_school_operating_unit/models/school_student_mutation.py
+++ b/ssi_school_operating_unit/models/school_student_mutation.py
@@ -1,0 +1,18 @@
+# Copyright 2026 OpenSynergy Indonesia
+# Copyright 2026 PT. Simetri Sinergi Indonesia
+# License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl).
+
+from odoo import models
+
+
+class SchoolStudentMutation(models.Model):  # pylint: disable=too-few-public-methods
+    """
+    Extends School Student Mutation with single operating unit support,
+    restricting each mutation record to one operating unit.
+    """
+
+    _name = "school_student_mutation"
+    _inherit = [
+        "school_student_mutation",
+        "mixin.single_operating_unit",
+    ]

--- a/ssi_school_operating_unit/security/ir_rule/school_student_mutation.xml
+++ b/ssi_school_operating_unit/security/ir_rule/school_student_mutation.xml
@@ -1,0 +1,25 @@
+<?xml version="1.0" encoding="utf-8" ?>
+<!-- Copyright 2026 OpenSynergy Indonesia
+     Copyright 2026 PT. Simetri Sinergi Indonesia
+     License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl). -->
+<odoo>
+
+<record id="school_student_mutation_ou" model="ir.rule">
+    <field
+            name="name"
+        >school_student_mutation - Responsible to operating unit data</field>
+    <field name="model_id" ref="ssi_school.model_school_student_mutation" />
+    <field
+            name="groups"
+            eval="[(4, ref('school_student_mutation_operating_unit_group'))]"
+        />
+    <field
+            name="domain_force"
+        >[('operating_unit_id','in',[g.id for g in user.operating_unit_ids])]</field>
+    <field name="perm_unlink" eval="1" />
+    <field name="perm_write" eval="1" />
+    <field name="perm_read" eval="1" />
+    <field name="perm_create" eval="1" />
+</record>
+
+</odoo>

--- a/ssi_school_operating_unit/security/res_groups/school_student_mutation.xml
+++ b/ssi_school_operating_unit/security/res_groups/school_student_mutation.xml
@@ -1,0 +1,23 @@
+<?xml version="1.0" encoding="utf-8" ?>
+<!-- Copyright 2026 OpenSynergy Indonesia
+     Copyright 2026 PT. Simetri Sinergi Indonesia
+     License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl). -->
+<odoo>
+
+<record id="school_student_mutation_operating_unit_group" model="res.groups">
+    <field name="name">Operating Unit</field>
+    <field
+            name="category_id"
+            ref="ssi_school.school_student_mutation_data_ownership_module_category"
+        />
+</record>
+
+<record id="ssi_school.school_student_mutation_company_group" model="res.groups">
+    <field name="name">Company</field>
+    <field
+            name="implied_ids"
+            eval="[(6, 0, [ref('school_student_mutation_operating_unit_group')])]"
+        />
+</record>
+
+</odoo>

--- a/ssi_school_operating_unit/tests/test_data_school_operating_unit.yaml
+++ b/ssi_school_operating_unit/tests/test_data_school_operating_unit.yaml
@@ -491,3 +491,160 @@ scenarios:
           - ["operating_unit_id", "=", "EVAL: registry['operating_unit'].id"]
         save_as: "enrollment_with_matching_ou"
         expect_count: 1
+
+  - name: "School Operating Unit - Student Class Mutation operating unit"
+    steps:
+      - step: "Get main company operating unit"
+        action: "search"
+        model: "operating.unit"
+        domain: [["company_id", "=", "REF: base.main_company"]]
+        save_as: "operating_unit"
+        limit: 1
+
+      - step: "Create grade type"
+        action: "create"
+        model: "school_grade_type"
+        save_as: "grade_type"
+        values:
+          name: "Grade Type Mutation OU"
+          code: "GTOU05"
+          sequence: 10
+
+      - step: "Create school"
+        action: "create"
+        model: "school"
+        save_as: "school"
+        values:
+          name: "School Mutation OU Test"
+          code: "SCHOU05"
+          grade_type_id: "EVAL: registry['grade_type'].id"
+
+      - step: "Create grade"
+        action: "create"
+        model: "school_grade"
+        save_as: "grade"
+        values:
+          name: "Grade Mutation OU"
+          code: "GOU05"
+          sequence: 10
+          type_id: "EVAL: registry['grade_type'].id"
+
+      - step: "Create source grade class"
+        action: "create"
+        model: "school_grade_class"
+        save_as: "grade_class_source"
+        values:
+          name: "Class A Mutation OU"
+          code: "GCOU05A"
+          school_id: "EVAL: registry['school'].id"
+          grade_id: "EVAL: registry['grade'].id"
+          capacity: 30
+
+      - step: "Create destination grade class"
+        action: "create"
+        model: "school_grade_class"
+        save_as: "grade_class_destination"
+        values:
+          name: "Class B Mutation OU"
+          code: "GCOU05B"
+          school_id: "EVAL: registry['school'].id"
+          grade_id: "EVAL: registry['grade'].id"
+          capacity: 30
+
+      - step: "Create academic year"
+        action: "create"
+        model: "school_academic_year"
+        save_as: "academic_year"
+        values:
+          name: "2025/2026 Mutation OU"
+          code: "AYOU05"
+          date_start: "2025-07-01"
+          date_end: "2026-06-30"
+
+      - step: "Create academic term"
+        action: "create"
+        model: "school_academic_term"
+        save_as: "academic_term"
+        values:
+          name: "Semester 1 Mutation OU"
+          code: "SMOU05"
+          date_start: "2025-07-01"
+          date_end: "2025-12-31"
+          year_id: "EVAL: registry['academic_year'].id"
+          enrollment_state: "open"
+
+      - step: "Create student contact"
+        action: "create"
+        model: "res.partner"
+        save_as: "student_contact"
+        values:
+          name: "Student Mutation OU Test"
+
+      - step: "Create school student"
+        action: "create"
+        model: "school_student"
+        save_as: "student"
+        values:
+          name: "Student Mutation OU"
+          code: "STOU05"
+          contact_id: "EVAL: registry['student_contact'].id"
+          school_id: "EVAL: registry['school'].id"
+
+      - step: "Create enrollment in source class with operating unit"
+        action: "create"
+        model: "school_enrollment"
+        save_as: "enrollment"
+        as_user: "base.user_admin"
+        values:
+          date: "2025-07-15"
+          academic_year_id: "EVAL: registry['academic_year'].id"
+          academic_term_id: "EVAL: registry['academic_term'].id"
+          school_id: "EVAL: registry['school'].id"
+          grade_id: "EVAL: registry['grade'].id"
+          grade_class_id: "EVAL: registry['grade_class_source'].id"
+          student_id: "EVAL: registry['student'].id"
+          operating_unit_id: "EVAL: registry['operating_unit'].id"
+
+      - step: "Confirm enrollment"
+        action: "call"
+        target: "enrollment"
+        method: "action_confirm"
+        as_user: "base.user_admin"
+        asserts:
+          state:
+            type: "value"
+            expected: "confirm"
+
+      - step: "Invalidate enrollment cache before approve"
+        action: "call"
+        target: "enrollment"
+        method: "invalidate_cache"
+
+      - step: "Approve enrollment"
+        action: "call"
+        target: "enrollment"
+        method: "action_approve_approval"
+        as_user: "base.user_admin"
+        asserts:
+          state:
+            type: "value"
+            expected: "open"
+
+      - step: "Create class mutation with operating unit"
+        action: "create"
+        model: "school_student_mutation"
+        save_as: "mutation"
+        values:
+          date: "2025-08-01"
+          student_id: "EVAL: registry['student'].id"
+          enrollment_id: "EVAL: registry['enrollment'].id"
+          destination_grade_class_id: "EVAL: registry['grade_class_destination'].id"
+          operating_unit_id: "EVAL: registry['operating_unit'].id"
+
+      - step: "Assert mutation has operating unit"
+        action: "assert"
+        target: "mutation"
+        asserts:
+          operating_unit_id:
+            type: "value"
+            operator: "is_truthy"

--- a/ssi_school_operating_unit/views/school_student_mutation.xml
+++ b/ssi_school_operating_unit/views/school_student_mutation.xml
@@ -1,0 +1,58 @@
+<?xml version="1.0" encoding="utf-8" ?>
+<!-- Copyright 2026 OpenSynergy Indonesia
+     Copyright 2026 PT. Simetri Sinergi Indonesia
+     License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl). -->
+<odoo>
+
+<record id="school_student_mutation_view_tree_ou" model="ir.ui.view">
+    <field name="name">school_student_mutation tree - operating unit</field>
+    <field name="model">school_student_mutation</field>
+    <field name="inherit_id" ref="ssi_school.school_student_mutation_view_tree" />
+    <field name="arch" type="xml">
+        <data>
+            <xpath expr="//field[@name='company_id']" position="after">
+                <field
+                        name="operating_unit_id"
+                        groups="operating_unit.group_multi_operating_unit"
+                        optional="hide"
+                    />
+            </xpath>
+        </data>
+    </field>
+</record>
+
+<record id="school_student_mutation_view_form_ou" model="ir.ui.view">
+    <field name="name">school_student_mutation form - operating unit</field>
+    <field name="model">school_student_mutation</field>
+    <field name="inherit_id" ref="ssi_school.school_student_mutation_view_form" />
+    <field name="arch" type="xml">
+        <data>
+            <xpath expr="//field[@name='company_id']" position="after">
+                <field
+                        name="operating_unit_id"
+                        groups="operating_unit.group_multi_operating_unit"
+                    />
+            </xpath>
+        </data>
+    </field>
+</record>
+
+<record id="school_student_mutation_view_search_ou" model="ir.ui.view">
+    <field name="name">school_student_mutation search - operating unit</field>
+    <field name="model">school_student_mutation</field>
+    <field name="inherit_id" ref="ssi_school.school_student_mutation_view_search" />
+    <field name="arch" type="xml">
+        <data>
+            <xpath expr="//group[@string='Group By']" position="inside">
+                <filter
+                        name="grp_ou"
+                        string="Operating Unit"
+                        context="{'group_by':'operating_unit_id'}"
+                        groups="operating_unit.group_multi_operating_unit"
+                    />
+            </xpath>
+        </data>
+    </field>
+</record>
+
+</odoo>

--- a/ssi_school_operating_unit/views/school_student_mutation.xml
+++ b/ssi_school_operating_unit/views/school_student_mutation.xml
@@ -43,7 +43,7 @@
     <field name="inherit_id" ref="ssi_school.school_student_mutation_view_search" />
     <field name="arch" type="xml">
         <data>
-            <xpath expr="//group[@string='Group By']" position="inside">
+            <xpath expr="//group" position="inside">
                 <filter
                         name="grp_ou"
                         string="Operating Unit"


### PR DESCRIPTION
## Ringkasan

Menambahkan dukungan Operating Unit ke model `school_student_mutation` (Student Class Mutation), melanjutkan pola yang sudah ada di `school_enrollment`/`school_homeroom` pada modul `ssi_school_operating_unit`.

- Field `operating_unit_id` via `mixin.single_operating_unit`
- Group "Operating Unit" ter-implied oleh group "Company" (data ownership)
- `ir.rule` pembatas akses berdasarkan `operating_unit_id`
- Field `operating_unit_id` ditambahkan ke tree, form, dan search view (dengan filter group-by)
- Skenario unit test YAML baru di `test_data_school_operating_unit.yaml`

Tidak ada perubahan pada modul basis `ssi_school`.

## Test plan

- [x] Unit test YAML ditulis (dijalankan CI)
- [ ] CI hijau