### PR TITLE
[UPD] ssi_school, ssi_school_admission

### DIFF
--- a/ssi_school/models/school_enrollment.py
+++ b/ssi_school/models/school_enrollment.py
@@ -5,7 +5,7 @@
 from datetime import date as datetime_date
 
 from odoo import _, api, fields, models
-from odoo.exceptions import ValidationError
+from odoo.exceptions import UserError, ValidationError
 
 from odoo.addons.ssi_decorator import ssi_decorator
 
@@ -767,6 +767,46 @@ Solution: Choose a different Grade Class or increase its capacity
         )
         if details:
             details.with_context(bypass_addendum_lock=True).write({"locked": True})
+
+    def _unlock_payment_term(self):
+        self.ensure_one()
+        Term = self.env[
+            "school_enrollment_payment_term"
+        ]  # pylint: disable=invalid-name
+        Detail = self.env[  # pylint: disable=invalid-name
+            "school_enrollment_payment_term_detail"
+        ]
+        terms = Term.search([("enrollment_id", "=", self.id), ("locked", "=", True)])
+        if terms:
+            terms.with_context(bypass_addendum_lock=True).write({"locked": False})
+        details = Detail.search(
+            [("term_id.enrollment_id", "=", self.id), ("locked", "=", True)]
+        )
+        if details:
+            details.with_context(bypass_addendum_lock=True).write({"locked": False})
+
+    @ssi_decorator.post_restart_action()
+    def _10_unlock_payment_term(self):
+        self.ensure_one()
+        self._unlock_payment_term()
+
+    @ssi_decorator.pre_cancel_action()
+    def _10_check_payment_term_invoice(self):
+        self.ensure_one()
+        invoiced_terms = self.payment_term_ids.filtered(lambda r: r.invoice_id)
+        if invoiced_terms:
+            error_message = (
+                _(
+                    """
+Context: Cancel enrollment
+Database ID: %s
+Problem: Payment term '%s' is already linked to an invoice
+Solution: Delete or disconnect the invoice on the payment term before cancelling this enrollment
+"""
+                )
+                % (self.id, invoiced_terms[0].name)
+            )
+            raise UserError(error_message)
 
     @ssi_decorator.post_cancel_action()
     def _10_unenroll_student(self):

--- a/ssi_school/policy_template/school_enrollment.xml
+++ b/ssi_school/policy_template/school_enrollment.xml
@@ -194,7 +194,12 @@ if document.last_term:
             name="group_ids"
             eval="[(6,0,[ref('school_enrollment_validator_group')])]"
         />
-            <field name="restrict_additional" eval="0" />
+            <field name="restrict_additional" eval="1" />
+            <field name="additional_python_code">result = True
+for term in document.payment_term_ids:
+    if term.invoice_id:
+        result = False
+        break</field>
 </record>
 
 <!-- Restart -->

