### PR TITLE
[UPD] ssi_school

### DIFF
--- a/ssi_school/models/school_student.py
+++ b/ssi_school/models/school_student.py
@@ -4,7 +4,7 @@
 
 
 from odoo import _, api, fields, models
-from odoo.exceptions import ValidationError
+from odoo.exceptions import UserError, ValidationError
 
 
 class SchoolStudent(models.Model):
@@ -265,6 +265,30 @@ Solution: Follow the allowed student state transition sequence
                     )
                     raise ValidationError(error_message)
         return super().write(values)
+
+    @api.constrains("code", "school_id")
+    def _check_duplicate_code(self):
+        for record in self:
+            if record.code == "/":
+                continue
+            criteria = [
+                ("code", "=", record.code),
+                ("id", "!=", record.id),
+                ("code", "!=", "/"),
+                ("school_id", "=", record.school_id.id),
+            ]
+            count_duplicate = self.search_count(criteria)
+            if count_duplicate > 0:
+                error_message = _(
+                    """
+Context: Create or update student
+Database ID: %s
+Problem: Duplicate code '%s' in school '%s'
+Solution: Change the student code to be unique within the school
+"""
+                    % (record.id, record.code, record.school_id.name)
+                )
+                raise UserError(error_message)
 
     @api.depends("enrollment_ids", "enrollment_ids.state")
     def _compute_active_enrollment_id(self):

--- a/ssi_school/tests/test_data_student.yaml
+++ b/ssi_school/tests/test_data_student.yaml
@@ -490,6 +490,140 @@ scenarios:
             type: "value"
             expected: "draft"
 
+  - name: "Duplicate Code Allowed Across Different Schools"
+    steps:
+      - step: "Create grade type"
+        action: "create"
+        model: "school_grade_type"
+        save_as: "grade_type"
+        values:
+          name: "Grade Type Dup Code"
+          code: "GTDUPC"
+          sequence: 10
+      - step: "Create school A"
+        action: "create"
+        model: "school"
+        save_as: "school_a"
+        values:
+          name: "School Dup Code A"
+          code: "SCHDUPA"
+          grade_type_id: "EVAL: registry['grade_type'].id"
+      - step: "Create school B"
+        action: "create"
+        model: "school"
+        save_as: "school_b"
+        values:
+          name: "School Dup Code B"
+          code: "SCHDUPB"
+          grade_type_id: "EVAL: registry['grade_type'].id"
+      - step: "Create contact for school A student"
+        action: "create"
+        model: "res.partner"
+        save_as: "contact_a"
+        values:
+          name: "Student Dup Code Contact A"
+      - step: "Create contact for school B student"
+        action: "create"
+        model: "res.partner"
+        save_as: "contact_b"
+        values:
+          name: "Student Dup Code Contact B"
+      - step: "Create student in school A with code DUP01"
+        action: "create"
+        model: "school_student"
+        save_as: "student_a"
+        values:
+          name: "Student Dup Code A"
+          code: "DUP01"
+          contact_id: "EVAL: registry['contact_a'].id"
+          school_id: "EVAL: registry['school_a'].id"
+      - step: "Create student in school B with the same code DUP01"
+        action: "create"
+        model: "school_student"
+        save_as: "student_b"
+        values:
+          name: "Student Dup Code B"
+          code: "DUP01"
+          contact_id: "EVAL: registry['contact_b'].id"
+          school_id: "EVAL: registry['school_b'].id"
+      - step: "Assert both students created"
+        action: "assert"
+        target: "student_a"
+        asserts:
+          id:
+            type: "value"
+            operator: "is_truthy"
+      - step: "Assert second student created"
+        action: "assert"
+        target: "student_b"
+        asserts:
+          id:
+            type: "value"
+            operator: "is_truthy"
+
+  - name: "Duplicate Slash Code Allowed In Same School"
+    steps:
+      - step: "Create grade type"
+        action: "create"
+        model: "school_grade_type"
+        save_as: "grade_type"
+        values:
+          name: "Grade Type Slash Code"
+          code: "GTSLC"
+          sequence: 10
+      - step: "Create school"
+        action: "create"
+        model: "school"
+        save_as: "school"
+        values:
+          name: "School Slash Code"
+          code: "SCHSLC"
+          grade_type_id: "EVAL: registry['grade_type'].id"
+      - step: "Create contact for first student"
+        action: "create"
+        model: "res.partner"
+        save_as: "contact1"
+        values:
+          name: "Student Slash Code Contact 1"
+      - step: "Create contact for second student"
+        action: "create"
+        model: "res.partner"
+        save_as: "contact2"
+        values:
+          name: "Student Slash Code Contact 2"
+      - step: "Create first student with code /"
+        action: "create"
+        model: "school_student"
+        save_as: "student1"
+        values:
+          name: "Student Slash Code 1"
+          code: "/"
+          contact_id: "EVAL: registry['contact1'].id"
+          school_id: "EVAL: registry['school'].id"
+      - step: "Create second student with code / in the same school"
+        action: "create"
+        model: "school_student"
+        save_as: "student2"
+        values:
+          name: "Student Slash Code 2"
+          code: "/"
+          contact_id: "EVAL: registry['contact2'].id"
+          school_id: "EVAL: registry['school'].id"
+      - step: "Assert first student created"
+        action: "assert"
+        target: "student1"
+        asserts:
+          id:
+            type: "value"
+            operator: "is_truthy"
+      - step: "Assert second student created"
+        action: "assert"
+        target: "student2"
+        asserts:
+          id:
+            type: "value"
+            operator: "is_truthy"
+
   - name: "Action Student State Transitions"
     steps:
       - step: "Create grade type"

