### PR TITLE
[UPD] ssi_school

### DIFF
--- a/ssi_school/models/school_student.py
+++ b/ssi_school/models/school_student.py
@@ -390,7 +390,17 @@ Solution: Change the student code to be unique within the school
                 ("state", "in", ["open", "done"]),
                 ("student_id", "=", record.id),
             ]
-            enrollments = self.env["school_enrollment"].search(criteria)
+            enrollments = (
+                self.env["school_enrollment"]
+                .search(criteria)
+                .sorted(
+                    key=lambda e: (
+                        e.academic_term_id.date_start
+                        or fields.Date.to_date("1900-01-01"),
+                        e.id,
+                    )
+                )
+            )
             if len(enrollments) > 0:
                 result = enrollments[-1].grade_id
             record.current_grade_id = result
@@ -422,7 +432,17 @@ Solution: Change the student code to be unique within the school
                     ("state", "=", "done"),
                     ("student_id", "=", record.id),
                 ]
-                enrollments = self.env["school_enrollment"].search(criteria)
+                enrollments = (
+                    self.env["school_enrollment"]
+                    .search(criteria)
+                    .sorted(
+                        key=lambda e: (
+                            e.academic_term_id.date_start
+                            or fields.Date.to_date("1900-01-01"),
+                            e.id,
+                        )
+                    )
+                )
                 if len(enrollments) > 0:
                     last_enrollment = enrollments[-1]
                     if last_enrollment.last_term:

--- a/ssi_school/tests/test_data_student.yaml
+++ b/ssi_school/tests/test_data_student.yaml
@@ -699,3 +699,250 @@ scenarios:
           state:
             type: "value"
             expected: "dropped"