--- a/ssi_school/tests/__init__.py
+++ b/ssi_school/tests/__init__.py
@@ -24,6 +24,7 @@ from . import (  # noqa: F401
     test_school_enrollment_product_summary,
     test_school_enrollment_payment_date_pattern,
     test_school_enrollment_addendum,
+    test_school_enrollment_restart_unlock,
     test_school_enrollment_integrity,
     test_school_homeroom,
     test_school_homeroom_integrity,

--- a/ssi_school/tests/test_data_enrollment_restart_unlock.yaml
+++ b/ssi_school/tests/test_data_enrollment_restart_unlock.yaml
@@ -154,6 +154,11 @@ scenarios:
         method: "action_confirm"
         as_user: "base.user_admin"
 
+      - step: "Invalidate enrollment cache before approve"
+        action: "call"
+        target: "enrollment"
+        method: "invalidate_cache"
+
       - step: "Approve enrollment"
         action: "call"
         target: "enrollment"
@@ -190,6 +195,11 @@ scenarios:
             type: "value"
             expected: true
 
+      - step: "Invalidate enrollment cache before cancel"
+        action: "call"
+        target: "enrollment"
+        method: "invalidate_cache"
+
       - step: "Cancel enrollment"
         action: "call"
         target: "enrollment"
@@ -199,6 +209,11 @@ scenarios:
           state:
             type: "value"
             expected: "cancel"
+
+      - step: "Invalidate enrollment cache before restart"
+        action: "call"
+        target: "enrollment"
+        method: "invalidate_cache"
 
       - step: "Restart enrollment"
         action: "call"

--- a/ssi_school/tests/test_data_enrollment_restart_unlock.yaml
+++ b/ssi_school/tests/test_data_enrollment_restart_unlock.yaml
@@ -1,0 +1,267 @@
+scenarios:
+  - name: "Restart Unlocks Payment Term And Detail, Remains Editable"
+    steps:
+      - step: "Setup - get receivable journal"
+        action: "search"
+        model: "account.journal"
+        domain: [["type", "=", "sale"]]
+        save_as: "receivable_journal"
+        limit: 1
+
+      - step: "Setup - get account type ref"
+        action: "ref"
+        xml_id: "account.data_account_type_revenue"
+        save_as: "account_type"
+
+      - step: "Setup - create income account"
+        action: "create"
+        model: "account.account"
+        save_as: "account"
+        values:
+          name: "School Fee Income RUNLK1"
+          code: "RUNLK14200"
+          user_type_id: "EVAL: registry['account_type'].id"
+
+      - step: "Setup - create product"
+        action: "create"
+        model: "product.product"
+        save_as: "product"
+        values:
+          name: "School Fee RUNLK1"
+          type: "service"
+          list_price: 1000000.0
+
+      - step: "Setup - create grade type"
+        action: "create"
+        model: "school_grade_type"
+        save_as: "grade_type"
+        values:
+          name: "Grade Type RUNLK1"
+          code: "GTRUNLK1"
+          sequence: 10
+
+      - step: "Setup - create academic year"
+        action: "create"
+        model: "school_academic_year"
+        save_as: "academic_year"
+        values:
+          name: "2024/2025 RUNLK1"
+          code: "AYRUNLK1"
+          date_start: "2024-07-01"
+          date_end: "2025-06-30"
+
+      - step: "Setup - create academic term"
+        action: "create"
+        model: "school_academic_term"
+        save_as: "academic_term"
+        values:
+          name: "Semester RUNLK1"
+          code: "SMRUNLK1"
+          date_start: "2024-07-01"
+          date_end: "2025-06-30"
+          year_id: "EVAL: registry['academic_year'].id"
+          enrollment_state: "open"
+
+      - step: "Setup - create school"
+        action: "create"
+        model: "school"
+        save_as: "school"
+        values:
+          name: "School RUNLK1"
+          code: "SCHRUNLK1"
+          grade_type_id: "EVAL: registry['grade_type'].id"
+
+      - step: "Setup - create grade"
+        action: "create"
+        model: "school_grade"
+        save_as: "grade"
+        values:
+          name: "Grade RUNLK1"
+          code: "GRUNLK1"
+          sequence: 10
+          type_id: "EVAL: registry['grade_type'].id"
+
+      - step: "Setup - create grade class"
+        action: "create"
+        model: "school_grade_class"
+        save_as: "grade_class"
+        values:
+          name: "Class RUNLK1"
+          code: "CLARUNLK1"
+          school_id: "EVAL: registry['school'].id"
+          grade_id: "EVAL: registry['grade'].id"
+
+      - step: "Setup - create student contact"
+        action: "create"
+        model: "res.partner"
+        save_as: "contact"
+        values:
+          name: "Student Contact RUNLK1"
+
+      - step: "Setup - create student"
+        action: "create"
+        model: "school_student"
+        save_as: "student"
+        values:
+          name: "Student RUNLK1"
+          code: "STURUNLK1"
+          contact_id: "EVAL: registry['contact'].id"
+          school_id: "EVAL: registry['school'].id"
+
+      - step: "Create enrollment"
+        action: "create"
+        model: "school_enrollment"
+        save_as: "enrollment"
+        as_user: "base.user_admin"
+        values:
+          date: "2024-07-01"
+          academic_year_id: "EVAL: registry['academic_year'].id"
+          academic_term_id: "EVAL: registry['academic_term'].id"
+          school_id: "EVAL: registry['school'].id"
+          grade_id: "EVAL: registry['grade'].id"
+          grade_class_id: "EVAL: registry['grade_class'].id"
+          student_id: "EVAL: registry['student'].id"
+          currency_id: "EVAL: env.company.currency_id.id"
+          receivable_journal_id: "EVAL: registry['receivable_journal'].id"
+
+      - step: "Create payment term"
+        action: "create"
+        model: "school_enrollment_payment_term"
+        save_as: "term"
+        as_user: "base.user_admin"
+        values:
+          enrollment_id: "EVAL: registry['enrollment'].id"
+          name: "Term 1 RUNLK1"
+          sequence: 10
+
+      - step: "Create payment term detail"
+        action: "create"
+        model: "school_enrollment_payment_term_detail"
+        save_as: "detail"
+        as_user: "base.user_admin"
+        values:
+          term_id: "EVAL: registry['term'].id"
+          product_id: "EVAL: registry['product'].id"
+          name: "Fee RUNLK1"
+          account_id: "EVAL: registry['account'].id"
+          uom_quantity: 1.0
+          uom_id: "REF: uom.product_uom_unit"
+          price_unit: 1000000.0
+
+      - step: "Confirm enrollment"
+        action: "call"
+        target: "enrollment"
+        method: "action_confirm"
+        as_user: "base.user_admin"
+
+      - step: "Approve enrollment"
+        action: "call"
+        target: "enrollment"
+        method: "action_approve_approval"
+        as_user: "base.user_admin"
+        asserts:
+          state:
+            type: "value"
+            expected: "open"
+
+      - step: "Invalidate term cache after opening"
+        action: "call"
+        target: "term"
+        method: "invalidate_cache"
+
+      - step: "Assert term locked after opening (control)"
+        action: "assert"
+        target: "term"
+        asserts:
+          locked:
+            type: "value"
+            expected: true
+
+      - step: "Invalidate detail cache after opening"
+        action: "call"
+        target: "detail"
+        method: "invalidate_cache"
+
+      - step: "Assert detail locked after opening (control)"
+        action: "assert"
+        target: "detail"
+        asserts:
+          locked:
+            type: "value"
+            expected: true
+
+      - step: "Cancel enrollment"
+        action: "call"
+        target: "enrollment"
+        method: "action_cancel"
+        as_user: "base.user_admin"
+        asserts:
+          state:
+            type: "value"
+            expected: "cancel"
+
+      - step: "Restart enrollment"
+        action: "call"
+        target: "enrollment"
+        method: "action_restart"
+        as_user: "base.user_admin"
+        asserts:
+          state:
+            type: "value"
+            expected: "draft"
+
+      - step: "Invalidate term cache after restart"
+        action: "call"
+        target: "term"
+        method: "invalidate_cache"
+
+      - step: "Assert term unlocked after restart"
+        action: "assert"
+        target: "term"
+        asserts:
+          locked:
+            type: "value"
+            expected: false
+
+      - step: "Invalidate detail cache after restart"
+        action: "call"
+        target: "detail"
+        method: "invalidate_cache"
+
+      - step: "Assert detail unlocked after restart"
+        action: "assert"
+        target: "detail"
+        asserts:
+          locked:
+            type: "value"
+            expected: false
+
+      - step: "Term is editable again after restart"
+        action: "write"
+        target: "term"
+        as_user: "base.user_admin"
+        values:
+          name: "Term 1 RUNLK1 Edited"
+
+      - step: "Assert term name updated"
+        action: "assert"
+        target: "term"
+        asserts:
+          name:
+            type: "value"
+            expected: "Term 1 RUNLK1 Edited"
+
+      - step: "Detail is editable again after restart"
+        action: "write"
+        target: "detail"
+        as_user: "base.user_admin"
+        values:
+          price_unit: 750000.0
+
+      - step: "Assert detail price updated"
+        action: "assert"
+        target: "detail"
+        asserts:
+          price_unit:
+            type: "value"
+            expected: 750000.0

--- a/ssi_school/tests/test_school_enrollment_restart_unlock.py
+++ b/ssi_school/tests/test_school_enrollment_restart_unlock.py
@@ -162,8 +162,10 @@ class TestSchoolEnrollmentRestartUnlock(YamlTransactionCase):
         self._open_enrollment(target)
 
         admin = self.env.ref("base.user_admin")
+        target.invalidate_cache()
         target.with_user(admin).action_cancel()
         self.assertEqual(target.state, "cancel")
+        target.invalidate_cache()
         target.with_user(admin).action_restart()
         self.assertEqual(target.state, "draft")
         old_term.invalidate_cache()

--- a/ssi_school/tests/test_school_enrollment_restart_unlock.py
+++ b/ssi_school/tests/test_school_enrollment_restart_unlock.py
@@ -1,0 +1,217 @@
+# Copyright 2026 OpenSynergy Indonesia
+# Copyright 2026 PT. Simetri Sinergi Indonesia
+# License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl).
+
+from odoo_yaml_test import YamlTransactionCase
+
+from odoo.exceptions import UserError
+from odoo.tests import tagged
+
+
+@tagged("post_install", "-at_install")
+class TestSchoolEnrollmentRestartUnlock(YamlTransactionCase):
+    def test_enrollment_restart_unlock(self):
+        self.run_yaml_scenario("test_data_enrollment_restart_unlock.yaml")
+
+    def _create_base_data(self, suffix):
+        account_type = self.env.ref("account.data_account_type_revenue")
+        account = self.env["account.account"].create(
+            {
+                "name": "School Fee Income %s" % suffix,
+                "code": "RSTUNLK%s4200" % suffix,
+                "user_type_id": account_type.id,
+            }
+        )
+        product = self.env["product.product"].create(
+            {
+                "name": "School Fee %s" % suffix,
+                "type": "service",
+                "list_price": 1000000.0,
+            }
+        )
+        grade_type = self.env["school_grade_type"].create(
+            {
+                "name": "Grade Type %s" % suffix,
+                "code": "GT%s" % suffix,
+                "sequence": 10,
+            }
+        )
+        academic_year = self.env["school_academic_year"].create(
+            {
+                "name": "2024/2025 %s" % suffix,
+                "code": "AY%s" % suffix,
+                "date_start": "2024-07-01",
+                "date_end": "2025-06-30",
+            }
+        )
+        academic_term = self.env["school_academic_term"].create(
+            {
+                "name": "Semester %s" % suffix,
+                "code": "SM%s" % suffix,
+                "date_start": "2024-07-01",
+                "date_end": "2025-06-30",
+                "year_id": academic_year.id,
+                "enrollment_state": "open",
+            }
+        )
+        school = self.env["school"].create(
+            {
+                "name": "School %s" % suffix,
+                "code": "SCH%s" % suffix,
+                "grade_type_id": grade_type.id,
+            }
+        )
+        grade = self.env["school_grade"].create(
+            {
+                "name": "Grade %s" % suffix,
+                "code": "G%s" % suffix,
+                "sequence": 10,
+                "type_id": grade_type.id,
+            }
+        )
+        grade_class = self.env["school_grade_class"].create(
+            {
+                "name": "Class %s" % suffix,
+                "code": "CLA%s" % suffix,
+                "school_id": school.id,
+                "grade_id": grade.id,
+            }
+        )
+        journal = self.env["account.journal"].search([("type", "=", "sale")], limit=1)
+        return {
+            "account": account,
+            "product": product,
+            "academic_year": academic_year,
+            "academic_term": academic_term,
+            "school": school,
+            "grade": grade,
+            "grade_class": grade_class,
+            "journal": journal,
+        }
+
+    def _create_enrollment(self, base, name_suffix):
+        contact = self.env["res.partner"].create(
+            {"name": "Student Contact %s" % name_suffix}
+        )
+        student = self.env["school_student"].create(
+            {
+                "name": "Student %s" % name_suffix,
+                "code": "STU%s" % name_suffix,
+                "contact_id": contact.id,
+                "school_id": base["school"].id,
+            }
+        )
+        return self.env["school_enrollment"].create(
+            {
+                "date": "2024-07-01",
+                "academic_year_id": base["academic_year"].id,
+                "academic_term_id": base["academic_term"].id,
+                "school_id": base["school"].id,
+                "grade_id": base["grade"].id,
+                "grade_class_id": base["grade_class"].id,
+                "student_id": student.id,
+                "currency_id": self.env.company.currency_id.id,
+                "receivable_journal_id": base["journal"].id,
+            }
+        )
+
+    def _add_term(self, base, enrollment, suffix):
+        term = self.env["school_enrollment_payment_term"].create(
+            {
+                "enrollment_id": enrollment.id,
+                "name": "Term %s" % suffix,
+                "sequence": 10,
+            }
+        )
+        detail = self.env["school_enrollment_payment_term_detail"].create(
+            {
+                "term_id": term.id,
+                "product_id": base["product"].id,
+                "name": "Fee %s" % suffix,
+                "account_id": base["account"].id,
+                "uom_quantity": 1.0,
+                "uom_id": self.env.ref("uom.product_uom_unit").id,
+                "price_unit": 1000000.0,
+            }
+        )
+        return term, detail
+
+    def _open_enrollment(self, enrollment):
+        admin = self.env.ref("base.user_admin")
+        enrollment.with_user(admin).action_confirm()
+        enrollment.invalidate_cache()
+        enrollment.with_user(admin).action_approve_approval()
+        self.assertEqual(enrollment.state, "open")
+
+    def test_lock_not_leaked_without_cancel(self):
+        base = self._create_base_data("NOREG1")
+        enrollment = self._create_enrollment(base, "NOREG1")
+        term, detail = self._add_term(base, enrollment, "NOREG1")
+        self._open_enrollment(enrollment)
+        term.invalidate_cache()
+        detail.invalidate_cache()
+        self.assertTrue(term.locked)
+        self.assertTrue(detail.locked)
+        with self.assertRaises(UserError):
+            term.write({"name": "Changed Name NOREG1"})
+
+    def test_copy_payment_term_after_restart(self):
+        base = self._create_base_data("CPTRST1")
+        target = self._create_enrollment(base, "CPTRST1TGT")
+        old_term, _old_detail = self._add_term(base, target, "CPTRST1OLD")
+        self._open_enrollment(target)
+
+        admin = self.env.ref("base.user_admin")
+        target.with_user(admin).action_cancel()
+        self.assertEqual(target.state, "cancel")
+        target.with_user(admin).action_restart()
+        self.assertEqual(target.state, "draft")
+        old_term.invalidate_cache()
+        self.assertFalse(old_term.locked)
+
+        source = self._create_enrollment(base, "CPTRST1SRC")
+        self._add_term(base, source, "CPTRST1NEW")
+
+        wizard = (
+            self.env["school_enrollment.wizard_copy_payment_term"]
+            .with_context(active_model="school_enrollment", active_ids=target.ids)
+            .create(
+                {
+                    "source_enrollment_id": source.id,
+                    "mode": "replace",
+                }
+            )
+        )
+        self.assertTrue(target.copy_payment_term_ok)
+        wizard.action_copy_payment_term()
+
+        target.invalidate_cache()
+        self.assertEqual(len(target.payment_term_ids), 1)
+        self.assertEqual(target.payment_term_ids.name, "Term CPTRST1NEW")
+
+    def test_cancel_blocked_when_invoice_exists(self):
+        base = self._create_base_data("CXLINV1")
+        enrollment = self._create_enrollment(base, "CXLINV1")
+        term, _detail = self._add_term(base, enrollment, "CXLINV1")
+        self._open_enrollment(enrollment)
+
+        term.action_create_invoice()
+        term.invalidate_cache()
+        self.assertTrue(term.invoice_id)
+
+        enrollment.invalidate_cache()
+        self.assertFalse(enrollment.cancel_ok)
+
+        admin = self.env.ref("base.user_admin")
+        with self.assertRaises(UserError):
+            enrollment.with_user(admin).action_cancel()
+
+        term.action_delete_invoice()
+        term.invalidate_cache()
+        self.assertFalse(term.invoice_id)
+
+        enrollment.invalidate_cache()
+        self.assertTrue(enrollment.cancel_ok)
+
+        enrollment.with_user(admin).action_cancel()
+        self.assertEqual(enrollment.state, "cancel")

--- a/ssi_school_admission/models/school_admission.py
+++ b/ssi_school_admission/models/school_admission.py
@@ -4,7 +4,8 @@
 
 from datetime import date as datetime_date
 
-from odoo import api, fields, models
+from odoo import _, api, fields, models
+from odoo.exceptions import UserError
 
 from odoo.addons.ssi_decorator import ssi_decorator
 
@@ -421,6 +422,44 @@ class SchoolAdmission(models.Model):
         )
         if details:
             details.with_context(bypass_addendum_lock=True).write({"locked": True})
