### PR TITLE
[UPD] ssi_school_admission

### DIFF
--- a/ssi_school_admission/views/school_admission.xml
+++ b/ssi_school_admission/views/school_admission.xml
@@ -142,7 +142,7 @@
                             context="{'form_view_ref': 'ssi_school_admission.school_admission_payment_term_view_form_embedded'}"
                             attrs="{'readonly': [('state','!=','draft'),('addendum_ok','=',False)]}"
                         >
-                        <tree>
+                        <tree create="true" edit="true" delete="true">
                             <field name="sequence" invisible="1" />
                             <field
                                     name="name"
@@ -157,6 +157,7 @@
                                     attrs="{'readonly': [('locked','=',True)]}"
                                 />
                             <field name="currency_id" invisible="1" />
+                            <field name="admission_state" invisible="1" />
                             <field name="addendum_ok" invisible="1" />
                             <field name="locked" invisible="1" />
                             <field name="amount_untaxed" />
@@ -177,6 +178,34 @@
                                     type="object"
                                     icon="fa-eraser"
                                     states="invoiced"
+                                />
+                            <button
+                                    name="action_disconnect_invoice"
+                                    title="Disconnect Invoice"
+                                    type="object"
+                                    icon="fa-unlink"
+                                    states="invoiced"
+                                />
+                            <button
+                                    name="action_mark_as_manual"
+                                    title="Mark as Manual"
+                                    type="object"
+                                    icon="fa-square-o"
+                                    states="uninvoiced"
+                                />
+                            <button
+                                    name="action_unmark_as_manual"
+                                    title="Unmark as Manual"
+                                    type="object"
+                                    icon="fa-check-square-o"
+                                    states="manual"
+                                />
+                            <button
+                                    name="action_open_duplicate_wizard"
+                                    title="Duplicate Term"
+                                    type="object"
+                                    icon="fa-files-o"
+                                    attrs="{'invisible':[('admission_state','!=','draft')]}"
                                 />
                         </tree>
                     </field>

--- a/ssi_school_admission/views/school_admission_payment_term.xml
+++ b/ssi_school_admission/views/school_admission_payment_term.xml
@@ -123,6 +123,7 @@
                             />
                         <field name="state" />
                         <field name="invoice_id" />
+                        <field name="currency_id" invisible="1" />
                         <field name="locked" invisible="1" />
                         <field name="admission_state" invisible="1" />
                         <field name="addendum_ok" invisible="1" />
@@ -132,7 +133,7 @@
                     <page name="detail" string="Detail">
                         <field
                                 name="detail_ids"
-                                colspan="4"
+                                colspan="2"
                                 nolabel="1"
                                 attrs="{'readonly': [('admission_state','!=','draft'),('addendum_ok','=',False)]}"
                             >
@@ -156,7 +157,13 @@
                                         name="account_id"
                                         attrs="{'readonly': [('locked','=',True)]}"
                                     />
+                                <field name="currency_id" invisible="1" />
+                                <field name="pricelist_id" invisible="1" />
                                 <field name="locked" invisible="1" />
+                                <field
+                                        name="price_unit"
+                                        attrs="{'readonly': [('locked','=',True)]}"
+                                    />
                                 <field
                                         name="uom_quantity"
                                         string="Quantity"
@@ -166,33 +173,101 @@
                                         name="uom_id"
                                         attrs="{'readonly': [('locked','=',True)]}"
                                     />
-                                <field
-                                        name="price_unit"
-                                        attrs="{'readonly': [('locked','=',True)]}"
-                                    />
+                                <field name="price_subtotal" />
                                 <field
                                         name="tax_ids"
                                         widget="many2many_tags"
                                         attrs="{'readonly': [('locked','=',True)]}"
                                     />
-                                <field name="price_subtotal" />
                                 <field name="price_tax" />
                                 <field name="price_total" />
                             </tree>
