### PR TITLE
[UPD] ssi_school, ssi_school_admission, ssi_school_incident - revisi urutan menu

### DIFF
--- a/ssi_school/menu.xml
+++ b/ssi_school/menu.xml
@@ -13,28 +13,28 @@
         id="menu_school_student_activity"
         name="Student Activities"
         parent="menu_school_root"
-        sequence="130"
+        sequence="40"
     />
 
 <menuitem
         id="menu_school_classroom"
         name="Classroom"
         parent="menu_school_root"
-        sequence="400"
+        sequence="60"
     />
 
 <menuitem
         id="menu_school_report"
-        name="Report"
+        name="Reporting"
         parent="menu_school_root"
-        sequence="980"
+        sequence="98"
     />
 
 <menuitem
         id="menu_school_configuration"
         name="Configuration"
         parent="menu_school_root"
-        sequence="990"
+        sequence="99"
     />
 
 <menuitem

--- a/ssi_school/views/school_homeroom.xml
+++ b/ssi_school/views/school_homeroom.xml
@@ -162,10 +162,10 @@
 <menuitem
         id="school_homeroom_menu"
         name="Homerooms"
-        parent="ssi_school.menu_school_root"
+        parent="ssi_school.menu_school_student_activity"
         action="school_homeroom_action"
         groups="school_homeroom_viewer_group"
-        sequence="145"
+        sequence="60"
     />
 
 </odoo>

--- a/ssi_school/views/school_student.xml
+++ b/ssi_school/views/school_student.xml
@@ -265,7 +265,7 @@
         parent="menu_school_root"
         action="school_student_action"
         groups="school_student_group"
-        sequence="110"
+        sequence="20"
     />
 
 </odoo>

--- a/ssi_school/views/school_teacher.xml
+++ b/ssi_school/views/school_teacher.xml
@@ -171,7 +171,7 @@
         parent="menu_school_root"
         action="school_teacher_action"
         groups="school_teacher_group"
-        sequence="120"
+        sequence="30"
     />
 
 </odoo>

--- a/ssi_school_admission/menu.xml
+++ b/ssi_school_admission/menu.xml
@@ -7,7 +7,7 @@
         id="menu_school_admission"
         name="Admission"
         parent="ssi_school.menu_school_root"
-        sequence="50"
+        sequence="10"
     />
 
 </odoo>

--- a/ssi_school_incident/menu.xml
+++ b/ssi_school_incident/menu.xml
@@ -7,7 +7,7 @@
         id="menu_incident_root"
         name="Incident"
         parent="ssi_school.menu_school_root"
-        sequence="500"
+        sequence="70"
     />
 
 <menuitem


### PR DESCRIPTION
## Ringkasan
- Ubah nama menu "Report" menjadi "Reporting" pada `ssi_school`, dengan sequence 98/99 untuk Reporting/Configuration sesuai standar SSI (selalu di urutan paling akhir).
- Susun ulang sequence submenu di bawah `menu_school_root` (Admission, Students, Teachers, Student Activities, Classroom, Incident) agar berada di bawah 98.
- Pindahkan menu Homerooms menjadi submenu di dalam Student Activities (bukan lagi sibling langsung di root).

Tidak ada perubahan XML ID, nama field, method, atau model — hanya `name` dan `sequence` pada menuitem.