### PR TITLE
[UPD] ssi_school

### DIFF
--- a/ssi_school/__manifest__.py
+++ b/ssi_school/__manifest__.py
@@ -22,6 +22,7 @@
         "ssi_m2o_configurator_mixin",
         "base_address_city",
         "ssi_financial_accounting",
+        "ssi_partner",
         "base_duration",
         "queue_job",
     ],

--- a/ssi_school/models/school_student.py
+++ b/ssi_school/models/school_student.py
@@ -90,6 +90,88 @@ class SchoolStudent(models.Model):
         readonly=False,
         help="Email address of the student, synchronized from the contact.",
     )
+
+    # Personal Information
+    gender = fields.Selection(
+        related="contact_id.gender",
+        store=True,
+        readonly=False,
+        help="Gender of the student, synchronized from the contact.",
+    )
+    birthdate_date = fields.Date(
+        related="contact_id.birthdate_date",
+        store=True,
+        readonly=False,
+        help="Date of birth of the student, synchronized from the contact.",
+    )
+    age = fields.Integer(
+        related="contact_id.age",
+        readonly=True,
+        help="Current age of the student, computed live from the contact's date of birth.",
+    )
+    birth_city = fields.Char(
+        related="contact_id.birth_city",
+        store=True,
+        readonly=False,
+        help="City of birth of the student, synchronized from the contact.",
+    )
+    birth_state_id = fields.Many2one(
+        related="contact_id.birth_state_id",
+        store=True,
+        readonly=False,
+        help="State/province of birth of the student, synchronized from the contact.",
+    )
+    birth_country_id = fields.Many2one(
+        related="contact_id.birth_country_id",
+        store=True,
+        readonly=False,
+        help="Country of birth of the student, synchronized from the contact.",
+    )
+    nationality_id = fields.Many2one(
+        related="contact_id.nationality_id",
+        store=True,
+        readonly=False,
+        help="Nationality of the student, synchronized from the contact.",
+    )
+    blood_type = fields.Selection(
+        related="contact_id.blood_type",
+        store=True,
+        readonly=False,
+        help="ABO blood type of the student, synchronized from the contact.",
+    )
+    blood_type_rhesus = fields.Selection(
+        related="contact_id.blood_type_rhesus",
+        store=True,
+        readonly=False,
+        help="Rhesus blood type of the student, synchronized from the contact.",
+    )
+    religion_id = fields.Many2one(
+        related="contact_id.religion_id",
+        store=True,
+        readonly=False,
+        help="Religion of the student, synchronized from the contact.",
+    )
+    ethnicity_id = fields.Many2one(
+        related="contact_id.ethnicity_id",
+        store=True,
+        readonly=False,
+        help="Ethnicity of the student, synchronized from the contact.",
+    )
+    marital = fields.Selection(
+        related="contact_id.marital",
+        store=True,
+        readonly=False,
+        help="Marital status of the student, synchronized from the contact.",
+    )
+
+    # Bank Accounts
+    bank_ids = fields.One2many(
+        string="Bank Accounts",
+        related="contact_id.bank_ids",
+        readonly=False,
+        help="Bank accounts of the student, managed through the linked contact.",
+    )
+
     school_id = fields.Many2one(
         string="School",
         comodel_name="school",

--- a/ssi_school/tests/__init__.py
+++ b/ssi_school/tests/__init__.py
@@ -12,6 +12,7 @@ from . import (  # noqa: F401
     test_school_academic_term,
     test_school_teacher,
     test_school_student,
+    test_school_student_personal_data,
     test_school_student_states,
     test_school_enrollment_payment_template,
     test_school_enrollment_payment_product_configurator,

--- a/ssi_school/tests/test_data_student_personal_data.yaml
+++ b/ssi_school/tests/test_data_student_personal_data.yaml
@@ -1,0 +1,228 @@
+scenarios:
+  - name: "Write-Through Scalar Personal Data From Student To Contact"
+    steps:
+      - step: "Create grade type"
+        action: "create"
+        model: "school_grade_type"
+        save_as: "grade_type"
+        values:
+          name: "Grade Type Personal Data WT"
+          code: "GTPDWT"
+          sequence: 10
+      - step: "Create school"
+        action: "create"
+        model: "school"
+        save_as: "school"
+        values:
+          name: "School Personal Data WT"
+          code: "SCHPDWT"
+          grade_type_id: "EVAL: registry['grade_type'].id"
+      - step: "Create religion"
+        action: "create"
+        model: "res_partner_religion"
+        save_as: "religion"
+        values:
+          name: "Religion Personal Data WT"
+          code: "RELPDWT"
+      - step: "Create contact"
+        action: "create"
+        model: "res.partner"
+        save_as: "contact"
+        values:
+          name: "Personal Data WT Contact"
+      - step: "Create student"
+        action: "create"
+        model: "school_student"
+        save_as: "student"
+        values:
+          name: "Personal Data WT Student"
+          code: "STUPDWT"
+          contact_id: "EVAL: registry['contact'].id"
+          school_id: "EVAL: registry['school'].id"
+      - step: "Write personal data on student"
+        action: "write"
+        target: "student"
+        values:
+          gender: "male"
+          religion_id: "EVAL: registry['religion'].id"
+          birthdate_date: 2010-05-01
+          blood_type: "A"
+      - step: "Assert scalar values written through to contact"
+        action: "assert"
+        target: "contact"
+        asserts:
+          gender:
+            type: "value"
+            expected: "male"
+          birthdate_date:
+            type: "value"
+            expected: 2010-05-01
+          blood_type:
+            type: "value"
+            expected: "A"
+      - step: "Assert religion_id written through to contact"
+        action: "search"
+        model: "res.partner"
+        domain:
+          - ["id", "=", "EVAL: registry['contact'].id"]
+          - ["religion_id", "=", "EVAL: registry['religion'].id"]
+        save_as: "check_religion"
+        expect_count: 1
+
+  - name: "Related Read Back From Contact To Student"
+    steps:
+      - step: "Create grade type"
+        action: "create"
+        model: "school_grade_type"
+        save_as: "grade_type"
+        values:
+          name: "Grade Type Personal Data RB"
+          code: "GTPDRB"
+          sequence: 10
+      - step: "Create school"
+        action: "create"
+        model: "school"
+        save_as: "school"
+        values:
+          name: "School Personal Data RB"
+          code: "SCHPDRB"
+          grade_type_id: "EVAL: registry['grade_type'].id"
+      - step: "Create contact"
+        action: "create"
+        model: "res.partner"
+        save_as: "contact"
+        values:
+          name: "Personal Data RB Contact"
+      - step: "Create student"
+        action: "create"
+        model: "school_student"
+        save_as: "student"
+        values:
+          name: "Personal Data RB Student"
+          code: "STUPDRB"
+          contact_id: "EVAL: registry['contact'].id"
+          school_id: "EVAL: registry['school'].id"
+      - step: "Write gender directly on contact"
+        action: "write"
+        target: "contact"
+        values:
+          gender: "female"
+      - step: "Assert gender read back on student"
+        action: "assert"
+        target: "student"
+        asserts:
+          gender:
+            type: "value"
+            expected: "female"
+
+  - name: "Bank Line Created Via Student Reflects On Contact"
+    steps:
+      - step: "Create grade type"
+        action: "create"
+        model: "school_grade_type"
+        save_as: "grade_type"
+        values:
+          name: "Grade Type Personal Data Bank"
+          code: "GTPDBK"
+          sequence: 10
+      - step: "Create school"
+        action: "create"
+        model: "school"
+        save_as: "school"
+        values:
+          name: "School Personal Data Bank"
+          code: "SCHPDBK"
+          grade_type_id: "EVAL: registry['grade_type'].id"
+      - step: "Create contact"
+        action: "create"
+        model: "res.partner"
+        save_as: "contact"
+        values:
+          name: "Personal Data Bank Contact"
+      - step: "Create student"
+        action: "create"
+        model: "school_student"
+        save_as: "student"
+        values:
+          name: "Personal Data Bank Student"
+          code: "STUPDBK"
+          contact_id: "EVAL: registry['contact'].id"
+          school_id: "EVAL: registry['school'].id"
+      - step: "Create bank"
+        action: "create"
+        model: "res.bank"
+        save_as: "bank"
+        values:
+          name: "Personal Data Bank Test"
+      - step: "Add bank line via student"
+        action: "write"
+        target: "student"
+        values:
+          bank_ids:
+            - - 0
+              - 0
+              - acc_number: "1234567890"
+                bank_id: "EVAL: registry['bank'].id"
+      - step: "Assert bank line added to contact"
+        action: "assert"
+        target: "contact"
+        asserts:
+          bank_ids:
+            type: "o2m"
+            check: "count"
+            expected_count: 1
+      - step: "Assert bank line owned by contact"
+        action: "search"
+        model: "res.partner.bank"
+        domain:
+          - ["acc_number", "=", "1234567890"]
+          - ["partner_id", "=", "EVAL: registry['contact'].id"]
+        save_as: "check_bank_line"
+        expect_count: 1
+
+  - name: "Age Non-Stored Reflects Contact Live Value"
+    steps:
+      - step: "Create grade type"
+        action: "create"
+        model: "school_grade_type"
+        save_as: "grade_type"
+        values:
+          name: "Grade Type Personal Data Age"
+          code: "GTPDAG"
+          sequence: 10
+      - step: "Create school"
+        action: "create"
+        model: "school"
+        save_as: "school"
+        values:
+          name: "School Personal Data Age"
+          code: "SCHPDAG"
+          grade_type_id: "EVAL: registry['grade_type'].id"
+      - step: "Create contact"
+        action: "create"
+        model: "res.partner"
+        save_as: "contact"
+        values:
+          name: "Personal Data Age Contact"
+      - step: "Create student"
+        action: "create"
+        model: "school_student"
+        save_as: "student"
+        values:
+          name: "Personal Data Age Student"
+          code: "STUPDAG"
+          contact_id: "EVAL: registry['contact'].id"
+          school_id: "EVAL: registry['school'].id"
+      - step: "Write birthdate_date on student"
+        action: "write"
+        target: "student"
+        values:
+          birthdate_date: 2000-01-01
+      - step: "Assert student age matches contact age"
+        action: "search"
+        model: "school_student"
+        domain:
+          - ["id", "=", "EVAL: registry['student'].id"]
+          - ["age", "=", "EVAL: registry['contact'].age"]
+        save_as: "check_age"
+        expect_count: 1

--- a/ssi_school/tests/test_school_student_personal_data.py
+++ b/ssi_school/tests/test_school_student_personal_data.py
@@ -1,0 +1,13 @@
+# Copyright 2026 OpenSynergy Indonesia
+# Copyright 2026 PT. Simetri Sinergi Indonesia
+# License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl).
+
+from odoo_yaml_test import YamlTransactionCase
+
+from odoo.tests import tagged
+
+
+@tagged("post_install", "-at_install")
+class TestSchoolStudentPersonalData(YamlTransactionCase):
+    def test_student_personal_data(self):
+        self.run_yaml_scenario("test_data_student_personal_data.yaml")

--- a/ssi_school/views/school_student.xml
+++ b/ssi_school/views/school_student.xml
@@ -113,6 +113,48 @@
                 <field name="state" widget="badge" />
             </xpath>
             <xpath expr="//page[1]" position="before">
+                <page name="personal_information" string="Personal Information">
+                    <group
+                            name="personal_information_identity"
+                            string="Identity"
+                            colspan="4"
+                            col="2"
+                        >
+                        <field name="gender" />
+                        <field name="birthdate_date" />
+                        <field name="age" />
+                        <field name="marital" />
+                        <field name="nationality_id" />
+                    </group>
+                    <group
+                            name="personal_information_birth_place"
+                            string="Birth Place"
+                            colspan="4"
+                            col="2"
+                        >
+                        <field name="birth_city" />
+                        <field name="birth_state_id" />
+                        <field name="birth_country_id" />
+                    </group>
+                    <group
+                            name="personal_information_health"
+                            string="Health"
+                            colspan="4"
+                            col="2"
+                        >
+                        <field name="blood_type" />
+                        <field name="blood_type_rhesus" />
+                    </group>
+                    <group
+                            name="personal_information_socio_cultural"
+                            string="Socio-Cultural"
+                            colspan="4"
+                            col="2"
+                        >
+                        <field name="religion_id" />
+                        <field name="ethnicity_id" />
+                    </group>
+                </page>
                 <page name="address" string="Contact &amp; Address">
                     <group name="address_1" colspan="4" col="2">
                         <group name="address_1_1" colspan="1" col="2">
@@ -193,6 +235,17 @@
                         <field name="mother_id" />
                         <field name="guardian_id" />
                     </group>
+                </page>
+                <page name="bank_accounts" string="Bank Accounts">
+                    <field name="bank_ids">
+                        <tree editable="bottom">
+                            <field name="acc_number" />
+                            <field name="bank_id" />
+                            <field name="acc_holder_name" />
+                            <field name="usage_id" />
+                            <field name="currency_id" />
+                        </tree>
+                    </field>
                 </page>
             </xpath>
         </data>


### PR DESCRIPTION
## Ringkasan

* Menambahkan dependency `ssi_partner` agar data personal partner (jenis kelamin, tanggal lahir, tempat lahir, kewarganegaraan, golongan darah, agama, etnis, status perkawinan) tersedia di `res.partner`.
* Menambahkan field related pada `school_student` untuk data personal (write-through ke `contact_id`) dan field `age` (read-only, non-stored).
* Menambahkan field `bank_ids` (related One2many ke `contact_id.bank_ids`) agar rekening bank siswa dapat dikelola langsung dari form student.
* Menambahkan page "Personal Information" (dikelompokkan per tema: Identity, Birth Place, Health, Socio-Cultural) dan page "Bank Accounts" pada form view `school_student`.
* Menambahkan unit test skenario YAML untuk write-through data personal, pembacaan balik dari contact, penambahan baris rekening bank via student, dan kesesuaian `age` dengan contact.

Referensi: BL-0081.