+
+    def _unlock_payment_term(self):
+        self.ensure_one()
+        Term = self.env["school_admission_payment_term"]  # pylint: disable=invalid-name
+        Detail = self.env[  # pylint: disable=invalid-name
+            "school_admission_payment_term_detail"
+        ]
+        terms = Term.search([("admission_id", "=", self.id), ("locked", "=", True)])
+        if terms:
+            terms.with_context(bypass_addendum_lock=True).write({"locked": False})
+        details = Detail.search(
+            [("term_id.admission_id", "=", self.id), ("locked", "=", True)]
+        )
+        if details:
+            details.with_context(bypass_addendum_lock=True).write({"locked": False})
+
+    @ssi_decorator.post_restart_action()
+    def _10_unlock_payment_term(self):
+        self.ensure_one()
+        self._unlock_payment_term()
+
+    @ssi_decorator.pre_cancel_action()
+    def _10_check_payment_term_invoice(self):
+        self.ensure_one()
+        invoiced_terms = self.payment_term_ids.filtered(lambda r: r.invoice_id)
+        if invoiced_terms:
+            error_message = (
+                _(
+                    """
+Context: Cancel admission
+Database ID: %s
+Problem: Payment term '%s' is already linked to an invoice
+Solution: Delete or disconnect the invoice on the payment term before cancelling this admission
+"""
+                )
+                % (self.id, invoiced_terms[0].name)
+            )
+            raise UserError(error_message)
 
     @ssi_decorator.post_open_action()
     def _10_create_school_student(self):

