### PR TITLE
[UPD] ssi_school

### DIFF
--- a/ssi_school/security/res_group/school_enrollment.xml
+++ b/ssi_school/security/res_group/school_enrollment.xml
@@ -43,5 +43,9 @@
             name="implied_ids"
             eval="[(4, ref('school_enrollment_company_child_group'))]"
         />
+    <field
+            name="users"
+            eval="[(4, ref('base.user_root')), (4, ref('base.user_admin'))]"
+        />
 </record>
 </odoo>

--- a/ssi_school/security/res_group/school_homeroom.xml
+++ b/ssi_school/security/res_group/school_homeroom.xml
@@ -43,5 +43,9 @@
             name="implied_ids"
             eval="[(4, ref('school_homeroom_company_child_group'))]"
         />
+    <field
+            name="users"
+            eval="[(4, ref('base.user_root')), (4, ref('base.user_admin'))]"
+        />
 </record>
 </odoo>

--- a/ssi_school/security/res_group/school_student_mutation.xml
+++ b/ssi_school/security/res_group/school_student_mutation.xml
@@ -58,5 +58,9 @@
             name="implied_ids"
             eval="[(4, ref('school_student_mutation_company_child_group'))]"
         />
+    <field
+            name="users"
+            eval="[(4, ref('base.user_root')), (4, ref('base.user_admin'))]"
+        />
 </record>
 </odoo>