+
+  - name: "Compute Current And Next Grade Uses Chronological Enrollment Order"
+    steps:
+      - step: "Create grade type"
+        action: "create"
+        model: "school_grade_type"
+        save_as: "grade_type"
+        values:
+          name: "Grade Type Chronological Order"
+          code: "GTCHR"
+          sequence: 10
+      - step: "Create school"
+        action: "create"
+        model: "school"
+        save_as: "school"
+        values:
+          name: "School Chronological Order"
+          code: "SCHCHR"
+          grade_type_id: "EVAL: registry['grade_type'].id"
+      - step: "Create grade 1 (sequence 10)"
+        action: "create"
+        model: "school_grade"
+        save_as: "grade_1"
+        values:
+          name: "Grade 1 Chronological"
+          code: "G1CHR"
+          sequence: 10
+          type_id: "EVAL: registry['grade_type'].id"
+      - step: "Create grade 2 (sequence 20)"
+        action: "create"
+        model: "school_grade"
+        save_as: "grade_2"
+        values:
+          name: "Grade 2 Chronological"
+          code: "G2CHR"
+          sequence: 20
+          type_id: "EVAL: registry['grade_type'].id"
+      - step: "Create grade 3 (sequence 30)"
+        action: "create"
+        model: "school_grade"
+        save_as: "grade_3"
+        values:
+          name: "Grade 3 Chronological"
+          code: "G3CHR"
+          sequence: 30
+          type_id: "EVAL: registry['grade_type'].id"
+      - step: "Create grade class for grade 1"
+        action: "create"
+        model: "school_grade_class"
+        save_as: "grade_class_1"
+        values:
+          name: "Class Chronological G1"
+          code: "CLCHR1"
+          school_id: "EVAL: registry['school'].id"
+          grade_id: "EVAL: registry['grade_1'].id"
+      - step: "Create grade class for grade 2"
+        action: "create"
+        model: "school_grade_class"
+        save_as: "grade_class_2"
+        values:
+          name: "Class Chronological G2"
+          code: "CLCHR2"
+          school_id: "EVAL: registry['school'].id"
+          grade_id: "EVAL: registry['grade_2'].id"
+      - step: "Create academic year Y1 (chronologically earlier)"
+        action: "create"
+        model: "school_academic_year"
+        save_as: "year_1"
+        values:
+          name: "2023/2024 Chronological"
+          code: "AYCHR1"
+          date_start: "2023-07-01"
+          date_end: "2024-06-30"
+      - step: "Create academic term for Y1 (its only term)"
+        action: "create"
+        model: "school_academic_term"
+        save_as: "term_1"
+        values:
+          name: "Term Y1 Chronological"
+          code: "TMCHR1"
+          date_start: "2023-07-01"
+          date_end: "2024-06-30"
+          year_id: "EVAL: registry['year_1'].id"
+      - step: "Create academic year Y2 (chronologically later)"
+        action: "create"
+        model: "school_academic_year"
+        save_as: "year_2"
+        values:
+          name: "2024/2025 Chronological"
+          code: "AYCHR2"
+          date_start: "2024-07-01"
+          date_end: "2025-06-30"
+      - step: "Create academic term for Y2 (its only term)"
+        action: "create"
+        model: "school_academic_term"
+        save_as: "term_2"
+        values:
+          name: "Term Y2 Chronological"
+          code: "TMCHR2"
+          date_start: "2024-07-01"
+          date_end: "2025-06-30"
+          year_id: "EVAL: registry['year_2'].id"
+      - step: "Create student contact"
+        action: "create"
+        model: "res.partner"
+        save_as: "contact"
+        values:
+          name: "Student Chronological Contact"
+      - step: "Create student"
+        action: "create"
+        model: "school_student"
+        save_as: "student"
+        values:
+          name: "Student Chronological"
+          code: "STUCHR"
+          contact_id: "EVAL: registry['contact'].id"
+          school_id: "EVAL: registry['school'].id"
+      - step:
+          "Create enrollment for Y2 first (back-fill: created first, id smaller, but
+          chronologically later)"
+        action: "create"
+        model: "school_enrollment"
+        save_as: "enrollment_late"
+        values:
+          academic_year_id: "EVAL: registry['year_2'].id"
+          academic_term_id: "EVAL: registry['term_2'].id"
+          school_id: "EVAL: registry['school'].id"
+          grade_id: "EVAL: registry['grade_2'].id"
+          grade_class_id: "EVAL: registry['grade_class_2'].id"
+          student_id: "EVAL: registry['student'].id"
+          promote_to_grade_id: "EVAL: registry['grade_3'].id"
+      - step: "Force enrollment for Y2 to done"
+        action: "write"
+        target: "enrollment_late"
+        values:
+          state: "done"
+      - step:
+          "Create enrollment for Y1 afterwards (back-fill: created later, id larger, but
+          chronologically earlier)"
+        action: "create"
+        model: "school_enrollment"
+        save_as: "enrollment_early"
+        values:
+          academic_year_id: "EVAL: registry['year_1'].id"
+          academic_term_id: "EVAL: registry['term_1'].id"
+          school_id: "EVAL: registry['school'].id"
+          grade_id: "EVAL: registry['grade_1'].id"
+          grade_class_id: "EVAL: registry['grade_class_1'].id"
+          student_id: "EVAL: registry['student'].id"
+          promote_to_grade_id: "EVAL: registry['grade_2'].id"
+      - step: "Force enrollment for Y1 to done"
+        action: "write"
+        target: "enrollment_early"
+        values:
+          state: "done"
+      - step: "Invalidate student cache"
+        action: "call"
+        target: "student"
+        method: "invalidate_cache"
+      - step:
+          "Assert current_grade_id is grade 2 (from the chronologically latest
+          enrollment, not the last-created one)"
+        action: "search"
+        model: "school_grade"
+        domain:
+          - ["id", "=", "EVAL: registry['student'].current_grade_id.id"]
+          - ["id", "=", "EVAL: registry['grade_2'].id"]
+        save_as: "check_current_grade"
+        expect_count: 1
+      - step:
+          "Assert next_grade_id is grade 3 (promoted from the chronologically latest
+          enrollment)"
+        action: "search"
+        model: "school_grade"
+        domain:
+          - ["id", "=", "EVAL: registry['student'].next_grade_id.id"]
+          - ["id", "=", "EVAL: registry['grade_3'].id"]
+        save_as: "check_next_grade"
+        expect_count: 1
+
+  - name:
+      "Compute Next Grade From Initial Grade Unaffected By Chronological Ordering Fix"
+    steps:
+      - step: "Create grade type"
+        action: "create"
+        model: "school_grade_type"
+        save_as: "grade_type"
+        values:
+          name: "Grade Type Chronological Control"
+          code: "GTCHRCTL"
+          sequence: 10
+      - step: "Create school"
+        action: "create"
+        model: "school"
+        save_as: "school"
+        values:
+          name: "School Chronological Control"
+          code: "SCHCHRCTL"
+          grade_type_id: "EVAL: registry['grade_type'].id"
+      - step: "Create grade 1 (sequence 10)"
+        action: "create"
+        model: "school_grade"
+        save_as: "grade_1"
+        values:
+          name: "Grade 1 Chronological Control"
+          code: "G1CTL"
+          sequence: 10
+          type_id: "EVAL: registry['grade_type'].id"
+      - step: "Create grade 2 (sequence 20)"
+        action: "create"
+        model: "school_grade"
+        save_as: "grade_2"
+        values:
+          name: "Grade 2 Chronological Control"
+          code: "G2CTL"
+          sequence: 20
+          type_id: "EVAL: registry['grade_type'].id"
+      - step: "Create student contact"
+        action: "create"
+        model: "res.partner"
+        save_as: "contact"
+        values:
+          name: "Student Chronological Control Contact"
+      - step: "Create student with initial_grade_id and no enrollment"
+        action: "create"
+        model: "school_student"
+        save_as: "student"
+        values:
+          name: "Student Chronological Control"
+          code: "STUCHRCTL"
+          contact_id: "EVAL: registry['contact'].id"
+          school_id: "EVAL: registry['school'].id"
+          initial_grade_id: "EVAL: registry['grade_1'].id"
+      - step: "Invalidate student cache"
+        action: "call"
+        target: "student"
+        method: "invalidate_cache"
+      - step:
+          "Assert next_grade_id is grade 2 (initial_grade_id.next_grade_id branch is
+          unaffected)"
+        action: "search"
+        model: "school_grade"
+        domain:
+          - ["id", "=", "EVAL: registry['student'].next_grade_id.id"]
+          - ["id", "=", "EVAL: registry['grade_2'].id"]
+        save_as: "check_next_grade"
+        expect_count: 1


### PR DESCRIPTION
## Ringkasan

* Urutkan pencarian enrollment secara kronologis (berdasarkan `academic_term_id.date_start`) pada `_compute_current_grade_id` dan `_compute_next_grade_id` di `school_student`, bukan berdasarkan urutan id/pembuatan record.
* Mencegah `current_grade_id`/`next_grade_id` keliru saat enrollment tahun lama di-input belakangan setelah enrollment tahun baru (koreksi data/migrasi histori).
* Tambah skenario unit test back-fill dan skenario kendali `initial_grade_id` tanpa enrollment.

Referensi: BL-0082 (backlog `ssi_school`).

## Test plan

- [x] Unit test ditulis (skenario YAML `odoo-yaml-test`), dijalankan via CI.