### PR TITLE
[UPD] ssi_school_student_graduation_operating_unit

### DIFF
--- a/ssi_school_student_graduation_operating_unit/__manifest__.py
+++ b/ssi_school_student_graduation_operating_unit/__manifest__.py
@@ -4,7 +4,7 @@
 
 {
     "name": "School Student Graduation - Operating Unit",
-    "version": "14.0.1.0.0",
+    "version": "14.0.1.1.0",
     "website": "https://simetri-sinergi.id",
     "author": (
         "OpenSynergy Indonesia, "
@@ -22,6 +22,9 @@
         "security/res_groups/school_student_graduation.xml",
         "security/ir_rule/school_student_graduation.xml",
         "views/school_student_graduation.xml",
+        "security/res_groups/school_student_graduation_batch.xml",
+        "security/ir_rule/school_student_graduation_batch.xml",
+        "views/school_student_graduation_batch.xml",
     ],
     "demo": [],
 }

--- a/ssi_school_student_graduation_operating_unit/models/__init__.py
+++ b/ssi_school_student_graduation_operating_unit/models/__init__.py
@@ -3,3 +3,4 @@
 # License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl).
 
 from . import school_student_graduation  # noqa: F401
+from . import school_student_graduation_batch  # noqa: F401

--- a/ssi_school_student_graduation_operating_unit/models/school_student_graduation_batch.py
+++ b/ssi_school_student_graduation_operating_unit/models/school_student_graduation_batch.py
@@ -1,0 +1,25 @@
+# Copyright 2026 OpenSynergy Indonesia
+# Copyright 2026 PT. Simetri Sinergi Indonesia
+# License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl).
+
+from odoo import models
+
+
+class SchoolStudentGraduationBatch(models.Model):
+    """
+    Extends School Student Graduation Batch with single operating unit
+    support, restricting each batch record to one operating unit and
+    propagating that operating unit to every school_student_graduation
+    document it generates.
+    """
+
+    _name = "school_student_graduation_batch"
+    _inherit = [
+        "school_student_graduation_batch",
+        "mixin.single_operating_unit",
+    ]
+
+    def _prepare_graduation_data(self, line):
+        res = super()._prepare_graduation_data(line)
+        res["operating_unit_id"] = self.operating_unit_id.id
+        return res

--- a/ssi_school_student_graduation_operating_unit/security/ir_rule/school_student_graduation_batch.xml
+++ b/ssi_school_student_graduation_operating_unit/security/ir_rule/school_student_graduation_batch.xml
@@ -1,0 +1,28 @@
+<?xml version="1.0" encoding="utf-8" ?>
+<!-- Copyright 2026 OpenSynergy Indonesia
+     Copyright 2026 PT. Simetri Sinergi Indonesia
+     License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl). -->
+<odoo>
+
+<record id="school_student_graduation_batch_ou" model="ir.rule">
+    <field
+            name="name"
+        >school_student_graduation_batch - Responsible to operating unit data</field>
+    <field
+            name="model_id"
+            ref="ssi_school_student_graduation.model_school_student_graduation_batch"
+        />
+    <field
+            name="groups"
+            eval="[(4, ref('school_student_graduation_batch_operating_unit_group'))]"
+        />
+    <field
+            name="domain_force"
+        >[('operating_unit_id','in',[g.id for g in user.operating_unit_ids])]</field>
+    <field name="perm_unlink" eval="1" />
+    <field name="perm_write" eval="1" />
+    <field name="perm_read" eval="1" />
+    <field name="perm_create" eval="1" />
+</record>
+
+</odoo>

--- a/ssi_school_student_graduation_operating_unit/security/res_groups/school_student_graduation_batch.xml
+++ b/ssi_school_student_graduation_operating_unit/security/res_groups/school_student_graduation_batch.xml
@@ -1,0 +1,26 @@
+<?xml version="1.0" encoding="utf-8" ?>
+<!-- Copyright 2026 OpenSynergy Indonesia
+     Copyright 2026 PT. Simetri Sinergi Indonesia
+     License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl). -->
+<odoo>
+
+<record id="school_student_graduation_batch_operating_unit_group" model="res.groups">
+    <field name="name">Operating Unit</field>
+    <field
+            name="category_id"
+            ref="ssi_school_student_graduation.school_student_graduation_batch_data_ownership_module_category"
+        />
+</record>
+
+<record
+        id="ssi_school_student_graduation.school_student_graduation_batch_company_group"
+        model="res.groups"
+    >
+    <field name="name">Company</field>
+    <field
+            name="implied_ids"
+            eval="[(6, 0, [ref('school_student_graduation_batch_operating_unit_group')])]"
+        />
+</record>
+
+</odoo>