--- a/ssi_school_admission/policy_template/school_admission.xml
+++ b/ssi_school_admission/policy_template/school_admission.xml
@@ -104,7 +104,12 @@
     <field name="restrict_user" eval="1" />
     <field name="computation_method">use_group</field>
     <field name="group_ids" eval="[(6,0,[ref('school_admission_validator_group')])]" />
-    <field name="restrict_additional" eval="0" />
+    <field name="restrict_additional" eval="1" />
+    <field name="additional_python_code">result = True
+for term in document.payment_term_ids:
+    if term.invoice_id:
+        result = False
+        break</field>
 </record>
 
 <!-- Restart -->

--- a/ssi_school_admission/tests/__init__.py
+++ b/ssi_school_admission/tests/__init__.py
@@ -9,6 +9,7 @@ from . import (  # noqa: F401
     test_school_admission_payment_date_pattern,
     test_school_admission_payment_term,
     test_school_admission_addendum,
+    test_school_admission_restart_unlock,
     test_school_admission_payment_term_duplicate,
     test_school_admission_copy_payment_term,
     test_school_admission_payment_product_configurator,

--- a/ssi_school_admission/tests/test_data_admission_restart_unlock.yaml
+++ b/ssi_school_admission/tests/test_data_admission_restart_unlock.yaml
@@ -133,6 +133,11 @@ scenarios:
         method: "action_confirm"
         as_user: "base.user_admin"
 
+      - step: "Invalidate admission cache before approve"
+        action: "call"
+        target: "admission"
+        method: "invalidate_cache"
+
       - step: "Approve admission"
         action: "call"
         target: "admission"
@@ -169,6 +174,11 @@ scenarios:
             type: "value"
             expected: true
 
+      - step: "Invalidate admission cache before cancel"
+        action: "call"
+        target: "admission"
+        method: "invalidate_cache"
+
       - step: "Cancel admission"
         action: "call"
         target: "admission"
@@ -178,6 +188,11 @@ scenarios:
           state:
             type: "value"
             expected: "cancel"
+
+      - step: "Invalidate admission cache before restart"
+        action: "call"
+        target: "admission"
+        method: "invalidate_cache"
 
       - step: "Restart admission"
         action: "call"

--- a/ssi_school_admission/tests/test_data_admission_restart_unlock.yaml
+++ b/ssi_school_admission/tests/test_data_admission_restart_unlock.yaml
@@ -1,0 +1,246 @@
+scenarios:
+  - name: "Restart Unlocks Payment Term And Detail, Remains Editable"
+    steps:
+      - step: "Setup - get receivable journal"
+        action: "search"
+        model: "account.journal"
+        domain: [["type", "=", "sale"]]
+        save_as: "receivable_journal"
+        limit: 1
+
+      - step: "Setup - get account type ref"
+        action: "ref"
+        xml_id: "account.data_account_type_revenue"
+        save_as: "account_type"
+
+      - step: "Setup - create income account"
+        action: "create"
+        model: "account.account"
+        save_as: "account"
+        values:
+          name: "Admission Fee Income RUNLK1"
+          code: "ADRUNLK14200"
+          user_type_id: "EVAL: registry['account_type'].id"
+
+      - step: "Setup - create product"
+        action: "create"
+        model: "product.product"
+        save_as: "product"
+        values:
+          name: "Admission Fee RUNLK1"
+          type: "service"
+          list_price: 2000000.0
+
+      - step: "Setup - create grade type"
+        action: "create"
+        model: "school_grade_type"
+        save_as: "grade_type"
+        values:
+          name: "Grade Type ADRUNLK1"
+          code: "GTADRUNLK1"
+          sequence: 10
+
+      - step: "Setup - create academic year"
+        action: "create"
+        model: "school_academic_year"
+        save_as: "academic_year"
+        values:
+          name: "2024/2025 ADRUNLK1"
+          code: "AYADRUNLK1"
+          date_start: "2024-07-01"
+          date_end: "2025-06-30"
+
+      - step: "Setup - create academic term"
+        action: "create"
+        model: "school_academic_term"
+        save_as: "academic_term"
+        values:
+          name: "Semester ADRUNLK1"
+          code: "SMADRUNLK1"
+          date_start: "2024-07-01"
+          date_end: "2025-06-30"
+          year_id: "EVAL: registry['academic_year'].id"
+          enrollment_state: "open"
+
+      - step: "Setup - create school"
+        action: "create"
+        model: "school"
+        save_as: "school"
+        values:
+          name: "School ADRUNLK1"
+          code: "SCHADRUNLK1"
+          grade_type_id: "EVAL: registry['grade_type'].id"
+
+      - step: "Setup - create grade"
+        action: "create"
+        model: "school_grade"
+        save_as: "grade"
+        values:
+          name: "Grade ADRUNLK1"
+          code: "GADRUNLK1"
+          sequence: 10
+          type_id: "EVAL: registry['grade_type'].id"
+
+      - step: "Setup - create student contact"
+        action: "create"
+        model: "res.partner"
+        save_as: "student_contact"
+        values:
+          name: "Student Contact ADRUNLK1"
+
+      - step: "Create admission"
+        action: "create"
+        model: "school_admission"
+        save_as: "admission"
+        as_user: "base.user_admin"
+        values:
+          date: "2024-07-01"
+          academic_year_id: "EVAL: registry['academic_year'].id"
+          academic_term_id: "EVAL: registry['academic_term'].id"
+          school_id: "EVAL: registry['school'].id"
+          grade_id: "EVAL: registry['grade'].id"
+          student_id: "EVAL: registry['student_contact'].id"
+          currency_id: "EVAL: env.company.currency_id.id"
+          receivable_journal_id: "EVAL: registry['receivable_journal'].id"
+
+      - step: "Create payment term"
+        action: "create"
+        model: "school_admission_payment_term"
+        save_as: "term"
+        as_user: "base.user_admin"
+        values:
+          admission_id: "EVAL: registry['admission'].id"
+          name: "Admission Term 1 ADRUNLK1"
+          sequence: 10
+
+      - step: "Create payment term detail"
+        action: "create"
+        model: "school_admission_payment_term_detail"
+        save_as: "detail"
+        as_user: "base.user_admin"
+        values:
+          term_id: "EVAL: registry['term'].id"
+          product_id: "EVAL: registry['product'].id"
+          name: "Admission Fee ADRUNLK1"
+          account_id: "EVAL: registry['account'].id"
+          uom_quantity: 1.0
+          uom_id: "REF: uom.product_uom_unit"
+          price_unit: 2000000.0
+
+      - step: "Confirm admission"
+        action: "call"
+        target: "admission"
+        method: "action_confirm"
+        as_user: "base.user_admin"
+
+      - step: "Approve admission"
+        action: "call"
+        target: "admission"
+        method: "action_approve_approval"
+        as_user: "base.user_admin"
+        asserts:
+          state:
+            type: "value"
+            expected: "open"
+
+      - step: "Invalidate term cache after opening"
+        action: "call"
+        target: "term"
+        method: "invalidate_cache"
+
+      - step: "Assert term locked after opening (control)"
+        action: "assert"
+        target: "term"
+        asserts:
+          locked:
+            type: "value"
+            expected: true
+
+      - step: "Invalidate detail cache after opening"
+        action: "call"
+        target: "detail"
+        method: "invalidate_cache"
+
+      - step: "Assert detail locked after opening (control)"
+        action: "assert"
+        target: "detail"
+        asserts:
+          locked:
+            type: "value"
+            expected: true
+
+      - step: "Cancel admission"
+        action: "call"
+        target: "admission"
+        method: "action_cancel"
+        as_user: "base.user_admin"
+        asserts:
+          state:
+            type: "value"
+            expected: "cancel"
+
+      - step: "Restart admission"
+        action: "call"
+        target: "admission"
+        method: "action_restart"
+        as_user: "base.user_admin"
+        asserts:
+          state:
+            type: "value"
+            expected: "draft"
+
+      - step: "Invalidate term cache after restart"
+        action: "call"
+        target: "term"
+        method: "invalidate_cache"
+
+      - step: "Assert term unlocked after restart"
+        action: "assert"
+        target: "term"
+        asserts:
+          locked:
+            type: "value"
+            expected: false
+
+      - step: "Invalidate detail cache after restart"
+        action: "call"
+        target: "detail"
+        method: "invalidate_cache"
+
+      - step: "Assert detail unlocked after restart"
+        action: "assert"
+        target: "detail"
+        asserts:
+          locked:
+            type: "value"
+            expected: false
+
+      - step: "Term is editable again after restart"
+        action: "write"
+        target: "term"
+        as_user: "base.user_admin"
+        values:
+          name: "Admission Term 1 ADRUNLK1 Edited"
+
+      - step: "Assert term name updated"
+        action: "assert"
+        target: "term"
+        asserts:
+          name:
+            type: "value"
+            expected: "Admission Term 1 ADRUNLK1 Edited"
+
+      - step: "Detail is editable again after restart"
+        action: "write"
+        target: "detail"
+        as_user: "base.user_admin"
+        values:
+          price_unit: 1500000.0
+
+      - step: "Assert detail price updated"
+        action: "assert"
+        target: "detail"
+        asserts:
+          price_unit:
+            type: "value"
+            expected: 1500000.0

--- a/ssi_school_admission/tests/test_school_admission_restart_unlock.py
+++ b/ssi_school_admission/tests/test_school_admission_restart_unlock.py
@@ -1,0 +1,200 @@
+# Copyright 2026 OpenSynergy Indonesia
+# Copyright 2026 PT. Simetri Sinergi Indonesia
+# License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl).
+
+from odoo_yaml_test import YamlTransactionCase
+
+from odoo.exceptions import UserError
+from odoo.tests import tagged
+
+
+@tagged("post_install", "-at_install")
+class TestSchoolAdmissionRestartUnlock(YamlTransactionCase):
+    def test_admission_restart_unlock(self):
+        self.run_yaml_scenario("test_data_admission_restart_unlock.yaml")
+
+    def _create_base_data(self, suffix):
+        account_type = self.env.ref("account.data_account_type_revenue")
+        account = self.env["account.account"].create(
+            {
+                "name": "Admission Fee Income %s" % suffix,
+                "code": "ADRSTUNLK%s4200" % suffix,
+                "user_type_id": account_type.id,
+            }
+        )
+        product = self.env["product.product"].create(
+            {
+                "name": "Admission Fee %s" % suffix,
+                "type": "service",
+                "list_price": 2000000.0,
+            }
+        )
+        grade_type = self.env["school_grade_type"].create(
+            {
+                "name": "Grade Type %s" % suffix,
+                "code": "GT%s" % suffix,
+                "sequence": 10,
+            }
+        )
+        academic_year = self.env["school_academic_year"].create(
+            {
+                "name": "2024/2025 %s" % suffix,
+                "code": "AY%s" % suffix,
+                "date_start": "2024-07-01",
+                "date_end": "2025-06-30",
+            }
+        )
+        academic_term = self.env["school_academic_term"].create(
+            {
+                "name": "Semester %s" % suffix,
+                "code": "SM%s" % suffix,
+                "date_start": "2024-07-01",
+                "date_end": "2025-06-30",
+                "year_id": academic_year.id,
+                "enrollment_state": "open",
+            }
+        )
+        school = self.env["school"].create(
+            {
+                "name": "School %s" % suffix,
+                "code": "SCH%s" % suffix,
+                "grade_type_id": grade_type.id,
+            }
+        )
+        grade = self.env["school_grade"].create(
+            {
+                "name": "Grade %s" % suffix,
+                "code": "G%s" % suffix,
+                "sequence": 10,
+                "type_id": grade_type.id,
+            }
+        )
+        journal = self.env["account.journal"].search([("type", "=", "sale")], limit=1)
+        return {
+            "account": account,
+            "product": product,
+            "academic_year": academic_year,
+            "academic_term": academic_term,
+            "school": school,
+            "grade": grade,
+            "journal": journal,
+        }
+
+    def _create_admission(self, base, name_suffix):
+        student_contact = self.env["res.partner"].create(
+            {"name": "Student Contact %s" % name_suffix}
+        )
+        return self.env["school_admission"].create(
+            {
+                "date": "2024-07-01",
+                "academic_year_id": base["academic_year"].id,
+                "academic_term_id": base["academic_term"].id,
+                "school_id": base["school"].id,
+                "grade_id": base["grade"].id,
+                "student_id": student_contact.id,
+                "pricelist_id": False,
+                "currency_id": self.env.company.currency_id.id,
+                "receivable_journal_id": base["journal"].id,
+            }
+        )
+
+    def _add_term(self, base, admission, suffix):
+        term = self.env["school_admission_payment_term"].create(
+            {
+                "admission_id": admission.id,
+                "name": "Admission Term %s" % suffix,
+                "sequence": 10,
+            }
+        )
+        detail = self.env["school_admission_payment_term_detail"].create(
+            {
+                "term_id": term.id,
+                "product_id": base["product"].id,
+                "name": "Admission Fee %s" % suffix,
+                "account_id": base["account"].id,
+                "uom_quantity": 1.0,
+                "uom_id": self.env.ref("uom.product_uom_unit").id,
+                "price_unit": 2000000.0,
+            }
+        )
+        return term, detail
+
+    def _open_admission(self, admission):
+        admin = self.env.ref("base.user_admin")
+        admission.with_user(admin).action_confirm()
+        admission.invalidate_cache()
+        admission.with_user(admin).action_approve_approval()
+        self.assertEqual(admission.state, "open")
+
+    def test_lock_not_leaked_without_cancel(self):
+        base = self._create_base_data("NOREG1")
+        admission = self._create_admission(base, "NOREG1")
+        term, detail = self._add_term(base, admission, "NOREG1")
+        self._open_admission(admission)
+        term.invalidate_cache()
+        detail.invalidate_cache()
+        self.assertTrue(term.locked)
+        self.assertTrue(detail.locked)
+        with self.assertRaises(UserError):
+            term.write({"name": "Changed Name NOREG1"})
+
+    def test_copy_payment_term_after_restart(self):
+        base = self._create_base_data("CPTRST1")
+        target = self._create_admission(base, "CPTRST1TGT")
+        old_term, _old_detail = self._add_term(base, target, "CPTRST1OLD")
+        self._open_admission(target)
+
+        admin = self.env.ref("base.user_admin")
+        target.with_user(admin).action_cancel()
+        self.assertEqual(target.state, "cancel")
+        target.with_user(admin).action_restart()
+        self.assertEqual(target.state, "draft")
+        old_term.invalidate_cache()
+        self.assertFalse(old_term.locked)
+
+        source = self._create_admission(base, "CPTRST1SRC")
+        self._add_term(base, source, "CPTRST1NEW")
+
+        wizard = (
+            self.env["school_admission.wizard_copy_payment_term"]
+            .with_context(active_model="school_admission", active_ids=target.ids)
+            .create(
+                {
+                    "source_admission_id": source.id,
+                    "mode": "replace",
+                }
+            )
+        )
+        self.assertTrue(target.copy_payment_term_ok)
+        wizard.action_copy_payment_term()
+
+        target.invalidate_cache()
+        self.assertEqual(len(target.payment_term_ids), 1)
+        self.assertEqual(target.payment_term_ids.name, "Admission Term CPTRST1NEW")
+
+    def test_cancel_blocked_when_invoice_exists(self):
+        base = self._create_base_data("CXLINV1")
+        admission = self._create_admission(base, "CXLINV1")
+        term, _detail = self._add_term(base, admission, "CXLINV1")
+        self._open_admission(admission)
+
+        term.action_create_invoice()
+        term.invalidate_cache()
+        self.assertTrue(term.invoice_id)
+
+        admission.invalidate_cache()
+        self.assertFalse(admission.cancel_ok)
+
+        admin = self.env.ref("base.user_admin")
+        with self.assertRaises(UserError):
+            admission.with_user(admin).action_cancel()
+
+        term.action_delete_invoice()
+        term.invalidate_cache()
+        self.assertFalse(term.invoice_id)
+
+        admission.invalidate_cache()
+        self.assertTrue(admission.cancel_ok)
+
+        admission.with_user(admin).action_cancel()
+        self.assertEqual(admission.state, "cancel")

--- a/ssi_school_admission/tests/test_school_admission_restart_unlock.py
+++ b/ssi_school_admission/tests/test_school_admission_restart_unlock.py
@@ -145,8 +145,10 @@ class TestSchoolAdmissionRestartUnlock(YamlTransactionCase):
         self._open_admission(target)
 
         admin = self.env.ref("base.user_admin")
+        target.invalidate_cache()
         target.with_user(admin).action_cancel()
         self.assertEqual(target.state, "cancel")
+        target.invalidate_cache()
         target.with_user(admin).action_restart()
         self.assertEqual(target.state, "draft")
         old_term.invalidate_cache()


### PR DESCRIPTION
## Ringkasan

Perbaikan bug yang sama di dua modul (BL-0102 `ssi_school`, BL-0103 `ssi_school_admission`,
BL-0103 depends_on BL-0102 agar pola implementasi identik):

Enrollment/admission yang pernah `open` (payment term & detail ter-`locked`), lalu
di-`cancel`, lalu di-`restart` kembali ke `draft` — payment term tetap terkunci
selamanya (tidak bisa diedit/dihapus, Copy Payment Term meledak `UserError` karena
`unlink()` term yang locked).

**Perbaikan:**
- `_unlock_payment_term()` (cermin `_lock_payment_term()`) dipanggil lewat hook
  `post_restart_action` — unlock hanya saat restart, bukan saat cancel.
- `pre_cancel_action` menolak cancel (hard guard) bila ada payment term yang sudah
  ber-invoice, dengan pesan error terstruktur.
- Policy template `cancel_ok` digerbangi `additional_python_code` (tombol Cancel
  tidak muncul saat ada payment term ber-invoice) — standar SSI: gerbang lewat
  policy `_ok`, bukan hardcode.

Dua lapis guard ini menjamin record ber-state `cancel` selalu bebas invoice,
sehingga unlock saat restart aman.

## Test plan

- [ ] CI hijau (pre-commit + unit test) untuk kedua modul
- [ ] `test_school_enrollment_restart_unlock.py` / `test_school_admission_restart_unlock.py`:
      lock saat open (kendali), unlock saat restart, editable kembali, copy payment
      term pulih setelah restart, cancel diblokir saat ada invoice, `cancel_ok`
      policy, non-regresi (tanpa cancel, lock tidak bocor)