### PR TITLE
[UPD] ssi_school

### DIFF
--- a/ssi_school/__manifest__.py
+++ b/ssi_school/__manifest__.py
@@ -3,7 +3,7 @@
 # License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl).
 {
     "name": "School",
-    "version": "14.0.5.1.0",
+    "version": "14.0.5.2.0",
     "website": "https://simetri-sinergi.id",
     # pylint: disable=line-too-long
     "author": "PT. Simetri Sinergi Indonesia, OpenSynergy Indonesia, Odoo Community Association (OCA)",  # noqa: B950
@@ -25,7 +25,8 @@
         "ssi_partner",
         "base_duration",
         "queue_job",
-        "hr",
+        "ssi_hr",
+        "ssi_hr_employee",
     ],
     "data": [
         "security/ir_module_category_data.xml",
@@ -70,6 +71,7 @@
         "approval_template/school_enrollment.xml",
         "approval_template/school_homeroom.xml",
         "approval_template/school_student_mutation.xml",
+        "data/ir_actions_server_data.xml",
         "menu.xml",
         "views/school_grade_type.xml",
         "views/school_grade.xml",
@@ -78,6 +80,7 @@
         "views/school_grade_class.xml",
         "views/school_student.xml",
         "views/school_teacher.xml",
+        "views/hr_employee.xml",
         "views/school_academic_year.xml",
         "views/school_academic_term.xml",
         "views/school_homeroom.xml",

--- a/ssi_school/data/ir_actions_server_data.xml
+++ b/ssi_school/data/ir_actions_server_data.xml
@@ -1,0 +1,14 @@
+<?xml version="1.0" encoding="utf-8" ?>
+<!-- Copyright 2026 OpenSynergy Indonesia
+     Copyright 2026 PT. Simetri Sinergi Indonesia
+     License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl). -->
+<odoo noupdate="1">
+<record id="action_hr_employee_create_teacher" model="ir.actions.server">
+    <field name="name">Create Teacher</field>
+    <field name="model_id" ref="hr.model_hr_employee" />
+    <field name="binding_model_id" ref="hr.model_hr_employee" />
+    <field name="binding_type">action</field>
+    <field name="state">code</field>
+    <field name="code">records.action_create_teacher()</field>
+</record>
+</odoo>