--- a/ssi_school/tests/test_school_student.py
+++ b/ssi_school/tests/test_school_student.py
@@ -4,6 +4,7 @@
 
 from odoo_yaml_test import YamlTransactionCase
 
+from odoo.exceptions import UserError
 from odoo.tests import Form, tagged
 
 
@@ -11,6 +12,52 @@ from odoo.tests import Form, tagged
 class TestSchoolStudent(YamlTransactionCase):
     def test_student(self):
         self.run_yaml_scenario("test_data_student.yaml")
+
+    def _create_school(self, code):
+        grade_type = self.env["school_grade_type"].create(
+            {
+                "name": f"Grade Type Dup Constrain {code}",
+                "code": f"GTDC{code}",
+                "sequence": 10,
+            }
+        )
+        return self.env["school"].create(
+            {
+                "name": f"School Dup Constrain {code}",
+                "code": f"SCHDC{code}",
+                "grade_type_id": grade_type.id,
+            }
+        )
+
+    def _create_student(self, code, school, name=None):
+        contact = self.env["res.partner"].create(
+            {"name": name or f"Dup Constrain Contact {code}"}
+        )
+        return self.env["school_student"].create(
+            {
+                "name": name or f"Dup Constrain Student {code}",
+                "code": code,
+                "contact_id": contact.id,
+                "school_id": school.id,
+            }
+        )
+
+    def test_duplicate_code_same_school_raises(self):
+        """Two students sharing a code within the same school must fail."""
+        school = self._create_school("DUP02")
+        self._create_student("DUP02", school)
+        with self.assertRaises(UserError):
+            self._create_student("DUP02", school)
+
+    def test_move_student_to_school_causing_duplicate_raises(self):
+        """Moving a student into a school where its code already exists
+        must trigger the constraint, since it re-checks on school_id change."""
+        school_a = self._create_school("MOVA")
+        school_b = self._create_school("MOVB")
+        self._create_student("MOVDUP", school_b)
+        student_a = self._create_student("MOVDUP", school_a)
+        with self.assertRaises(UserError):
+            student_a.write({"school_id": school_b.id})
 
     def test_onchange_school_id_clears_initial_grade(self):
         """Mengganti school_id harus mengosongkan initial_grade_id."""


### PR DESCRIPTION
## Ringkasan

Membatasi keunikan kode student (`school_student.code`) agar berlaku per sekolah (`school_id`), bukan lagi unik secara global di seluruh tabel.

* Override `_check_duplicate_code` dengan `@api.constrains("code", "school_id")` sehingga perpindahan sekolah ikut memicu validasi ulang.
* Nilai `"/"` tetap dikecualikan dari pengecekan (konvensi auto-generate mixin).
* `mixin.master_data` (ssi-mixin) tidak disentuh.

## Test plan

- [x] Skenario YAML: kode duplikat antar sekolah berbeda → boleh (`Duplicate Code Allowed Across Different Schools`)
- [x] Skenario YAML: kode `"/"` ganda dalam satu sekolah → boleh (`Duplicate Slash Code Allowed In Same School`)
- [x] Unit test Python: kode duplikat dalam sekolah yang sama → `UserError` (`test_duplicate_code_same_school_raises`)
- [x] Unit test Python: perpindahan student yang menyebabkan tabrakan kode → `UserError` (`test_move_student_to_school_causing_duplicate_raises`)