--- a/ssi_school_student_graduation_operating_unit/tests/__init__.py
+++ b/ssi_school_student_graduation_operating_unit/tests/__init__.py
@@ -3,3 +3,4 @@
 # License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl).
 
 from . import test_school_student_graduation_operating_unit  # noqa: F401
+from . import test_school_student_graduation_batch_operating_unit  # noqa: F401

--- a/ssi_school_student_graduation_operating_unit/tests/test_data_school_student_graduation_batch_operating_unit.yaml
+++ b/ssi_school_student_graduation_operating_unit/tests/test_data_school_student_graduation_batch_operating_unit.yaml
@@ -1,0 +1,110 @@
+scenarios:
+  - name: "Student Graduation Batch propagates Operating Unit to generated Graduation"
+    steps:
+      - step: "Setup - create operating unit partner"
+        action: "create"
+        model: "res.partner"
+        save_as: "ou_partner"
+        values:
+          name: "Graduation Batch Operating Unit Partner"
+
+      - step: "Setup - create operating unit"
+        action: "create"
+        model: "operating.unit"
+        save_as: "ou"
+        values:
+          name: "Graduation Batch Operating Unit"
+          code: "OUSGB1"
+          company_id: "REF: base.main_company"
+          partner_id: "EVAL: registry['ou_partner'].id"
+
+      - step: "Setup - create grade type"
+        action: "create"
+        model: "school_grade_type"
+        save_as: "grade_type"
+        values:
+          name: "Grade Type Graduation Batch OU Test"
+          code: "GTSGBOU1"
+          sequence: 10
+
+      - step: "Setup - create school"
+        action: "create"
+        model: "school"
+        save_as: "school"
+        values:
+          name: "School Graduation Batch OU Test"
+          code: "SCHSGBOU1"
+          grade_type_id: "EVAL: registry['grade_type'].id"
+
+      - step: "Setup - create student contact"
+        action: "create"
+        model: "res.partner"
+        save_as: "contact"
+        values:
+          name: "Student Contact Graduation Batch OU Test"
+
+      - step: "Setup - create student, already enrolled and eligible"
+        action: "create"
+        model: "school_student"
+        save_as: "student"
+        values:
+          name: "Student Graduation Batch OU Test"
+          code: "STUSGBOU1"
+          contact_id: "EVAL: registry['contact'].id"
+          school_id: "EVAL: registry['school'].id"
+          state: "enrol"
+
+      - step: "Create graduation batch with operating unit and student line"
+        action: "create"
+        model: "school_student_graduation_batch"
+        save_as: "batch"
+        values:
+          date: "2025-06-30"
+          operating_unit_id: "EVAL: registry['ou'].id"
+          line_ids:
+            - - 0
+              - 0
+              - student_id: "EVAL: registry['student'].id"
+
+      - step: "Assert operating unit stored on batch via search"
+        action: "search"
+        model: "school_student_graduation_batch"
+        domain:
+          - ["id", "=", "EVAL: registry['batch'].id"]
+          - ["operating_unit_id", "=", "EVAL: registry['ou'].id"]
+        save_as: "check_batch_operating_unit_stored"
+        expect_count: 1
+
+      - step: "Confirm batch"
+        action: "call"
+        target: "batch"
+        method: "action_confirm"
+        as_user: "base.user_admin"
+        asserts:
+          state:
+            type: "value"
+            expected: "confirm"
+
+      - step: "Invalidate batch cache before approve"
+        action: "call"
+        target: "batch"
+        method: "invalidate_cache"
+
+      - step: "Approve batch, triggering done and graduation generation"
+        action: "call"
+        target: "batch"
+        method: "action_approve_approval"
+        as_user: "base.user_admin"
+        asserts:
+          state:
+            type: "value"
+            expected: "done"
+
+      - step: "Assert generated graduation inherited batch operating unit"
+        action: "search"
+        model: "school_student_graduation"
+        domain:
+          - ["student_id", "=", "EVAL: registry['student'].id"]
+          - ["operating_unit_id", "=", "EVAL: registry['ou'].id"]
+        save_as: "check_graduation_operating_unit_propagated"
+        expect_count: 1