--- a/ssi_school/models/__init__.py
+++ b/ssi_school/models/__init__.py
@@ -3,6 +3,7 @@
 # License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl).
 
 from . import (  # noqa: F401
+    hr_employee,
     school_grade_type,
     school_grade,
     school_branch,

--- a/ssi_school/models/hr_employee.py
+++ b/ssi_school/models/hr_employee.py
@@ -1,0 +1,72 @@
+# Copyright 2026 OpenSynergy Indonesia
+# Copyright 2026 PT. Simetri Sinergi Indonesia
+# License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl).
+
+from odoo import api, fields, models
+
+
+class HrEmployee(models.Model):
+    """
+    Extension of hr.employee to generate school_teacher records.
+
+    Adds the ability to bulk-create Teacher records from selected employees
+    (via the Action menu on the Employee list view), guarded so employees
+    that already have a Teacher are skipped instead of duplicated.
+    """
+
+    _inherit = "hr.employee"
+
+    teacher_ids = fields.One2many(
+        string="Teachers",
+        comodel_name="school_teacher",
+        inverse_name="employee_id",
+        help="Teacher records created from this employee.",
+    )
+    teacher_id = fields.Many2one(
+        string="Teacher",
+        comodel_name="school_teacher",
+        compute="_compute_teacher_id",
+        compute_sudo=True,
+        store=True,
+        help="Teacher record representing this employee, if any.",
+    )
+
+    @api.depends("teacher_ids")
+    def _compute_teacher_id(self):
+        for record in self:
+            record.teacher_id = record.teacher_ids and record.teacher_ids[0] or False
+
+    def action_create_teacher(self):
+        for record in self.sudo():
+            record._create_teacher()
+
+    def action_open_teacher(self):
+        for record in self.sudo():
+            result = record._open_teacher()
+        return result
+
+    def _create_teacher(self):
+        self.ensure_one()
+        if self.teacher_id:
+            return self.teacher_id
+        return self.env["school_teacher"].create(self._prepare_teacher_data())
+
+    def _open_teacher(self):
+        self.ensure_one()
+        waction = self.env.ref("ssi_school.school_teacher_action").read()[0]
+        waction.update(
+            {
+                "view_mode": "form",
+                "res_id": self.teacher_id.id,
+                "views": [(False, "form")],
+            }
+        )
+        return waction
+
+    def _prepare_teacher_data(self):
+        self.ensure_one()
+        return {
+            "name": self.name,
+            "code": self.barcode or "/",
+            "employee_id": self.id,
+        }

--- a/ssi_school/tests/__init__.py
+++ b/ssi_school/tests/__init__.py
@@ -4,6 +4,7 @@
 
 from . import (  # noqa: F401
     common,
+    test_hr_employee,
     test_school_grade_type,
     test_school_grade,
     test_school_branch,

--- a/ssi_school/tests/test_data_hr_employee.yaml
+++ b/ssi_school/tests/test_data_hr_employee.yaml
@@ -1,0 +1,166 @@
+scenarios:
+  - name: "Create Teacher From Employee"
+    steps:
+      - step: "Create home address partner"
+        action: "create"
+        model: "res.partner"
+        save_as: "partner"
+        values:
+          name: "Employee Home Address EMP-T-001"
+      - step: "Create employee with barcode"
+        action: "create"
+        model: "hr.employee"
+        save_as: "employee"
+        values:
+          name: "Employee EMP-T-001"
+          barcode: "EMP-T-001"
+          company_id: "base.main_company"
+          address_home_id: "EVAL: registry['partner'].id"
+      - step: "Run Create Teacher action"
+        action: "call"
+        target: "employee"
+        method: "action_create_teacher"
+      - step: "Verify Teacher created for employee"
+        action: "search"
+        model: "school_teacher"
+        domain: [["employee_id", "=", "EVAL: registry['employee'].id"]]
+        save_as: "teachers"
+        expect_count: 1
+      - step: "Assert employee.teacher_id is set"
+        action: "assert"
+        target: "employee"
+        asserts:
+          teacher_id:
+            type: "value"
+            operator: "is_truthy"
+
+  - name: "Teacher Code From Barcode"
+    steps:
+      - step: "Create home address partner"
+        action: "create"
+        model: "res.partner"
+        save_as: "partner"
+        values:
+          name: "Employee Home Address EMP-T-002"
+      - step: "Create employee with barcode"
+        action: "create"
+        model: "hr.employee"
+        save_as: "employee"
+        values:
+          name: "Employee EMP-T-002"
+          barcode: "EMP-T-002"
+          company_id: "base.main_company"
+          address_home_id: "EVAL: registry['partner'].id"
+      - step: "Run Create Teacher action"
+        action: "call"
+        target: "employee"
+        method: "action_create_teacher"
+      - step: "Verify Teacher code equals employee barcode"
+        action: "search"
+        model: "school_teacher"
+        domain: [["code", "=", "EMP-T-002"]]
+        save_as: "teachers"
+        expect_count: 1
+
+  - name: "Fallback Code When No Barcode"
+    steps:
+      - step: "Create home address partner"
+        action: "create"
+        model: "res.partner"
+        save_as: "partner"
+        values:
+          name: "Employee Home Address No Barcode"
+      - step: "Create employee without barcode"
+        action: "create"
+        model: "hr.employee"
+        save_as: "employee"
+        values:
+          name: "Employee No Barcode"
+          company_id: "base.main_company"
+          address_home_id: "EVAL: registry['partner'].id"
+      - step: "Run Create Teacher action"
+        action: "call"
+        target: "employee"
+        method: "action_create_teacher"
+      - step: "Verify Teacher code falls back to /"
+        action: "search"
+        model: "school_teacher"
+        domain:
+          - ["employee_id", "=", "EVAL: registry['employee'].id"]
+          - ["code", "=", "/"]
+        save_as: "teachers"
+        expect_count: 1
+
+  - name: "Idempotent - No Duplicate Teacher"
+    steps:
+      - step: "Create home address partner"
+        action: "create"
+        model: "res.partner"
+        save_as: "partner"
+        values:
+          name: "Employee Home Address Idempotent"
+      - step: "Create employee with barcode"
+        action: "create"
+        model: "hr.employee"
+        save_as: "employee"
+        values:
+          name: "Employee Idempotent"
+          barcode: "EMP-T-IDEMPOTENT"
+          company_id: "base.main_company"
+          address_home_id: "EVAL: registry['partner'].id"
+      - step: "Run Create Teacher action first time"
+        action: "call"
+        target: "employee"
+        method: "action_create_teacher"
+      - step: "Run Create Teacher action second time"
+        action: "call"
+        target: "employee"
+        method: "action_create_teacher"
+      - step: "Verify only one Teacher exists for employee"
+        action: "search"
+        model: "school_teacher"
+        domain: [["employee_id", "=", "EVAL: registry['employee'].id"]]
+        save_as: "teachers"
+        expect_count: 1
+
+  - name: "Existing Teacher Is Not Recreated"
+    steps:
+      - step: "Create home address partner"
+        action: "create"
+        model: "res.partner"
+        save_as: "partner"
+        values:
+          name: "Employee Home Address Existing Teacher"
+      - step: "Create employee with barcode"
+        action: "create"
+        model: "hr.employee"
+        save_as: "employee"
+        values:
+          name: "Employee Existing Teacher"
+          barcode: "EMP-T-EXISTING"
+          company_id: "base.main_company"
+          address_home_id: "EVAL: registry['partner'].id"
+      - step: "Manually create Teacher for employee"
+        action: "create"
+        model: "school_teacher"
+        save_as: "teacher"
+        values:
+          name: "Existing Teacher"
+          code: "TCHEXIST"
+          employee_id: "EVAL: registry['employee'].id"
+      - step: "Run Create Teacher action"
+        action: "call"
+        target: "employee"
+        method: "action_create_teacher"
+      - step: "Verify still only one Teacher for employee"
+        action: "search"
+        model: "school_teacher"
+        domain: [["employee_id", "=", "EVAL: registry['employee'].id"]]
+        save_as: "teachers_for_employee"
+        expect_count: 1
+      - step: "Verify existing Teacher was not overwritten"
+        action: "search"
+        model: "school_teacher"
+        domain: [["code", "=", "TCHEXIST"]]
+        save_as: "teachers_existing"
+        expect_count: 1

--- a/ssi_school/tests/test_data_teacher.yaml
+++ b/ssi_school/tests/test_data_teacher.yaml
@@ -221,6 +221,7 @@ scenarios:
           name: "Teacher Personal Employee"
           company_id: "base.main_company"
           address_home_id: "EVAL: registry['partner'].id"
+          marital: "married"
       - step: "Create teacher"
         action: "create"
         model: "school_teacher"

--- a/ssi_school/tests/test_hr_employee.py
+++ b/ssi_school/tests/test_hr_employee.py
@@ -1,0 +1,13 @@
+# Copyright 2026 OpenSynergy Indonesia
+# Copyright 2026 PT. Simetri Sinergi Indonesia
+# License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl).
+
+from odoo_yaml_test import YamlTransactionCase
+
+from odoo.tests import tagged
+
+
+@tagged("post_install", "-at_install")
+class TestHrEmployee(YamlTransactionCase):  # pylint: disable=too-few-public-methods
+    def test_create_teacher_from_employee(self):
+        self.run_yaml_scenario("test_data_hr_employee.yaml")

--- a/ssi_school/views/hr_employee.xml
+++ b/ssi_school/views/hr_employee.xml
@@ -1,0 +1,29 @@
+<?xml version="1.0" encoding="utf-8" ?>
+<!-- Copyright 2026 OpenSynergy Indonesia
+     Copyright 2026 PT. Simetri Sinergi Indonesia
+     License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl). -->
+<odoo>
+<record id="hr_employee_view_form" model="ir.ui.view">
+    <field name="name">school - hr.employee - form</field>
+    <field name="model">hr.employee</field>
+    <field name="inherit_id" ref="hr.view_employee_form" />
+    <field name="arch" type="xml">
+        <data>
+            <xpath expr="//div[@name='button_box']" position="inside">
+                <field name="teacher_id" invisible="1" />
+                <button
+                        name="action_open_teacher"
+                        type="object"
+                        class="oe_stat_button"
+                        icon="fa-graduation-cap"
+                        attrs="{'invisible': [('teacher_id', '=', False)]}"
+                    >
+                    <div class="o_form_field o_stat_info">
+                        <span class="o_stat_text">Teacher</span>
+                    </div>
+                </button>
+            </xpath>
+        </data>
+    </field>
+</record>
+</odoo>


### PR DESCRIPTION
## Summary

* Tambah server action massal "Create Teacher" pada `hr.employee` (menu Action di list view), dapat dijalankan atas banyak employee sekaligus.
* Idempoten: employee yang sudah punya `school_teacher` dilewati tanpa error dan tanpa duplikat.
* `code` Teacher hasil aksi diambil dari `employee.barcode`, fallback `"/"` bila kosong.
* Tambah smart button "Teacher" di form Employee (tampil hanya bila employee sudah punya Teacher).
* Naikkan dependensi dari `hr` ke `ssi_hr` + `ssi_hr_employee`.
* Tambah unit test (`odoo-yaml-test`) 5 skenario: create, code dari barcode, fallback code, idempoten, existing teacher tidak dibuat ulang.

Referensi backlog: BL-0133.

## Test plan

- [ ] CI hijau (pre-commit + unit test)