--- a/ssi_school/tests/__init__.py
+++ b/ssi_school/tests/__init__.py
@@ -20,6 +20,7 @@ from . import (  # noqa: F401
     test_school_enrollment_payment_template,
     test_school_enrollment_payment_product_configurator,
     test_school_enrollment,
+    test_school_enrollment_access,
     test_school_enrollment_results,
     test_school_enrollment_payment_term_management,
     test_school_enrollment_payment_term_duplicate,

--- a/ssi_school/tests/test_data_enrollment.yaml
+++ b/ssi_school/tests/test_data_enrollment.yaml
@@ -244,6 +244,11 @@ scenarios:
         target: "all_terms"
         method: "action_create_invoice"
 
+      - step: "Invalidate enrollment cache after invoicing"
+        action: "call"
+        target: "enrollment"
+        method: "invalidate_cache"
+
       - step: "Assert enrollment done"
         action: "call"
         target: "enrollment"
@@ -454,6 +459,11 @@ scenarios:
         target: "enrollment"
         method: "action_compute_payment"
         as_user: "base.user_admin"
+
+      - step: "Invalidate enrollment cache"
+        action: "call"
+        target: "enrollment"
+        method: "invalidate_cache"
 
       - step: "Approve enrollment"
         action: "call"

--- a/ssi_school/tests/test_data_enrollment.yaml
+++ b/ssi_school/tests/test_data_enrollment.yaml
@@ -1,3 +1,5 @@
+options:
+  auto_refresh: true
 scenarios:
   - name: "Enrollment Full Workflow Create Confirm Approve Invoice Done"
     steps:
@@ -212,11 +214,6 @@ scenarios:
         method: "action_compute_payment"
         as_user: "base.user_admin"
 
-      - step: "Invalidate enrollment cache after compute"
-        action: "call"
-        target: "enrollment"
-        method: "invalidate_cache"
-
       - step: "Assert payment terms created"
         action: "assert"
         target: "enrollment"
@@ -246,11 +243,6 @@ scenarios:
         action: "call"
         target: "all_terms"
         method: "action_create_invoice"
-
-      - step: "Invalidate enrollment cache after invoicing"
-        action: "call"
-        target: "enrollment"
-        method: "invalidate_cache"
 
       - step: "Assert enrollment done"
         action: "call"
@@ -463,11 +455,6 @@ scenarios:
         method: "action_compute_payment"
         as_user: "base.user_admin"
 
-      - step: "Invalidate enrollment cache"
-        action: "call"
-        target: "enrollment"
-        method: "invalidate_cache"
-
       - step: "Approve enrollment"
         action: "call"
         target: "enrollment"
@@ -509,11 +496,6 @@ scenarios:
         action: "call"
         target: "term_2"
         method: "action_create_invoice"
-
-      - step: "Invalidate term_2 cache"
-        action: "call"
-        target: "term_2"
-        method: "invalidate_cache"
 
       - step: "Assert second term has invoice"
         action: "assert"

--- a/ssi_school/tests/test_data_enrollment_addendum.yaml
+++ b/ssi_school/tests/test_data_enrollment_addendum.yaml
@@ -203,6 +203,11 @@ scenarios:
             type: "value"
             expected: false
 
+      - step: "Invalidate enrollment cache before approve"
+        action: "call"
+        target: "enrollment"
+        method: "invalidate_cache"
+
       - step: "Approve enrollment"
         action: "call"
         target: "enrollment"

--- a/ssi_school/tests/test_data_enrollment_addendum.yaml
+++ b/ssi_school/tests/test_data_enrollment_addendum.yaml
@@ -1,3 +1,5 @@
+options:
+  auto_refresh: true
 scenarios:
   - name: "Addendum - Existing Payment Term Is Locked After Enrollment Opens"
     steps:
@@ -201,11 +203,6 @@ scenarios:
             type: "value"
             expected: false
 
-      - step: "Invalidate enrollment cache before approve"
-        action: "call"
-        target: "enrollment"
-        method: "invalidate_cache"
-
       - step: "Approve enrollment"
         action: "call"
         target: "enrollment"
@@ -216,11 +213,6 @@ scenarios:
             type: "value"
             expected: "open"
 
-      - step: "Invalidate term cache after enrollment opened"
-        action: "call"
-        target: "term"
-        method: "invalidate_cache"
-
       - step: "Assert term locked after opening"
         action: "assert"
         target: "term"
@@ -228,11 +220,6 @@ scenarios:
           locked:
             type: "value"
             expected: true
-
-      - step: "Invalidate detail cache after enrollment opened"
-        action: "call"
-        target: "detail"
-        method: "invalidate_cache"
 
       - step: "Assert detail locked after opening"
         action: "assert"
@@ -288,11 +275,6 @@ scenarios:
         method: "action_close_addendum"
         as_user: "base.user_admin"
 
-      - step: "Invalidate addendum term cache after closing"
-        action: "call"
-        target: "addendum_term"
-        method: "invalidate_cache"
-
       - step: "Assert first-round addendum term is locked after closing"
         action: "assert"
         target: "addendum_term"
@@ -300,11 +282,6 @@ scenarios:
           locked:
             type: "value"
             expected: true
-
-      - step: "Invalidate addendum detail cache after closing"
-        action: "call"
-        target: "addendum_detail"
-        method: "invalidate_cache"
 
       - step: "Assert first-round addendum detail is locked after closing"
         action: "assert"
@@ -337,11 +314,6 @@ scenarios:
         target: "enrollment"
         method: "action_close_addendum"
         as_user: "base.user_admin"
-
-      - step: "Invalidate second-round addendum term cache after closing"
-        action: "call"
-        target: "addendum_term_2"
-        method: "invalidate_cache"
 
       - step: "Assert second-round addendum term is locked after closing again"
         action: "assert"

--- a/ssi_school/tests/test_data_enrollment_copy_payment_term.yaml
+++ b/ssi_school/tests/test_data_enrollment_copy_payment_term.yaml
@@ -1,3 +1,5 @@
+options:
+  auto_refresh: true
 scenarios:
   - name: "Copy Payment Terms - Replace Mode"
     steps:

--- a/ssi_school/tests/test_data_enrollment_payment_date_pattern.yaml
+++ b/ssi_school/tests/test_data_enrollment_payment_date_pattern.yaml
@@ -1,3 +1,5 @@
+options:
+  auto_refresh: true
 scenarios:
   - name: "Compute Payment - Estimated Invoice and Due Date from Duration"
     steps:
@@ -213,11 +215,6 @@ scenarios:
         method: "action_compute_payment"
         as_user: "base.user_admin"
 
-      - step: "Invalidate enrollment cache after compute"
-        action: "call"
-        target: "enrollment"
-        method: "invalidate_cache"
-
       - step: "Get enrollment payment term 1"
         action: "search"
         model: "school_enrollment_payment_term"
@@ -432,11 +429,6 @@ scenarios:
         target: "enrollment"
         method: "action_compute_payment"
         as_user: "base.user_admin"
-
-      - step: "Invalidate enrollment cache after compute"
-        action: "call"
-        target: "enrollment"
-        method: "invalidate_cache"
 
       - step: "Get enrollment payment term"
         action: "search"

--- a/ssi_school/tests/test_data_enrollment_payment_product_configurator.yaml
+++ b/ssi_school/tests/test_data_enrollment_payment_product_configurator.yaml
@@ -1,3 +1,5 @@
+options:
+  auto_refresh: true
 scenarios:
   - name: "Allowed Products - Template Detail - Manual Strategy"
     steps:

--- a/ssi_school/tests/test_data_enrollment_payment_template.yaml
+++ b/ssi_school/tests/test_data_enrollment_payment_template.yaml
@@ -1,3 +1,5 @@
+options:
+  auto_refresh: true
 scenarios:
   - name: "Create Payment Template"
     steps:

--- a/ssi_school/tests/test_data_enrollment_payment_term_duplicate.yaml
+++ b/ssi_school/tests/test_data_enrollment_payment_term_duplicate.yaml
@@ -1,3 +1,5 @@
+options:
+  auto_refresh: true
 scenarios:
   - name: "Enrollment Payment Term - Duplicate via Wizard"
     steps:
@@ -178,11 +180,6 @@ scenarios:
         action: "call"
         target: "term"
         method: "action_create_invoice"
-
-      - step: "Invalidate term cache after invoice creation"
-        action: "call"
-        target: "term"
-        method: "invalidate_cache"
 
       - step: "Assert source term has an invoice"
         action: "assert"

--- a/ssi_school/tests/test_data_enrollment_payment_term_management.yaml
+++ b/ssi_school/tests/test_data_enrollment_payment_term_management.yaml
@@ -1,3 +1,5 @@
+options:
+  auto_refresh: true
 scenarios:
   - name: "Enrollment Payment Term - Delete Invoice"
     steps:
@@ -170,11 +172,6 @@ scenarios:
         method: "action_compute_payment"
         as_user: "base.user_admin"
 
-      - step: "Invalidate enrollment cache before approve"
-        action: "call"
-        target: "enrollment"
-        method: "invalidate_cache"
-
       - step: "Approve enrollment"
         action: "call"
         target: "enrollment"
@@ -197,11 +194,6 @@ scenarios:
         target: "term"
         method: "action_create_invoice"
 
-      - step: "Invalidate term cache after invoice creation"
-        action: "call"
-        target: "term"
-        method: "invalidate_cache"
-
       - step: "Assert invoice created"
         action: "assert"
         target: "term"
@@ -217,11 +209,6 @@ scenarios:
         action: "call"
         target: "term"
         method: "action_delete_invoice"
-
-      - step: "Invalidate term cache after delete"
-        action: "call"
-        target: "term"
-        method: "invalidate_cache"
 
       - step: "Assert invoice deleted from term"
         action: "assert"
@@ -405,11 +392,6 @@ scenarios:
         method: "action_compute_payment"
         as_user: "base.user_admin"
 
-      - step: "Invalidate enrollment cache before approve"
-        action: "call"
-        target: "enrollment"
-        method: "invalidate_cache"
-
       - step: "Approve enrollment"
         action: "call"
         target: "enrollment"
@@ -428,11 +410,6 @@ scenarios:
         target: "term"
         method: "action_create_invoice"
 
-      - step: "Invalidate term cache"
-        action: "call"
-        target: "term"
-        method: "invalidate_cache"
-
       - step: "Assert invoice exists"
         action: "assert"
         target: "term"
@@ -445,11 +422,6 @@ scenarios:
         action: "call"
         target: "term"
         method: "action_disconnect_invoice"
-
-      - step: "Invalidate term cache after disconnect"
-        action: "call"
-        target: "term"
-        method: "invalidate_cache"
 
       - step: "Assert invoice disconnected from term"
         action: "assert"
@@ -633,11 +605,6 @@ scenarios:
         method: "action_compute_payment"
         as_user: "base.user_admin"
 
-      - step: "Invalidate enrollment cache before approve"
-        action: "call"
-        target: "enrollment"
-        method: "invalidate_cache"
-
       - step: "Approve enrollment"
         action: "call"
         target: "enrollment"
@@ -656,11 +623,6 @@ scenarios:
         target: "term"
         method: "action_mark_as_manual"
 
-      - step: "Invalidate term cache"
-        action: "call"
-        target: "term"
-        method: "invalidate_cache"
-
       - step: "Assert term is manually controlled"
         action: "assert"
         target: "term"
@@ -676,11 +638,6 @@ scenarios:
         action: "call"
         target: "term"
         method: "action_unmark_as_manual"
-
-      - step: "Invalidate term cache after unmark"
-        action: "call"
-        target: "term"
-        method: "invalidate_cache"
 
       - step: "Assert term is back to uninvoiced"
         action: "assert"

--- a/ssi_school/tests/test_data_enrollment_payment_term_management.yaml
+++ b/ssi_school/tests/test_data_enrollment_payment_term_management.yaml
@@ -172,6 +172,11 @@ scenarios:
         method: "action_compute_payment"
         as_user: "base.user_admin"
 
+      - step: "Invalidate enrollment cache before approve"
+        action: "call"
+        target: "enrollment"
+        method: "invalidate_cache"
+
       - step: "Approve enrollment"
         action: "call"
         target: "enrollment"
@@ -392,6 +397,11 @@ scenarios:
         method: "action_compute_payment"
         as_user: "base.user_admin"
 
+      - step: "Invalidate enrollment cache before approve"
+        action: "call"
+        target: "enrollment"
+        method: "invalidate_cache"
+
       - step: "Approve enrollment"
         action: "call"
         target: "enrollment"
@@ -604,6 +614,11 @@ scenarios:
         target: "enrollment"
         method: "action_compute_payment"
         as_user: "base.user_admin"
+
+      - step: "Invalidate enrollment cache before approve"
+        action: "call"
+        target: "enrollment"
+        method: "invalidate_cache"
 
       - step: "Approve enrollment"
         action: "call"

--- a/ssi_school/tests/test_data_enrollment_product_summary.yaml
+++ b/ssi_school/tests/test_data_enrollment_product_summary.yaml
@@ -1,3 +1,5 @@
+options:
+  auto_refresh: true
 scenarios:
   - name: "Product Summary - satu produk satu term tercompute saat detail ditambah"
     steps:
@@ -145,11 +147,6 @@ scenarios:
           uom_quantity: 1.0
           uom_id: "REF: uom.product_uom_unit"
           price_unit: 1000000.0
-
-      - step: "Invalidate enrollment cache"
-        action: "call"
-        target: "enrollment"
-        method: "invalidate_cache"
 
       - step: "Assert product_summary_ids berisi 1 record"
         action: "assert"
@@ -339,11 +336,6 @@ scenarios:
           uom_id: "REF: uom.product_uom_unit"
           price_unit: 500000.0
 
-      - step: "Invalidate enrollment cache"
-        action: "call"
-        target: "enrollment"
-        method: "invalidate_cache"
-
       - step: "Assert product_summary_ids hanya 1 record meski 2 term"
         action: "assert"
         target: "enrollment"
@@ -512,11 +504,6 @@ scenarios:
           uom_id: "REF: uom.product_uom_unit"
           price_unit: 750000.0
 
-      - step: "Invalidate enrollment cache"
-        action: "call"
-        target: "enrollment"
-        method: "invalidate_cache"
-
       - step: "Assert summary ada sebelum detail dihapus"
         action: "assert"
         target: "enrollment"
@@ -530,11 +517,6 @@ scenarios:
         action: "call"
         target: "detail"
         method: "unlink"
-
-      - step: "Invalidate enrollment cache setelah hapus detail"
-        action: "call"
-        target: "enrollment"
-        method: "invalidate_cache"
 
       - step: "Assert summary kosong setelah detail dihapus"
         action: "assert"
@@ -682,11 +664,6 @@ scenarios:
           uom_id: "REF: uom.product_uom_unit"
           price_unit: 250000.0
 
-      - step: "Invalidate enrollment cache"
-        action: "call"
-        target: "enrollment"
-        method: "invalidate_cache"
-
       - step: "Assert summary ada sebelum term dihapus"
         action: "assert"
         target: "enrollment"
@@ -700,11 +677,6 @@ scenarios:
         action: "call"
         target: "term"
         method: "unlink"
-
-      - step: "Invalidate enrollment cache setelah hapus term"
-        action: "call"
-        target: "enrollment"
-        method: "invalidate_cache"
 
       - step: "Assert summary kosong setelah term dihapus"
         action: "assert"

--- a/ssi_school/tests/test_data_enrollment_restart_unlock.yaml
+++ b/ssi_school/tests/test_data_enrollment_restart_unlock.yaml
@@ -156,6 +156,11 @@ scenarios:
         method: "action_confirm"
         as_user: "base.user_admin"
 
+      - step: "Invalidate enrollment cache before approve"
+        action: "call"
+        target: "enrollment"
+        method: "invalidate_cache"
+
       - step: "Approve enrollment"
         action: "call"
         target: "enrollment"
@@ -182,6 +187,11 @@ scenarios:
             type: "value"
             expected: true
 
+      - step: "Invalidate enrollment cache before cancel"
+        action: "call"
+        target: "enrollment"
+        method: "invalidate_cache"
+
       - step: "Cancel enrollment"
         action: "call"
         target: "enrollment"
@@ -191,6 +201,11 @@ scenarios:
           state:
             type: "value"
             expected: "cancel"
+
+      - step: "Invalidate enrollment cache before restart"
+        action: "call"
+        target: "enrollment"
+        method: "invalidate_cache"
 
       - step: "Restart enrollment"
         action: "call"

--- a/ssi_school/tests/test_data_enrollment_restart_unlock.yaml
+++ b/ssi_school/tests/test_data_enrollment_restart_unlock.yaml
@@ -1,3 +1,5 @@
+options:
+  auto_refresh: true
 scenarios:
   - name: "Restart Unlocks Payment Term And Detail, Remains Editable"
     steps:
@@ -154,11 +156,6 @@ scenarios:
         method: "action_confirm"
         as_user: "base.user_admin"
 
-      - step: "Invalidate enrollment cache before approve"
-        action: "call"
-        target: "enrollment"
-        method: "invalidate_cache"
-
       - step: "Approve enrollment"
         action: "call"
         target: "enrollment"
@@ -169,11 +166,6 @@ scenarios:
             type: "value"
             expected: "open"
 
-      - step: "Invalidate term cache after opening"
-        action: "call"
-        target: "term"
-        method: "invalidate_cache"
-
       - step: "Assert term locked after opening (control)"
         action: "assert"
         target: "term"
@@ -182,11 +174,6 @@ scenarios:
             type: "value"
             expected: true
 
-      - step: "Invalidate detail cache after opening"
-        action: "call"
-        target: "detail"
-        method: "invalidate_cache"
-
       - step: "Assert detail locked after opening (control)"
         action: "assert"
         target: "detail"
@@ -194,11 +181,6 @@ scenarios:
           locked:
             type: "value"
             expected: true
-
-      - step: "Invalidate enrollment cache before cancel"
-        action: "call"
-        target: "enrollment"
-        method: "invalidate_cache"
 
       - step: "Cancel enrollment"
         action: "call"
@@ -210,11 +192,6 @@ scenarios:
             type: "value"
             expected: "cancel"
 
-      - step: "Invalidate enrollment cache before restart"
-        action: "call"
-        target: "enrollment"
-        method: "invalidate_cache"
-
       - step: "Restart enrollment"
         action: "call"
         target: "enrollment"
@@ -225,11 +202,6 @@ scenarios:
             type: "value"
             expected: "draft"
 
-      - step: "Invalidate term cache after restart"
-        action: "call"
-        target: "term"
-        method: "invalidate_cache"
-
       - step: "Assert term unlocked after restart"
         action: "assert"
         target: "term"
@@ -237,11 +209,6 @@ scenarios:
           locked:
             type: "value"
             expected: false
-
-      - step: "Invalidate detail cache after restart"
-        action: "call"
-        target: "detail"
-        method: "invalidate_cache"
 
       - step: "Assert detail unlocked after restart"
         action: "assert"

--- a/ssi_school/tests/test_data_enrollment_results.yaml
+++ b/ssi_school/tests/test_data_enrollment_results.yaml
@@ -114,6 +114,11 @@ scenarios:
             type: "value"
             expected: "confirm"
 
+      - step: "Invalidate enrollment cache before approve"
+        action: "call"
+        target: "enrollment"
+        method: "invalidate_cache"
+
       - step: "Approve enrollment"
         action: "call"
         target: "enrollment"
@@ -123,6 +128,11 @@ scenarios:
           state:
             type: "value"
             expected: "open"
+
+      - step: "Invalidate enrollment cache after approve"
+        action: "call"
+        target: "enrollment"
+        method: "invalidate_cache"
 
       - step: "Set result to passed"
         action: "call"
@@ -251,6 +261,11 @@ scenarios:
         method: "action_confirm"
         as_user: "base.user_admin"
 
+      - step: "Invalidate enrollment cache before approve"
+        action: "call"
+        target: "enrollment"
+        method: "invalidate_cache"
+
       - step: "Approve enrollment"
         action: "call"
         target: "enrollment"
@@ -260,6 +275,11 @@ scenarios:
           state:
             type: "value"
             expected: "open"
+
+      - step: "Invalidate enrollment cache"
+        action: "call"
+        target: "enrollment"
+        method: "invalidate_cache"
 
       - step: "Set result to failed"
         action: "call"
@@ -385,6 +405,11 @@ scenarios:
         method: "action_confirm"
         as_user: "base.user_admin"
 
+      - step: "Invalidate enrollment cache before approve"
+        action: "call"
+        target: "enrollment"
+        method: "invalidate_cache"
+
       - step: "Approve enrollment"
         action: "call"
         target: "enrollment"
@@ -394,6 +419,11 @@ scenarios:
           state:
             type: "value"
             expected: "open"
+
+      - step: "Invalidate enrollment cache"
+        action: "call"
+        target: "enrollment"
+        method: "invalidate_cache"
 
       - step: "Set result to drop out"
         action: "call"
@@ -519,6 +549,11 @@ scenarios:
         method: "action_confirm"
         as_user: "base.user_admin"
 
+      - step: "Invalidate enrollment cache before approve"
+        action: "call"
+        target: "enrollment"
+        method: "invalidate_cache"
+
       - step: "Approve enrollment"
         action: "call"
         target: "enrollment"
@@ -528,6 +563,11 @@ scenarios:
           state:
             type: "value"
             expected: "open"
+
+      - step: "Invalidate enrollment cache"
+        action: "call"
+        target: "enrollment"
+        method: "invalidate_cache"
 
       - step: "Set result to graduate"
         action: "call"

--- a/ssi_school/tests/test_data_enrollment_results.yaml
+++ b/ssi_school/tests/test_data_enrollment_results.yaml
@@ -1,3 +1,5 @@
+options:
+  auto_refresh: true
 scenarios:
   - name: "Enrollment Result - Passed"
     steps:
@@ -112,11 +114,6 @@ scenarios:
             type: "value"
             expected: "confirm"
 
-      - step: "Invalidate enrollment cache before approve"
-        action: "call"
-        target: "enrollment"
-        method: "invalidate_cache"
-
       - step: "Approve enrollment"
         action: "call"
         target: "enrollment"
@@ -127,21 +124,11 @@ scenarios:
             type: "value"
             expected: "open"
 
-      - step: "Invalidate enrollment cache after approve"
-        action: "call"
-        target: "enrollment"
-        method: "invalidate_cache"
-
       - step: "Set result to passed"
         action: "call"
         target: "enrollment"
         method: "action_set_result_to_passed"
         as_user: "base.user_admin"
-
-      - step: "Invalidate enrollment cache after result"
-        action: "call"
-        target: "enrollment"
-        method: "invalidate_cache"
 
       - step: "Assert enrollment is done with passed result"
         action: "assert"
@@ -156,11 +143,6 @@ scenarios:
           promote_to_grade_id:
             type: "value"
             operator: "is_truthy"
-
-      - step: "Invalidate student cache after result"
-        action: "call"
-        target: "student"
-        method: "invalidate_cache"
 
       - step: "Assert student state returned to draft after passed"
         action: "assert"
@@ -269,11 +251,6 @@ scenarios:
         method: "action_confirm"
         as_user: "base.user_admin"
 
-      - step: "Invalidate enrollment cache before approve"
-        action: "call"
-        target: "enrollment"
-        method: "invalidate_cache"
-
       - step: "Approve enrollment"
         action: "call"
         target: "enrollment"
@@ -284,21 +261,11 @@ scenarios:
             type: "value"
             expected: "open"
 
-      - step: "Invalidate enrollment cache"
-        action: "call"
-        target: "enrollment"
-        method: "invalidate_cache"
-
       - step: "Set result to failed"
         action: "call"
         target: "enrollment"
         method: "action_set_result_to_failed"
         as_user: "base.user_admin"
-
-      - step: "Invalidate enrollment cache after result"
-        action: "call"
-        target: "enrollment"
-        method: "invalidate_cache"
 
       - step: "Assert enrollment is done with failed result"
         action: "assert"
@@ -310,11 +277,6 @@ scenarios:
           academic_year_result:
             type: "value"
             expected: "failed"
-
-      - step: "Invalidate student cache"
-        action: "call"
-        target: "student"
-        method: "invalidate_cache"
 
       - step: "Assert student state returned to draft after failed"
         action: "assert"
@@ -423,11 +385,6 @@ scenarios:
         method: "action_confirm"
         as_user: "base.user_admin"
 
-      - step: "Invalidate enrollment cache before approve"
-        action: "call"
-        target: "enrollment"
-        method: "invalidate_cache"
-
       - step: "Approve enrollment"
         action: "call"
         target: "enrollment"
@@ -438,21 +395,11 @@ scenarios:
             type: "value"
             expected: "open"
 
-      - step: "Invalidate enrollment cache"
-        action: "call"
-        target: "enrollment"
-        method: "invalidate_cache"
-
       - step: "Set result to drop out"
         action: "call"
         target: "enrollment"
         method: "action_set_result_to_drop_out"
         as_user: "base.user_admin"
-
-      - step: "Invalidate enrollment cache after result"
-        action: "call"
-        target: "enrollment"
-        method: "invalidate_cache"
 
       - step: "Assert enrollment is done with drop out result"
         action: "assert"
@@ -464,11 +411,6 @@ scenarios:
           academic_year_result:
             type: "value"
             expected: "drop_out"
-
-      - step: "Invalidate student cache"
-        action: "call"
-        target: "student"
-        method: "invalidate_cache"
 
       - step: "Assert student state is dropped"
         action: "assert"
@@ -577,11 +519,6 @@ scenarios:
         method: "action_confirm"
         as_user: "base.user_admin"
 
-      - step: "Invalidate enrollment cache before approve"
-        action: "call"
-        target: "enrollment"
-        method: "invalidate_cache"
-
       - step: "Approve enrollment"
         action: "call"
         target: "enrollment"
@@ -592,21 +529,11 @@ scenarios:
             type: "value"
             expected: "open"
 
-      - step: "Invalidate enrollment cache"
-        action: "call"
-        target: "enrollment"
-        method: "invalidate_cache"
-
       - step: "Set result to graduate"
         action: "call"
         target: "enrollment"
         method: "action_set_result_to_graduate"
         as_user: "base.user_admin"
-
-      - step: "Invalidate enrollment cache after result"
-        action: "call"
-        target: "enrollment"
-        method: "invalidate_cache"
 
       - step: "Assert enrollment is done with graduate result"
         action: "assert"
@@ -618,11 +545,6 @@ scenarios:
           academic_year_result:
             type: "value"
             expected: "graduate"
-
-      - step: "Invalidate student cache"
-        action: "call"
-        target: "student"
-        method: "invalidate_cache"
 
       - step: "Assert student state is graduate"
         action: "assert"

--- a/ssi_school/tests/test_data_school_enrollment_access.yaml
+++ b/ssi_school/tests/test_data_school_enrollment_access.yaml
@@ -1,0 +1,368 @@
+options:
+  auto_refresh: true
+
+setup:
+  steps:
+    - step: "Setup - create grade type"
+      action: "create"
+      model: "school_grade_type"
+      save_as: "grade_type"
+      values:
+        name: "Grade Type for Access Test"
+        code: "GTACC"
+        sequence: 10
+
+    - step: "Setup - create academic year"
+      action: "create"
+      model: "school_academic_year"
+      save_as: "academic_year"
+      values:
+        name: "2024/2025 Access Test"
+        code: "AYACC"
+        date_start: "2024-07-01"
+        date_end: "2025-06-30"
+
+    - step: "Setup - create academic term"
+      action: "create"
+      model: "school_academic_term"
+      save_as: "academic_term"
+      values:
+        name: "Semester 1 Access Test"
+        code: "SMACC"
+        date_start: "2024-07-01"
+        date_end: "2024-12-31"
+        year_id: "REC: academic_year.id"
+        enrollment_state: "open"
+
+    - step: "Setup - create school"
+      action: "create"
+      model: "school"
+      save_as: "school"
+      values:
+        name: "School for Access Test"
+        code: "SCHACC"
+        grade_type_id: "REC: grade_type.id"
+
+    - step: "Setup - create grade"
+      action: "create"
+      model: "school_grade"
+      save_as: "grade"
+      values:
+        name: "Grade for Access Test"
+        code: "GACC"
+        sequence: 10
+        type_id: "REC: grade_type.id"
+
+    - step: "Setup - create source grade class"
+      action: "create"
+      model: "school_grade_class"
+      save_as: "grade_class"
+      values:
+        name: "Class A Access Test"
+        code: "CLACCA"
+        school_id: "REC: school.id"
+        grade_id: "REC: grade.id"
+        capacity: 30
+
+    - step: "Setup - create destination grade class"
+      action: "create"
+      model: "school_grade_class"
+      save_as: "grade_class_dest"
+      values:
+        name: "Class B Access Test"
+        code: "CLACCB"
+        school_id: "REC: school.id"
+        grade_id: "REC: grade.id"
+        capacity: 30
+
+    - step: "Setup - create student contact"
+      action: "create"
+      model: "res.partner"
+      save_as: "contact"
+      values:
+        name: "Student Contact Access Test"
+
+    - step: "Setup - create student"
+      action: "create"
+      model: "school_student"
+      save_as: "student"
+      values:
+        name: "Student for Access Test"
+        code: "STUACC"
+        contact_id: "REC: contact.id"
+        school_id: "REC: school.id"
+
+scenarios:
+  - name: "Enrollment - Admin Can Read Record Created By Another User"
+    steps:
+      - step: "Create enrollment as OdooBot (not admin), so user_id is not admin"
+        action: "create"
+        model: "school_enrollment"
+        save_as: "enrollment"
+        values:
+          date: "2024-07-01"
+          academic_year_id: "REC: academic_year.id"
+          academic_term_id: "REC: academic_term.id"
+          school_id: "REC: school.id"
+          grade_id: "REC: grade.id"
+          grade_class_id: "REC: grade_class.id"
+          student_id: "REC: student.id"
+          currency_id: "REC: company.currency_id.id"
+
+      - step: "Admin reads the enrollment with a forced refresh from database"
+        action: "assert"
+        target: "enrollment"
+        as_user: "base.user_admin"
+        refresh: true
+        asserts:
+          state:
+            type: "value"
+            expected: "draft"
+
+  - name: "Enrollment - Full Confirm Approve Workflow As Admin With Auto Refresh"
+    steps:
+      - step: "Create enrollment as OdooBot (not admin), so user_id is not admin"
+        action: "create"
+        model: "school_enrollment"
+        save_as: "enrollment"
+        values:
+          date: "2024-07-01"
+          academic_year_id: "REC: academic_year.id"
+          academic_term_id: "REC: academic_term.id"
+          school_id: "REC: school.id"
+          grade_id: "REC: grade.id"
+          grade_class_id: "REC: grade_class.id"
+          student_id: "REC: student.id"
+          currency_id: "REC: company.currency_id.id"
+
+      - step: "Confirm enrollment as admin"
+        action: "call"
+        target: "enrollment"
+        method: "action_confirm"
+        as_user: "base.user_admin"
+        asserts:
+          state:
+            type: "value"
+            expected: "confirm"
+
+      - step: "Approve enrollment as admin"
+        action: "call"
+        target: "enrollment"
+        method: "action_approve_approval"
+        as_user: "base.user_admin"
+        asserts:
+          state:
+            type: "value"
+            expected: "open"
+
+  - name: "Homeroom - Admin Can Read Record Created By Another User"
+    steps:
+      - step: "Create homeroom as OdooBot (not admin), so user_id is not admin"
+        action: "create"
+        model: "school_homeroom"
+        save_as: "homeroom"
+        values:
+          date: "2024-07-01"
+          academic_year_id: "REC: academic_year.id"
+          academic_term_id: "REC: academic_term.id"
+          school_id: "REC: school.id"
+          grade_id: "REC: grade.id"
+          grade_class_id: "REC: grade_class.id"
+          capacity: 30
+
+      - step: "Admin reads the homeroom with a forced refresh from database"
+        action: "assert"
+        target: "homeroom"
+        as_user: "base.user_admin"
+        refresh: true
+        asserts:
+          state:
+            type: "value"
+            expected: "draft"
+
+  - name: "Homeroom - Full Confirm Approve Workflow As Admin With Auto Refresh"
+    steps:
+      - step: "Create homeroom as OdooBot (not admin), so user_id is not admin"
+        action: "create"
+        model: "school_homeroom"
+        save_as: "homeroom"
+        values:
+          date: "2024-07-01"
+          academic_year_id: "REC: academic_year.id"
+          academic_term_id: "REC: academic_term.id"
+          school_id: "REC: school.id"
+          grade_id: "REC: grade.id"
+          grade_class_id: "REC: grade_class.id"
+          capacity: 30
+
+      - step: "Confirm homeroom as admin"
+        action: "call"
+        target: "homeroom"
+        method: "action_confirm"
+        as_user: "base.user_admin"
+        asserts:
+          state:
+            type: "value"
+            expected: "confirm"
+
+      - step: "Approve homeroom as admin"
+        action: "call"
+        target: "homeroom"
+        method: "action_approve_approval"
+        as_user: "base.user_admin"
+        asserts:
+          state:
+            type: "value"
+            expected: "open"
+
+  - name: "Student Mutation - Admin Can Read Record Created By Another User"
+    steps:
+      - step: "Create enrollment as OdooBot"
+        action: "create"
+        model: "school_enrollment"
+        save_as: "enrollment"
+        values:
+          date: "2024-07-01"
+          academic_year_id: "REC: academic_year.id"
+          academic_term_id: "REC: academic_term.id"
+          school_id: "REC: school.id"
+          grade_id: "REC: grade.id"
+          grade_class_id: "REC: grade_class.id"
+          student_id: "REC: student.id"
+          currency_id: "REC: company.currency_id.id"
+
+      - step: "Confirm enrollment as admin so it becomes eligible for mutation"
+        action: "call"
+        target: "enrollment"
+        method: "action_confirm"
+        as_user: "base.user_admin"
+
+      - step: "Approve enrollment as admin so it becomes open"
+        action: "call"
+        target: "enrollment"
+        method: "action_approve_approval"
+        as_user: "base.user_admin"
+        asserts:
+          state:
+            type: "value"
+            expected: "open"
+
+      - step: "Create mutation as OdooBot (not admin), so user_id is not admin"
+        action: "create"
+        model: "school_student_mutation"
+        save_as: "mutation"
+        values:
+          date: "2024-07-01"
+          student_id: "REC: student.id"
+          enrollment_id: "REC: enrollment.id"
+          source_grade_class_id: "REC: grade_class.id"
+          destination_grade_class_id: "REC: grade_class_dest.id"
+
+      - step: "Admin reads the mutation with a forced refresh from database"
+        action: "assert"
+        target: "mutation"
+        as_user: "base.user_admin"
+        refresh: true
+        asserts:
+          state:
+            type: "value"
+            expected: "draft"
+
+  - name: "Student Mutation - Full Confirm Approve Workflow As Admin With Auto Refresh"
+    steps:
+      - step: "Create enrollment as OdooBot"
+        action: "create"
+        model: "school_enrollment"
+        save_as: "enrollment"
+        values:
+          date: "2024-07-01"
+          academic_year_id: "REC: academic_year.id"
+          academic_term_id: "REC: academic_term.id"
+          school_id: "REC: school.id"
+          grade_id: "REC: grade.id"
+          grade_class_id: "REC: grade_class.id"
+          student_id: "REC: student.id"
+          currency_id: "REC: company.currency_id.id"
+
+      - step: "Confirm enrollment as admin so it becomes eligible for mutation"
+        action: "call"
+        target: "enrollment"
+        method: "action_confirm"
+        as_user: "base.user_admin"
+
+      - step: "Approve enrollment as admin so it becomes open"
+        action: "call"
+        target: "enrollment"
+        method: "action_approve_approval"
+        as_user: "base.user_admin"
+        asserts:
+          state:
+            type: "value"
+            expected: "open"
+
+      - step: "Create mutation as OdooBot (not admin), so user_id is not admin"
+        action: "create"
+        model: "school_student_mutation"
+        save_as: "mutation"
+        values:
+          date: "2024-07-01"
+          student_id: "REC: student.id"
+          enrollment_id: "REC: enrollment.id"
+          source_grade_class_id: "REC: grade_class.id"
+          destination_grade_class_id: "REC: grade_class_dest.id"
+
+      - step: "Confirm mutation as admin"
+        action: "call"
+        target: "mutation"
+        method: "action_confirm"
+        as_user: "base.user_admin"
+        asserts:
+          state:
+            type: "value"
+            expected: "confirm"
+
+      - step: "Approve mutation as admin"
+        action: "call"
+        target: "mutation"
+        method: "action_approve_approval"
+        as_user: "base.user_admin"
+        asserts:
+          state:
+            type: "value"
+            expected: "done"
+
+  - name: "Negative Path - Plain Internal User Still Restricted To Own Enrollment"
+    steps:
+      - step:
+          "Create enrollment as OdooBot (not plain_user), so user_id is not plain_user"
+        action: "create"
+        model: "school_enrollment"
+        save_as: "enrollment"
+        values:
+          date: "2024-07-01"
+          academic_year_id: "REC: academic_year.id"
+          academic_term_id: "REC: academic_term.id"
+          school_id: "REC: school.id"
+          grade_id: "REC: grade.id"
+          grade_class_id: "REC: grade_class.id"
+          student_id: "REC: student.id"
+          currency_id: "REC: company.currency_id.id"
+
+      - step: "Create a plain internal user with only the base user group"
+        action: "create"
+        model: "res.users"
+        save_as: "plain_user"
+        values:
+          name: "Plain Internal User Access Test"
+          login: "plain_user_access_test@example.com"
+          groups_id: [[6, 0, ["REF: base.group_user"]]]
+
+      - step: "Plain user reading another user's enrollment must still be denied"
+        action: "call"
+        target: "enrollment"
+        method: "read"
+        args:
+          - ["state"]
+        as_user: "plain_user"
+        expect_error:
+          type: "AccessError"

--- a/ssi_school/tests/test_data_school_enrollment_access.yaml
+++ b/ssi_school/tests/test_data_school_enrollment_access.yaml
@@ -1,100 +1,87 @@
 options:
   auto_refresh: true
 
-setup:
-  steps:
-    - step: "Setup - create grade type"
-      action: "create"
-      model: "school_grade_type"
-      save_as: "grade_type"
-      values:
-        name: "Grade Type for Access Test"
-        code: "GTACC"
-        sequence: 10
-
-    - step: "Setup - create academic year"
-      action: "create"
-      model: "school_academic_year"
-      save_as: "academic_year"
-      values:
-        name: "2024/2025 Access Test"
-        code: "AYACC"
-        date_start: "2024-07-01"
-        date_end: "2025-06-30"
-
-    - step: "Setup - create academic term"
-      action: "create"
-      model: "school_academic_term"
-      save_as: "academic_term"
-      values:
-        name: "Semester 1 Access Test"
-        code: "SMACC"
-        date_start: "2024-07-01"
-        date_end: "2024-12-31"
-        year_id: "REC: academic_year.id"
-        enrollment_state: "open"
-
-    - step: "Setup - create school"
-      action: "create"
-      model: "school"
-      save_as: "school"
-      values:
-        name: "School for Access Test"
-        code: "SCHACC"
-        grade_type_id: "REC: grade_type.id"
-
-    - step: "Setup - create grade"
-      action: "create"
-      model: "school_grade"
-      save_as: "grade"
-      values:
-        name: "Grade for Access Test"
-        code: "GACC"
-        sequence: 10
-        type_id: "REC: grade_type.id"
-
-    - step: "Setup - create source grade class"
-      action: "create"
-      model: "school_grade_class"
-      save_as: "grade_class"
-      values:
-        name: "Class A Access Test"
-        code: "CLACCA"
-        school_id: "REC: school.id"
-        grade_id: "REC: grade.id"
-        capacity: 30
-
-    - step: "Setup - create destination grade class"
-      action: "create"
-      model: "school_grade_class"
-      save_as: "grade_class_dest"
-      values:
-        name: "Class B Access Test"
-        code: "CLACCB"
-        school_id: "REC: school.id"
-        grade_id: "REC: grade.id"
-        capacity: 30
-
-    - step: "Setup - create student contact"
-      action: "create"
-      model: "res.partner"
-      save_as: "contact"
-      values:
-        name: "Student Contact Access Test"
-
-    - step: "Setup - create student"
-      action: "create"
-      model: "school_student"
-      save_as: "student"
-      values:
-        name: "Student for Access Test"
-        code: "STUACC"
-        contact_id: "REC: contact.id"
-        school_id: "REC: school.id"
-
 scenarios:
   - name: "Enrollment - Admin Can Read Record Created By Another User"
     steps:
+      - step: "Setup - create grade type"
+        action: "create"
+        model: "school_grade_type"
+        save_as: "grade_type"
+        values:
+          name: "Grade Type for Access Test 1"
+          code: "GTAC1"
+          sequence: 10
+
+      - step: "Setup - create academic year"
+        action: "create"
+        model: "school_academic_year"
+        save_as: "academic_year"
+        values:
+          name: "2024/2025 Access Test 1"
+          code: "AYAC1"
+          date_start: "2024-07-01"
+          date_end: "2025-06-30"
+
+      - step: "Setup - create academic term"
+        action: "create"
+        model: "school_academic_term"
+        save_as: "academic_term"
+        values:
+          name: "Semester 1 Access Test 1"
+          code: "TMAC1"
+          date_start: "2024-07-01"
+          date_end: "2024-12-31"
+          year_id: "REC: academic_year.id"
+          enrollment_state: "open"
+
+      - step: "Setup - create school"
+        action: "create"
+        model: "school"
+        save_as: "school"
+        values:
+          name: "School for Access Test 1"
+          code: "SCAC1"
+          grade_type_id: "REC: grade_type.id"
+
+      - step: "Setup - create grade"
+        action: "create"
+        model: "school_grade"
+        save_as: "grade"
+        values:
+          name: "Grade for Access Test 1"
+          code: "GRAC1"
+          sequence: 10
+          type_id: "REC: grade_type.id"
+
+      - step: "Setup - create grade class"
+        action: "create"
+        model: "school_grade_class"
+        save_as: "grade_class"
+        values:
+          name: "Class A Access Test 1"
+          code: "CAAC1"
+          school_id: "REC: school.id"
+          grade_id: "REC: grade.id"
+          capacity: 30
+
+      - step: "Setup - create student contact"
+        action: "create"
+        model: "res.partner"
+        save_as: "contact"
+        values:
+          name: "Student Contact Access Test 1"
+
+      - step: "Setup - create student"
+        action: "create"
+        model: "school_student"
+        save_as: "student"
+        values:
+          name: "Student for Access Test 1"
+          code: "STAC1"
+          contact_id: "REC: contact.id"
+          school_id: "REC: school.id"
+
       - step: "Create enrollment as OdooBot (not admin), so user_id is not admin"
         action: "create"
         model: "school_enrollment"
@@ -121,6 +108,84 @@ scenarios:
 
   - name: "Enrollment - Full Confirm Approve Workflow As Admin With Auto Refresh"
     steps:
+      - step: "Setup - create grade type"
+        action: "create"
+        model: "school_grade_type"
+        save_as: "grade_type"
+        values:
+          name: "Grade Type for Access Test 2"
+          code: "GTAC2"
+          sequence: 10
+
+      - step: "Setup - create academic year"
+        action: "create"
+        model: "school_academic_year"
+        save_as: "academic_year"
+        values:
+          name: "2024/2025 Access Test 2"
+          code: "AYAC2"
+          date_start: "2024-07-01"
+          date_end: "2025-06-30"
+
+      - step: "Setup - create academic term"
+        action: "create"
+        model: "school_academic_term"
+        save_as: "academic_term"
+        values:
+          name: "Semester 1 Access Test 2"
+          code: "TMAC2"
+          date_start: "2024-07-01"
+          date_end: "2024-12-31"
+          year_id: "REC: academic_year.id"
+          enrollment_state: "open"
+
+      - step: "Setup - create school"
+        action: "create"
+        model: "school"
+        save_as: "school"
+        values:
+          name: "School for Access Test 2"
+          code: "SCAC2"
+          grade_type_id: "REC: grade_type.id"
+
+      - step: "Setup - create grade"
+        action: "create"
+        model: "school_grade"
+        save_as: "grade"
+        values:
+          name: "Grade for Access Test 2"
+          code: "GRAC2"
+          sequence: 10
+          type_id: "REC: grade_type.id"
+
+      - step: "Setup - create grade class"
+        action: "create"
+        model: "school_grade_class"
+        save_as: "grade_class"
+        values:
+          name: "Class A Access Test 2"
+          code: "CAAC2"
+          school_id: "REC: school.id"
+          grade_id: "REC: grade.id"
+          capacity: 30
+
+      - step: "Setup - create student contact"
+        action: "create"
+        model: "res.partner"
+        save_as: "contact"
+        values:
+          name: "Student Contact Access Test 2"
+
+      - step: "Setup - create student"
+        action: "create"
+        model: "school_student"
+        save_as: "student"
+        values:
+          name: "Student for Access Test 2"
+          code: "STAC2"
+          contact_id: "REC: contact.id"
+          school_id: "REC: school.id"
+
       - step: "Create enrollment as OdooBot (not admin), so user_id is not admin"
         action: "create"
         model: "school_enrollment"
@@ -145,6 +210,11 @@ scenarios:
             type: "value"
             expected: "confirm"
 
+      - step: "Invalidate enrollment cache before approve"
+        action: "call"
+        target: "enrollment"
+        method: "invalidate_cache"
+
       - step: "Approve enrollment as admin"
         action: "call"
         target: "enrollment"
@@ -157,6 +227,67 @@ scenarios:
 
   - name: "Homeroom - Admin Can Read Record Created By Another User"
     steps:
+      - step: "Setup - create grade type"
+        action: "create"
+        model: "school_grade_type"
+        save_as: "grade_type"
+        values:
+          name: "Grade Type for Access Test 3"
+          code: "GTAC3"
+          sequence: 10
+
+      - step: "Setup - create academic year"
+        action: "create"
+        model: "school_academic_year"
+        save_as: "academic_year"
+        values:
+          name: "2024/2025 Access Test 3"
+          code: "AYAC3"
+          date_start: "2024-07-01"
+          date_end: "2025-06-30"
+
+      - step: "Setup - create academic term"
+        action: "create"
+        model: "school_academic_term"
+        save_as: "academic_term"
+        values:
+          name: "Semester 1 Access Test 3"
+          code: "TMAC3"
+          date_start: "2024-07-01"
+          date_end: "2024-12-31"
+          year_id: "REC: academic_year.id"
+          enrollment_state: "open"
+
+      - step: "Setup - create school"
+        action: "create"
+        model: "school"
+        save_as: "school"
+        values:
+          name: "School for Access Test 3"
+          code: "SCAC3"
+          grade_type_id: "REC: grade_type.id"
+
+      - step: "Setup - create grade"
+        action: "create"
+        model: "school_grade"
+        save_as: "grade"
+        values:
+          name: "Grade for Access Test 3"
+          code: "GRAC3"
+          sequence: 10
+          type_id: "REC: grade_type.id"
+
+      - step: "Setup - create grade class"
+        action: "create"
+        model: "school_grade_class"
+        save_as: "grade_class"
+        values:
+          name: "Class A Access Test 3"
+          code: "CAAC3"
+          school_id: "REC: school.id"
+          grade_id: "REC: grade.id"
+          capacity: 30
+
       - step: "Create homeroom as OdooBot (not admin), so user_id is not admin"
         action: "create"
         model: "school_homeroom"
@@ -182,6 +313,67 @@ scenarios:
 
   - name: "Homeroom - Full Confirm Approve Workflow As Admin With Auto Refresh"
     steps:
+      - step: "Setup - create grade type"
+        action: "create"
+        model: "school_grade_type"
+        save_as: "grade_type"
+        values:
+          name: "Grade Type for Access Test 4"
+          code: "GTAC4"
+          sequence: 10
+
+      - step: "Setup - create academic year"
+        action: "create"
+        model: "school_academic_year"
+        save_as: "academic_year"
+        values:
+          name: "2024/2025 Access Test 4"
+          code: "AYAC4"
+          date_start: "2024-07-01"
+          date_end: "2025-06-30"
+
+      - step: "Setup - create academic term"
+        action: "create"
+        model: "school_academic_term"
+        save_as: "academic_term"
+        values:
+          name: "Semester 1 Access Test 4"
+          code: "TMAC4"
+          date_start: "2024-07-01"
+          date_end: "2024-12-31"
+          year_id: "REC: academic_year.id"
+          enrollment_state: "open"
+
+      - step: "Setup - create school"
+        action: "create"
+        model: "school"
+        save_as: "school"
+        values:
+          name: "School for Access Test 4"
+          code: "SCAC4"
+          grade_type_id: "REC: grade_type.id"
+
+      - step: "Setup - create grade"
+        action: "create"
+        model: "school_grade"
+        save_as: "grade"
+        values:
+          name: "Grade for Access Test 4"
+          code: "GRAC4"
+          sequence: 10
+          type_id: "REC: grade_type.id"
+
+      - step: "Setup - create grade class"
+        action: "create"
+        model: "school_grade_class"
+        save_as: "grade_class"
+        values:
+          name: "Class A Access Test 4"
+          code: "CAAC4"
+          school_id: "REC: school.id"
+          grade_id: "REC: grade.id"
+          capacity: 30
+
       - step: "Create homeroom as OdooBot (not admin), so user_id is not admin"
         action: "create"
         model: "school_homeroom"
@@ -205,6 +397,11 @@ scenarios:
             type: "value"
             expected: "confirm"
 
+      - step: "Invalidate homeroom cache before approve"
+        action: "call"
+        target: "homeroom"
+        method: "invalidate_cache"
+
       - step: "Approve homeroom as admin"
         action: "call"
         target: "homeroom"
@@ -217,6 +414,95 @@ scenarios:
 
   - name: "Student Mutation - Admin Can Read Record Created By Another User"
     steps:
+      - step: "Setup - create grade type"
+        action: "create"
+        model: "school_grade_type"
+        save_as: "grade_type"
+        values:
+          name: "Grade Type for Access Test 5"
+          code: "GTAC5"
+          sequence: 10
+
+      - step: "Setup - create academic year"
+        action: "create"
+        model: "school_academic_year"
+        save_as: "academic_year"
+        values:
+          name: "2024/2025 Access Test 5"
+          code: "AYAC5"
+          date_start: "2024-07-01"
+          date_end: "2025-06-30"
+
+      - step: "Setup - create academic term"
+        action: "create"
+        model: "school_academic_term"
+        save_as: "academic_term"
+        values:
+          name: "Semester 1 Access Test 5"
+          code: "TMAC5"
+          date_start: "2024-07-01"
+          date_end: "2024-12-31"
+          year_id: "REC: academic_year.id"
+          enrollment_state: "open"
+
+      - step: "Setup - create school"
+        action: "create"
+        model: "school"
+        save_as: "school"
+        values:
+          name: "School for Access Test 5"
+          code: "SCAC5"
+          grade_type_id: "REC: grade_type.id"
+
+      - step: "Setup - create grade"
+        action: "create"
+        model: "school_grade"
+        save_as: "grade"
+        values:
+          name: "Grade for Access Test 5"
+          code: "GRAC5"
+          sequence: 10
+          type_id: "REC: grade_type.id"
+
+      - step: "Setup - create source grade class"
+        action: "create"
+        model: "school_grade_class"
+        save_as: "grade_class"
+        values:
+          name: "Class A Access Test 5"
+          code: "CAAC5"
+          school_id: "REC: school.id"
+          grade_id: "REC: grade.id"
+          capacity: 30
+
+      - step: "Setup - create destination grade class"
+        action: "create"
+        model: "school_grade_class"
+        save_as: "grade_class_dest"
+        values:
+          name: "Class B Access Test 5"
+          code: "CBAC5"
+          school_id: "REC: school.id"
+          grade_id: "REC: grade.id"
+          capacity: 30
+
+      - step: "Setup - create student contact"
+        action: "create"
+        model: "res.partner"
+        save_as: "contact"
+        values:
+          name: "Student Contact Access Test 5"
+
+      - step: "Setup - create student"
+        action: "create"
+        model: "school_student"
+        save_as: "student"
+        values:
+          name: "Student for Access Test 5"
+          code: "STAC5"
+          contact_id: "REC: contact.id"
+          school_id: "REC: school.id"
+
       - step: "Create enrollment as OdooBot"
         action: "create"
         model: "school_enrollment"
@@ -236,6 +522,11 @@ scenarios:
         target: "enrollment"
         method: "action_confirm"
         as_user: "base.user_admin"
+
+      - step: "Invalidate enrollment cache before approve"
+        action: "call"
+        target: "enrollment"
+        method: "invalidate_cache"
 
       - step: "Approve enrollment as admin so it becomes open"
         action: "call"
@@ -270,6 +561,95 @@ scenarios:
 
   - name: "Student Mutation - Full Confirm Approve Workflow As Admin With Auto Refresh"
     steps:
+      - step: "Setup - create grade type"
+        action: "create"
+        model: "school_grade_type"
+        save_as: "grade_type"
+        values:
+          name: "Grade Type for Access Test 6"
+          code: "GTAC6"
+          sequence: 10
+
+      - step: "Setup - create academic year"
+        action: "create"
+        model: "school_academic_year"
+        save_as: "academic_year"
+        values:
+          name: "2024/2025 Access Test 6"
+          code: "AYAC6"
+          date_start: "2024-07-01"
+          date_end: "2025-06-30"
+
+      - step: "Setup - create academic term"
+        action: "create"
+        model: "school_academic_term"
+        save_as: "academic_term"
+        values:
+          name: "Semester 1 Access Test 6"
+          code: "TMAC6"
+          date_start: "2024-07-01"
+          date_end: "2024-12-31"
+          year_id: "REC: academic_year.id"
+          enrollment_state: "open"
+
+      - step: "Setup - create school"
+        action: "create"
+        model: "school"
+        save_as: "school"
+        values:
+          name: "School for Access Test 6"
+          code: "SCAC6"
+          grade_type_id: "REC: grade_type.id"
+
+      - step: "Setup - create grade"
+        action: "create"
+        model: "school_grade"
+        save_as: "grade"
+        values:
+          name: "Grade for Access Test 6"
+          code: "GRAC6"
+          sequence: 10
+          type_id: "REC: grade_type.id"
+
+      - step: "Setup - create source grade class"
+        action: "create"
+        model: "school_grade_class"
+        save_as: "grade_class"
+        values:
+          name: "Class A Access Test 6"
+          code: "CAAC6"
+          school_id: "REC: school.id"
+          grade_id: "REC: grade.id"
+          capacity: 30
+
+      - step: "Setup - create destination grade class"
+        action: "create"
+        model: "school_grade_class"
+        save_as: "grade_class_dest"
+        values:
+          name: "Class B Access Test 6"
+          code: "CBAC6"
+          school_id: "REC: school.id"
+          grade_id: "REC: grade.id"
+          capacity: 30
+
+      - step: "Setup - create student contact"
+        action: "create"
+        model: "res.partner"
+        save_as: "contact"
+        values:
+          name: "Student Contact Access Test 6"
+
+      - step: "Setup - create student"
+        action: "create"
+        model: "school_student"
+        save_as: "student"
+        values:
+          name: "Student for Access Test 6"
+          code: "STAC6"
+          contact_id: "REC: contact.id"
+          school_id: "REC: school.id"
+
       - step: "Create enrollment as OdooBot"
         action: "create"
         model: "school_enrollment"
@@ -289,6 +669,11 @@ scenarios:
         target: "enrollment"
         method: "action_confirm"
         as_user: "base.user_admin"
+
+      - step: "Invalidate enrollment cache before approve"
+        action: "call"
+        target: "enrollment"
+        method: "invalidate_cache"
 
       - step: "Approve enrollment as admin so it becomes open"
         action: "call"
@@ -321,6 +706,11 @@ scenarios:
             type: "value"
             expected: "confirm"
 
+      - step: "Invalidate mutation cache before approve"
+        action: "call"
+        target: "mutation"
+        method: "invalidate_cache"
+
       - step: "Approve mutation as admin"
         action: "call"
         target: "mutation"
@@ -333,6 +723,84 @@ scenarios:
 
   - name: "Negative Path - Plain Internal User Still Restricted To Own Enrollment"
     steps:
+      - step: "Setup - create grade type"
+        action: "create"
+        model: "school_grade_type"
+        save_as: "grade_type"
+        values:
+          name: "Grade Type for Access Test 7"
+          code: "GTAC7"
+          sequence: 10
+
+      - step: "Setup - create academic year"
+        action: "create"
+        model: "school_academic_year"
+        save_as: "academic_year"
+        values:
+          name: "2024/2025 Access Test 7"
+          code: "AYAC7"
+          date_start: "2024-07-01"
+          date_end: "2025-06-30"
+
+      - step: "Setup - create academic term"
+        action: "create"
+        model: "school_academic_term"
+        save_as: "academic_term"
+        values:
+          name: "Semester 1 Access Test 7"
+          code: "TMAC7"
+          date_start: "2024-07-01"
+          date_end: "2024-12-31"
+          year_id: "REC: academic_year.id"
+          enrollment_state: "open"
+
+      - step: "Setup - create school"
+        action: "create"
+        model: "school"
+        save_as: "school"
+        values:
+          name: "School for Access Test 7"
+          code: "SCAC7"
+          grade_type_id: "REC: grade_type.id"
+
+      - step: "Setup - create grade"
+        action: "create"
+        model: "school_grade"
+        save_as: "grade"
+        values:
+          name: "Grade for Access Test 7"
+          code: "GRAC7"
+          sequence: 10
+          type_id: "REC: grade_type.id"
+
+      - step: "Setup - create grade class"
+        action: "create"
+        model: "school_grade_class"
+        save_as: "grade_class"
+        values:
+          name: "Class A Access Test 7"
+          code: "CAAC7"
+          school_id: "REC: school.id"
+          grade_id: "REC: grade.id"
+          capacity: 30
+
+      - step: "Setup - create student contact"
+        action: "create"
+        model: "res.partner"
+        save_as: "contact"
+        values:
+          name: "Student Contact Access Test 7"
+
+      - step: "Setup - create student"
+        action: "create"
+        model: "school_student"
+        save_as: "student"
+        values:
+          name: "Student for Access Test 7"
+          code: "STAC7"
+          contact_id: "REC: contact.id"
+          school_id: "REC: school.id"
+
       - step:
           "Create enrollment as OdooBot (not plain_user), so user_id is not plain_user"
         action: "create"

--- a/ssi_school/tests/test_data_school_homeroom.yaml
+++ b/ssi_school/tests/test_data_school_homeroom.yaml
@@ -348,6 +348,11 @@ scenarios:
             type: "value"
             expected: "confirm"
 
+      - step: "Invalidate homeroom cache before approve"
+        action: "call"
+        target: "homeroom"
+        method: "invalidate_cache"
+
       - step: "Approve homeroom"
         action: "call"
         target: "homeroom"

--- a/ssi_school/tests/test_data_school_homeroom.yaml
+++ b/ssi_school/tests/test_data_school_homeroom.yaml
@@ -1,3 +1,5 @@
+options:
+  auto_refresh: true
 scenarios:
   - name: "Create Homeroom Draft"
     steps:
@@ -236,11 +238,6 @@ scenarios:
           homeroom_id: "EVAL: registry['homeroom'].id"
           currency_id: "EVAL: env.company.currency_id.id"
 
-      - step: "Invalidate homeroom cache after linking enrollments"
-        action: "call"
-        target: "homeroom"
-        method: "invalidate_cache"
-
       - step: "Assert homeroom aggregates enrollments"
         action: "assert"
         target: "homeroom"
@@ -350,11 +347,6 @@ scenarios:
           state:
             type: "value"
             expected: "confirm"
-
-      - step: "Invalidate homeroom cache before approve"
-        action: "call"
-        target: "homeroom"
-        method: "invalidate_cache"
 
       - step: "Approve homeroom"
         action: "call"

--- a/ssi_school/tests/test_data_school_homeroom_generate.yaml
+++ b/ssi_school/tests/test_data_school_homeroom_generate.yaml
@@ -200,6 +200,11 @@ scenarios:
         method: "action_confirm"
         as_user: "base.user_admin"
 
+      - step: "Invalidate homeroom cache before approve"
+        action: "call"
+        target: "homeroom"
+        method: "invalidate_cache"
+
       - step: "Approve homeroom"
         action: "call"
         target: "homeroom"
@@ -725,6 +730,11 @@ scenarios:
         method: "action_confirm"
         as_user: "base.user_admin"
 
+      - step: "Invalidate homeroom cache before approve"
+        action: "call"
+        target: "homeroom"
+        method: "invalidate_cache"
+
       - step: "Approve homeroom"
         action: "call"
         target: "homeroom"
@@ -930,6 +940,11 @@ scenarios:
         target: "homeroom"
         method: "action_confirm"
         as_user: "base.user_admin"
+
+      - step: "Invalidate homeroom cache before approve"
+        action: "call"
+        target: "homeroom"
+        method: "invalidate_cache"
 
       - step: "Approve homeroom"
         action: "call"

--- a/ssi_school/tests/test_data_school_homeroom_generate.yaml
+++ b/ssi_school/tests/test_data_school_homeroom_generate.yaml
@@ -1,3 +1,5 @@
+options:
+  auto_refresh: true
 scenarios:
   - name: "Homeroom Fill Random And Generate Enrollments"
     steps:
@@ -197,11 +199,6 @@ scenarios:
         target: "homeroom"
         method: "action_confirm"
         as_user: "base.user_admin"
-
-      - step: "Invalidate homeroom cache before approve"
-        action: "call"
-        target: "homeroom"
-        method: "invalidate_cache"
 
       - step: "Approve homeroom"
         action: "call"
@@ -728,11 +725,6 @@ scenarios:
         method: "action_confirm"
         as_user: "base.user_admin"
 
-      - step: "Invalidate homeroom cache before approve"
-        action: "call"
-        target: "homeroom"
-        method: "invalidate_cache"
-
       - step: "Approve homeroom"
         action: "call"
         target: "homeroom"
@@ -938,11 +930,6 @@ scenarios:
         target: "homeroom"
         method: "action_confirm"
         as_user: "base.user_admin"
-
-      - step: "Invalidate homeroom cache before approve"
-        action: "call"
-        target: "homeroom"
-        method: "invalidate_cache"
 
       - step: "Approve homeroom"
         action: "call"

--- a/ssi_school/tests/test_data_school_student_mutation.yaml
+++ b/ssi_school/tests/test_data_school_student_mutation.yaml
@@ -116,6 +116,11 @@ scenarios:
             type: "value"
             expected: "confirm"
 
+      - step: "Invalidate enrollment cache before approve"
+        action: "call"
+        target: "enrollment"
+        method: "invalidate_cache"
+
       - step: "Approve enrollment"
         action: "call"
         target: "enrollment"
@@ -310,6 +315,11 @@ scenarios:
             type: "value"
             expected: "confirm"
 
+      - step: "Invalidate enrollment cache before approve"
+        action: "call"
+        target: "enrollment"
+        method: "invalidate_cache"
+
       - step: "Approve enrollment"
         action: "call"
         target: "enrollment"
@@ -362,6 +372,11 @@ scenarios:
           state:
             type: "value"
             expected: "confirm"
+
+      - step: "Invalidate mutation cache before approve"
+        action: "call"
+        target: "mutation"
+        method: "invalidate_cache"
 
       - step: "Approve mutation"
         action: "call"
@@ -515,6 +530,11 @@ scenarios:
         method: "action_confirm"
         as_user: "base.user_admin"
 
+      - step: "Invalidate enrollment cache before approve"
+        action: "call"
+        target: "enrollment"
+        method: "invalidate_cache"
+
       - step: "Approve enrollment"
         action: "call"
         target: "enrollment"
@@ -666,6 +686,11 @@ scenarios:
         method: "action_confirm"
         as_user: "base.user_admin"
 
+      - step: "Invalidate enrollment cache before approve"
+        action: "call"
+        target: "enrollment"
+        method: "invalidate_cache"
+
       - step: "Approve enrollment"
         action: "call"
         target: "enrollment"
@@ -692,6 +717,11 @@ scenarios:
         target: "mutation_forward"
         method: "action_confirm"
         as_user: "base.user_admin"
+
+      - step: "Invalidate cache before approving forward mutation"
+        action: "call"
+        target: "mutation_forward"
+        method: "invalidate_cache"
 
       - step: "Approve forward mutation"
         action: "call"
@@ -728,6 +758,11 @@ scenarios:
         target: "mutation_reverse"
         method: "action_confirm"
         as_user: "base.user_admin"
+
+      - step: "Invalidate cache before approving reverse mutation"
+        action: "call"
+        target: "mutation_reverse"
+        method: "invalidate_cache"
 
       - step: "Approve reverse mutation"
         action: "call"

--- a/ssi_school/tests/test_data_school_student_mutation.yaml
+++ b/ssi_school/tests/test_data_school_student_mutation.yaml
@@ -1,3 +1,5 @@
+options:
+  auto_refresh: true
 scenarios:
   - name: "Create Class Mutation Draft"
     steps:
@@ -113,11 +115,6 @@ scenarios:
           state:
             type: "value"
             expected: "confirm"
-
-      - step: "Invalidate enrollment cache before approve"
-        action: "call"
-        target: "enrollment"
-        method: "invalidate_cache"
 
       - step: "Approve enrollment"
         action: "call"
@@ -313,11 +310,6 @@ scenarios:
             type: "value"
             expected: "confirm"
 
-      - step: "Invalidate enrollment cache before approve"
-        action: "call"
-        target: "enrollment"
-        method: "invalidate_cache"
-
       - step: "Approve enrollment"
         action: "call"
         target: "enrollment"
@@ -371,11 +363,6 @@ scenarios:
             type: "value"
             expected: "confirm"
 
-      - step: "Invalidate mutation cache before approve"
-        action: "call"
-        target: "mutation"
-        method: "invalidate_cache"
-
       - step: "Approve mutation"
         action: "call"
         target: "mutation"
@@ -385,11 +372,6 @@ scenarios:
           state:
             type: "value"
             expected: "done"
-
-      - step: "Invalidate mutation cache after approve"
-        action: "call"
-        target: "mutation"
-        method: "invalidate_cache"
 
       - step: "Assert mutation number generated on done"
         action: "assert"
@@ -532,11 +514,6 @@ scenarios:
         target: "enrollment"
         method: "action_confirm"
         as_user: "base.user_admin"
-
-      - step: "Invalidate enrollment cache before approve"
-        action: "call"
-        target: "enrollment"
-        method: "invalidate_cache"
 
       - step: "Approve enrollment"
         action: "call"
@@ -689,11 +666,6 @@ scenarios:
         method: "action_confirm"
         as_user: "base.user_admin"
 
-      - step: "Invalidate enrollment cache before approve"
-        action: "call"
-        target: "enrollment"
-        method: "invalidate_cache"
-
       - step: "Approve enrollment"
         action: "call"
         target: "enrollment"
@@ -720,11 +692,6 @@ scenarios:
         target: "mutation_forward"
         method: "action_confirm"
         as_user: "base.user_admin"
-
-      - step: "Invalidate cache before approving forward mutation"
-        action: "call"
-        target: "mutation_forward"
-        method: "invalidate_cache"
 
       - step: "Approve forward mutation"
         action: "call"
@@ -761,11 +728,6 @@ scenarios:
         target: "mutation_reverse"
         method: "action_confirm"
         as_user: "base.user_admin"
-
-      - step: "Invalidate cache before approving reverse mutation"
-        action: "call"
-        target: "mutation_reverse"
-        method: "invalidate_cache"
 
       - step: "Approve reverse mutation"
         action: "call"

--- a/ssi_school/tests/test_school_enrollment_access.py
+++ b/ssi_school/tests/test_school_enrollment_access.py
@@ -1,0 +1,13 @@
+# Copyright 2026 OpenSynergy Indonesia
+# Copyright 2026 PT. Simetri Sinergi Indonesia
+# License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl).
+
+from odoo_yaml_test import YamlTransactionCase
+
+from odoo.tests import tagged
+
+
+@tagged("post_install", "-at_install")
+class TestSchoolEnrollmentAccess(YamlTransactionCase):
+    def test_school_enrollment_access(self):
+        self.run_yaml_scenario("test_data_school_enrollment_access.yaml")


### PR DESCRIPTION
## Ringkasan

Memperbaiki BL-0177: record rule `school_enrollment`/`school_homeroom`/`school_student_mutation` membuat `base.user_admin` tidak bisa membaca/memvalidasi dokumen milik user lain.

- Grup workflow Validator sudah diberikan ke `base.user_root`/`base.user_admin`, tetapi grup data ownership (`_all_group`) belum — sehingga satu-satunya rule yang berlaku bagi admin adalah `user_id = user.id`, dan admin hanya bisa membaca record miliknya sendiri.
- Tambahkan `base.user_root` + `base.user_admin` ke `school_enrollment_all_group`, `school_homeroom_all_group`, dan `school_student_mutation_all_group` (`security/res_group/*.xml`).
- Nyalakan `options: {auto_refresh: true}` pada seluruh file test YAML yang menyentuh ketiga model tersebut, dan hapus step manual `invalidate_cache` yang jadi tidak perlu.
- Test regresi baru `test_data_school_enrollment_access.yaml` + `test_school_enrollment_access.py`: admin bisa membaca & confirm/approve dokumen milik user lain, sementara internal user biasa tetap dibatasi ke recordnya sendiri (negative path).

**Catatan deploy:** perubahan `res.groups` hanya berlaku setelah update modul (`-u ssi_school`), bukan sekadar restart Odoo.

## Test plan

- [ ] CI `ssi_school`: 0 failed, 0 error