--- a/ssi_school_student_graduation_operating_unit/tests/test_school_student_graduation_batch_operating_unit.py
+++ b/ssi_school_student_graduation_operating_unit/tests/test_school_student_graduation_batch_operating_unit.py
@@ -1,0 +1,17 @@
+# Copyright 2026 OpenSynergy Indonesia
+# Copyright 2026 PT. Simetri Sinergi Indonesia
+# License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl).
+
+from odoo_yaml_test import YamlTransactionCase
+
+from odoo.tests import tagged
+
+
+@tagged("post_install", "-at_install")
+class TestSchoolStudentGraduationBatchOperatingUnit(
+    YamlTransactionCase
+):  # pylint: disable=too-few-public-methods
+    def test_school_student_graduation_batch_operating_unit(self):
+        self.run_yaml_scenario(
+            "test_data_school_student_graduation_batch_operating_unit.yaml"
+        )

--- a/ssi_school_student_graduation_operating_unit/views/school_student_graduation_batch.xml
+++ b/ssi_school_student_graduation_operating_unit/views/school_student_graduation_batch.xml
@@ -1,0 +1,67 @@
+<?xml version="1.0" encoding="utf-8" ?>
+<!-- Copyright 2026 OpenSynergy Indonesia
+     Copyright 2026 PT. Simetri Sinergi Indonesia
+     License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl). -->
+<odoo>
+
+<record id="school_student_graduation_batch_view_tree_ou" model="ir.ui.view">
+    <field name="name">school_student_graduation_batch tree - operating unit</field>
+    <field name="model">school_student_graduation_batch</field>
+    <field
+            name="inherit_id"
+            ref="ssi_school_student_graduation.school_student_graduation_batch_view_tree"
+        />
+    <field name="arch" type="xml">
+        <data>
+            <xpath expr="//field[@name='company_id']" position="after">
+                <field
+                        name="operating_unit_id"
+                        groups="operating_unit.group_multi_operating_unit"
+                        optional="hide"
+                    />
+            </xpath>
+        </data>
+    </field>
+</record>
+
+<record id="school_student_graduation_batch_view_form_ou" model="ir.ui.view">
+    <field name="name">school_student_graduation_batch form - operating unit</field>
+    <field name="model">school_student_graduation_batch</field>
+    <field
+            name="inherit_id"
+            ref="ssi_school_student_graduation.school_student_graduation_batch_view_form"
+        />
+    <field name="arch" type="xml">
+        <data>
+            <xpath expr="//field[@name='company_id']" position="after">
+                <field
+                        name="operating_unit_id"
+                        groups="operating_unit.group_multi_operating_unit"
+                    />
+            </xpath>
+        </data>
+    </field>
+</record>
+
+<record id="school_student_graduation_batch_view_search_ou" model="ir.ui.view">
+    <field name="name">school_student_graduation_batch search - operating unit</field>
+    <field name="model">school_student_graduation_batch</field>
+    <field
+            name="inherit_id"
+            ref="ssi_school_student_graduation.school_student_graduation_batch_view_search"
+        />
+    <field name="arch" type="xml">
+        <data>
+            <xpath expr="//group" position="inside">
+                <filter
+                        name="grp_ou"
+                        string="Operating Unit"
+                        context="{'group_by':'operating_unit_id'}"
+                        groups="operating_unit.group_multi_operating_unit"
+                    />
+            </xpath>
+        </data>
+    </field>
+</record>
+
+</odoo>


### PR DESCRIPTION
## Summary
- Menambahkan dukungan single Operating Unit ke `school_student_graduation_batch` (BL-0100).
- Meneruskan `operating_unit_id` dari batch ke setiap dokumen `school_student_graduation` yang di-generate saat batch done (override `_prepare_graduation_data`).
- Menambahkan security (res_groups + ir_rule) dan view OU untuk batch, mengikuti pola yang sudah ada untuk `school_student_graduation` di modul ini.
- Menambahkan unit test skenario propagasi Operating Unit batch -> graduation.

## Test plan
- [x] Unit test ditulis (`tests/test_school_student_graduation_batch_operating_unit.py` + data YAML) dan terdaftar di `tests/__init__.py`.
- [ ] CI hijau.