+                            <form>
+                                <header />
+                                <sheet>
+                                    <group name="detail_group" colspan="4" col="2">
+                                        <group name="detail_left" colspan="1" col="2">
+                                            <field
+                                                    name="allowed_product_ids"
+                                                    widget="many2many_tags"
+                                                    invisible="1"
+                                                />
+                                            <field name="locked" invisible="1" />
+                                            <field
+                                                    name="product_id"
+                                                    domain="[('id','in',allowed_product_ids)]"
+                                                    attrs="{'readonly': [('locked','=',True)]}"
+                                                />
+                                            <field
+                                                    name="name"
+                                                    attrs="{'readonly': [('locked','=',True)]}"
+                                                />
+                                            <field
+                                                    name="usage_id"
+                                                    attrs="{'readonly': [('locked','=',True)]}"
+                                                />
+                                            <field
+                                                    name="account_id"
+                                                    attrs="{'readonly': [('locked','=',True)]}"
+                                                />
+                                            <field
+                                                    name="analytic_account_id"
+                                                    attrs="{'readonly': [('locked','=',True)]}"
+                                                />
+                                        </group>
+                                        <group name="detail_right" colspan="1" col="2">
+                                            <label
+                                                    for="uom_quantity"
+                                                    string="Quantity"
+                                                />
+                                            <div>
+                                                <field
+                                                        name="uom_quantity"
+                                                        class="oe_inline"
+                                                        attrs="{'readonly': [('locked','=',True)]}"
+                                                    />
+                                                <field
+                                                        name="uom_id"
+                                                        attrs="{'required':[('product_id','!=',False)],'readonly': [('locked','=',True)]}"
+                                                        class="oe_inline"
+                                                    />
+                                            </div>
+                                            <field
+                                                    name="currency_id"
+                                                    invisible="1"
+                                                    force_save="1"
+                                                />
+                                            <field
+                                                    name="pricelist_id"
+                                                    invisible="1"
+                                                    force_save="1"
+                                                />
+                                            <field
+                                                    name="price_unit"
+                                                    attrs="{'readonly': [('locked','=',True)]}"
+                                                />
+                                            <field name="price_subtotal" />
+                                            <field
+                                                    name="tax_ids"
+                                                    widget="many2many_tags"
+                                                    attrs="{'readonly': [('locked','=',True)]}"
+                                                />
+                                            <field name="price_tax" />
+                                            <field name="price_total" />
+                                        </group>
+                                    </group>
+                                </sheet>
+                            </form>
                         </field>
                     </page>
-                    <page name="amount" string="Amount">
-                        <group name="amount_group" colspan="4" col="2">
-                            <group name="amount_left" colspan="1" col="2" />
-                            <group name="amount_right" colspan="1" col="2">
-                                <field name="currency_id" invisible="1" />
-                                <field name="amount_untaxed" />
-                                <field name="amount_tax" />
-                                <field name="amount_total" />
-                            </group>
-                        </group>
-                    </page>
                 </notebook>
+                <group name="term_footer" colspan="4" col="2">
+                    <group name="term_footer_left" colspan="1" col="2">
+                        <field name="amount_untaxed" />
+                        <field name="amount_tax" />
+                        <field name="amount_total" />
+                    </group>
+                </group>
             </sheet>
         </form>
     </field>


### PR DESCRIPTION
Menyamakan tampilan Payment Term pada form Admission dengan form Enrollment (BL-0126). Perubahan **view-only**, tanpa perubahan model/Python.

## Perubahan

**`views/school_admission_payment_term.xml`** (form embedded Payment Term)
* Tab "Detail": tree `detail_ids` diselaraskan dengan Enrollment — `colspan` 4 → 2, ditambah `currency_id`/`pricelist_id` invisible, `price_unit` dipindah sebelum quantity/uom, `tax_ids` setelah `price_subtotal`.
* Ditambahkan nested `<form>` untuk baris `detail_ids`, sehingga klik satu baris detail membuka form kustom (grup kiri: `product_id`, `name`, `usage_id`, `account_id`, `analytic_account_id`; grup kanan: quantity+uom, `price_unit`, `price_subtotal`, `tax_ids`, `price_tax`, `price_total`) alih-alih form generik bawaan Odoo.
* Tab notebook "Amount" dihapus; `amount_untaxed`/`amount_tax`/`amount_total` menjadi group footer di luar notebook, seperti Enrollment.

**`views/school_admission.xml`** (tab "Fee")
* Tree `payment_term_ids` mengekspos empat tombol baris yang method-nya sudah ada di model: `action_disconnect_invoice`, `action_mark_as_manual`, `action_unmark_as_manual`, `action_open_duplicate_wizard`.

## Test

Tidak ada skenario YAML baru — perubahan murni tampilan. Keempat method di balik tombol baru sudah tercakup test existing (`test_data_admission_payment_term.yaml`, `test_data_admission_payment_term_duplicate.yaml`).