### PR TITLE
[UPD] ssi_school, ssi_school_admission

### DIFF
--- a/ssi_school/__manifest__.py
+++ b/ssi_school/__manifest__.py
@@ -53,6 +53,7 @@
         "security/ir_model_access/school_enrollment_payment_term_detail.xml",
         "security/ir_model_access/school_enrollment_payment_term_wizard_duplicate.xml",
         "security/ir_model_access/school_enrollment_wizard_copy_payment_term.xml",
+        "security/ir_model_access/school_enrollment_wizard_create_due_invoice.xml",
         "security/ir_model_access/school_enrollment_product_summary.xml",
         "security/ir_model_access/school_enrollment_fee_analysis.xml",
         "security/ir_model_access/school_enrollment_payment_template.xml",
@@ -93,6 +94,7 @@
         "views/school_enrollment_fee_analysis.xml",
         "wizards/school_enrollment_payment_term_duplicate.xml",
         "wizards/school_enrollment_copy_payment_term.xml",
+        "wizards/school_enrollment_create_due_invoice.xml",
     ],
     "demo": [
         "demo/res_partner.xml",

--- a/ssi_school/models/school_enrollment.py
+++ b/ssi_school/models/school_enrollment.py
@@ -385,6 +385,16 @@ class SchoolEnrollment(models.Model):
             "before the addendum remain locked."
         ),
     )
+    create_invoice_ok = fields.Boolean(
+        string="Can Create Due Invoice",
+        compute="_compute_policy",
+        store=False,
+        compute_sudo=True,
+        help=(
+            "Policy that determines whether invoices may be created for "
+            "payment terms that are due, via the Create Due Invoice wizard."
+        ),
+    )
 
     def _recompute_product_summaries(self):
         for record in self.sudo():
@@ -751,6 +761,62 @@ Solution: Choose a different Grade Class or increase its capacity
         for record in self.sudo():
             record._lock_payment_term()  # pylint: disable=protected-access
 
+    def action_open_create_due_invoice_wizard(self):
+        for record in self.sudo():
+            # pylint: disable=protected-access
+            result = record._open_create_due_invoice_wizard()
+        return result
+
+    def _open_create_due_invoice_wizard(self):
+        self.ensure_one()
+        waction = self.env.ref(
+            "ssi_school.school_enrollment_wizard_create_due_invoice_action"
+        ).read()[0]
+        waction.update(
+            {
+                "context": {
+                    "active_model": "school_enrollment",
+                    "active_id": self.id,
+                    "active_ids": [self.id],
+                },
+            }
+        )
+        return waction
+
+    def _create_due_invoice(self, date_start=False, date_end=False):
+        self.ensure_one()
+        self._check_create_invoice_policy()
+        for term in self._get_due_payment_term(date_start, date_end):
+            term._create_invoice()  # pylint: disable=protected-access
+
+    def _get_due_payment_term(self, date_start=False, date_end=False):
+        self.ensure_one()
+        date_end = date_end or fields.Date.context_today(self)
+        return self.payment_term_ids.filtered(
+            lambda r: r.state == "uninvoiced"
+            and r.date_invoice
+            and (not date_start or r.date_invoice >= date_start)
+            and r.date_invoice <= date_end
+        )
+
+    def _check_create_invoice_policy(self):
+        self.ensure_one()
+        if self.env.context.get("bypass_policy_check", False):
+            return True
+        if not self.create_invoice_ok:
+            error_message = (
+                _(
+                    """
+Context: Create due invoice
+Database ID: %s
+Problem: Document is not allowed to create due invoice
+Solution: Check create due invoice policy prerequisite
+"""
+                )
+                % (self.id,)
+            )
+            raise UserError(error_message)
+
     def _lock_payment_term(self):
         self.ensure_one()
         Term = self.env[
@@ -833,6 +899,7 @@ Solution: Delete or disconnect the invoice on the payment term before cancelling
             "graduate_ok",
             "copy_payment_term_ok",
             "addendum_ok",
+            "create_invoice_ok",
         ]
         res += policy_field
         return res

--- a/ssi_school/policy_template/school_enrollment.xml
+++ b/ssi_school/policy_template/school_enrollment.xml
@@ -71,6 +71,27 @@
     <field name="restrict_additional" eval="0" />
 </record>
 
+<!-- Create Due Invoice -->
+<record
+        id="policy_template_school_enrollment_create_invoice"
+        model="policy.template_detail"
+    >
+    <field name="template_id" ref="policy_template_school_enrollment" />
+    <field
+            name="field_id"
+            search="[('model_id.model','=','school_enrollment'),('name','=','create_invoice_ok')]"
+        />
+    <field name="restrict_state" eval="1" />
+    <field
+            name="state_ids"
+            search="[('field_id.model_id.model','=','school_enrollment'),('value','=','open')]"
+        />
+    <field name="restrict_user" eval="1" />
+    <field name="computation_method">use_group</field>
+    <field name="group_ids" eval="[(6,0,[ref('school_enrollment_user_group')])]" />
+    <field name="restrict_additional" eval="0" />
+</record>
+
 <!-- Done -->
 <record id="policy_template_school_enrollment_done" model="policy.template_detail">
     <field name="template_id" ref="policy_template_school_enrollment" />

--- a/ssi_school/security/ir_model_access/school_enrollment_wizard_create_due_invoice.xml
+++ b/ssi_school/security/ir_model_access/school_enrollment_wizard_create_due_invoice.xml
@@ -1,0 +1,20 @@
+<?xml version="1.0" encoding="utf-8" ?>
+<!-- Copyright 2026 OpenSynergy Indonesia
+     Copyright 2026 PT. Simetri Sinergi Indonesia
+     License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl). -->
+<odoo>
+
+<record
+        id="school_enrollment_wizard_create_due_invoice_user_access"
+        model="ir.model.access"
+    >
+    <field name="name">school_enrollment.wizard_create_due_invoice - user</field>
+    <field name="model_id" ref="model_school_enrollment_wizard_create_due_invoice" />
+    <field name="group_id" ref="school_enrollment_user_group" />
+    <field name="perm_read" eval="1" />
+    <field name="perm_create" eval="1" />
+    <field name="perm_write" eval="1" />
+    <field name="perm_unlink" eval="1" />
+</record>
+
+</odoo>

--- a/ssi_school/tests/__init__.py
+++ b/ssi_school/tests/__init__.py
@@ -25,6 +25,7 @@ from . import (  # noqa: F401
     test_school_enrollment_payment_term_management,
     test_school_enrollment_payment_term_duplicate,
     test_school_enrollment_copy_payment_term,
+    test_school_enrollment_create_due_invoice,
     test_school_enrollment_product_summary,
     test_school_enrollment_fee_analysis,
     test_school_enrollment_payment_date_pattern,

--- a/ssi_school/tests/test_data_enrollment_create_due_invoice.yaml
+++ b/ssi_school/tests/test_data_enrollment_create_due_invoice.yaml
@@ -1,0 +1,1824 @@
+options:
+  auto_refresh: true
+scenarios:
+  - name: "Create Due Invoice - No Range Invoices Only Due Terms"
+    steps:
+      - step: "Setup - get account type ref"
+        action: "ref"
+        xml_id: "account.data_account_type_revenue"
+        save_as: "account_type"
+
+      - step: "Setup - create income account"
+        action: "create"
+        model: "account.account"
+        save_as: "account"
+        values:
+          name: "School Fee Income CDI1"
+          code: "CDI14200"
+          user_type_id: "REC: account_type.id"
+
+      - step: "Setup - create product"
+        action: "create"
+        model: "product.product"
+        save_as: "product"
+        values:
+          name: "School Fee CDI1"
+          type: "service"
+          list_price: 500000.0
+
+      - step: "Setup - create grade type"
+        action: "create"
+        model: "school_grade_type"
+        save_as: "grade_type"
+        values:
+          name: "Grade Type CDI1"
+          code: "GTCDI1"
+          sequence: 10
+
+      - step: "Setup - create academic year"
+        action: "create"
+        model: "school_academic_year"
+        save_as: "academic_year"
+        values:
+          name: "2024/2025 CDI1"
+          code: "AYCDI1"
+          date_start: "2024-07-01"
+          date_end: "2025-06-30"
+
+      - step: "Setup - create academic term"
+        action: "create"
+        model: "school_academic_term"
+        save_as: "academic_term"
+        values:
+          name: "Semester CDI1"
+          code: "SMCDI1"
+          date_start: "2024-07-01"
+          date_end: "2025-06-30"
+          year_id: "REC: academic_year.id"
+          enrollment_state: "open"
+
+      - step: "Setup - create school"
+        action: "create"
+        model: "school"
+        save_as: "school"
+        values:
+          name: "School CDI1"
+          code: "SCHCDI1"
+          grade_type_id: "REC: grade_type.id"
+
+      - step: "Setup - create grade"
+        action: "create"
+        model: "school_grade"
+        save_as: "grade"
+        values:
+          name: "Grade CDI1"
+          code: "GCDI1"
+          sequence: 10
+          type_id: "REC: grade_type.id"
+
+      - step: "Setup - create grade class"
+        action: "create"
+        model: "school_grade_class"
+        save_as: "grade_class"
+        values:
+          name: "Class CDI1"
+          code: "CLACDI1"
+          school_id: "REC: school.id"
+          grade_id: "REC: grade.id"
+
+      - step: "Setup - get receivable journal"
+        action: "search"
+        model: "account.journal"
+        domain: [["type", "=", "sale"]]
+        save_as: "receivable_journal"
+        limit: 1
+
+      - step: "Setup - create student contact"
+        action: "create"
+        model: "res.partner"
+        save_as: "contact"
+        values:
+          name: "Student Contact CDI1"
+
+      - step: "Setup - create student"
+        action: "create"
+        model: "school_student"
+        save_as: "student"
+        values:
+          name: "Student CDI1"
+          code: "STUCDI1"
+          contact_id: "REC: contact.id"
+          school_id: "REC: school.id"
+
+      - step: "Create enrollment"
+        action: "create"
+        model: "school_enrollment"
+        save_as: "enrollment"
+        values:
+          date: "2024-07-01"
+          academic_year_id: "REC: academic_year.id"
+          academic_term_id: "REC: academic_term.id"
+          school_id: "REC: school.id"
+          grade_id: "REC: grade.id"
+          grade_class_id: "REC: grade_class.id"
+          student_id: "REC: student.id"
+          currency_id: "REC: company.currency_id.id"
+          receivable_journal_id: "REC: receivable_journal.id"
+
+      - step: "Confirm enrollment"
+        action: "call"
+        target: "enrollment"
+        method: "action_confirm"
+        as_user: "base.user_admin"
+
+      - step: "Invalidate enrollment cache before approve"
+        action: "call"
+        target: "enrollment"
+        method: "invalidate_cache"
+
+      - step: "Approve enrollment"
+        action: "call"
+        target: "enrollment"
+        method: "action_approve_approval"
+        as_user: "base.user_admin"
+        asserts:
+          state:
+            type: "value"
+            expected: "open"
+
+      - step: "Assert enrollment is allowed to create due invoice"
+        action: "assert"
+        target: "enrollment"
+        asserts:
+          create_invoice_ok:
+            type: "value"
+            expected: true
+
+      - step: "Create term A (10 days ago, uninvoiced)"
+        action: "create"
+        model: "school_enrollment_payment_term"
+        save_as: "term_a"
+        values:
+          enrollment_id: "REC: enrollment.id"
+          name: "Term A CDI1"
+          sequence: 10
+          date_invoice: "EVAL: (datetime.now() + timedelta(days=-10)).date()"
+          detail_ids:
+            - - 0
+              - 0
+              - product_id: "REC: product.id"
+                name: "Fee A CDI1"
+                account_id: "REC: account.id"
+                uom_quantity: 1.0
+                uom_id: "REF: uom.product_uom_unit"
+                price_unit: 500000.0
+
+      - step: "Create term B (today, uninvoiced)"
+        action: "create"
+        model: "school_enrollment_payment_term"
+        save_as: "term_b"
+        values:
+          enrollment_id: "REC: enrollment.id"
+          name: "Term B CDI1"
+          sequence: 20
+          date_invoice: "EVAL: datetime.now().date()"
+          detail_ids:
+            - - 0
+              - 0
+              - product_id: "REC: product.id"
+                name: "Fee B CDI1"
+                account_id: "REC: account.id"
+                uom_quantity: 1.0
+                uom_id: "REF: uom.product_uom_unit"
+                price_unit: 500000.0
+
+      - step: "Create term C (10 days from now, uninvoiced)"
+        action: "create"
+        model: "school_enrollment_payment_term"
+        save_as: "term_c"
+        values:
+          enrollment_id: "REC: enrollment.id"
+          name: "Term C CDI1"
+          sequence: 30
+          date_invoice: "EVAL: (datetime.now() + timedelta(days=10)).date()"
+          detail_ids:
+            - - 0
+              - 0
+              - product_id: "REC: product.id"
+                name: "Fee C CDI1"
+                account_id: "REC: account.id"
+                uom_quantity: 1.0
+                uom_id: "REF: uom.product_uom_unit"
+                price_unit: 500000.0
+
+      - step: "Create term D (manually controlled, yesterday)"
+        action: "create"
+        model: "school_enrollment_payment_term"
+        save_as: "term_d"
+        values:
+          enrollment_id: "REC: enrollment.id"
+          name: "Term D CDI1"
+          sequence: 40
+          manually_control: true
+          date_invoice: "EVAL: (datetime.now() + timedelta(days=-1)).date()"
+
+      - step: "Create term E (uninvoiced, no date_invoice)"
+        action: "create"
+        model: "school_enrollment_payment_term"
+        save_as: "term_e"
+        values:
+          enrollment_id: "REC: enrollment.id"
+          name: "Term E CDI1"
+          sequence: 50
+
+      - step: "Create wizard with no date range"
+        action: "create"
+        model: "school_enrollment.wizard_create_due_invoice"
+        save_as: "wizard"
+        values:
+          enrollment_ids:
+            - - 6
+              - 0
+              - - "REC: enrollment.id"
+
+      - step: "Run create due invoice (no range)"
+        action: "call"
+        target: "wizard"
+        method: "action_create_due_invoice"
+
+      - step: "Assert term A invoiced"
+        action: "assert"
+        target: "term_a"
+        asserts:
+          state:
+            type: "value"
+            expected: "invoiced"
+          invoice_id:
+            type: "value"
+            operator: "is_truthy"
+
+      - step: "Assert term B invoiced"
+        action: "assert"
+        target: "term_b"
+        asserts:
+          state:
+            type: "value"
+            expected: "invoiced"
+          invoice_id:
+            type: "value"
+            operator: "is_truthy"
+
+      - step: "Assert term C untouched (in the future)"
+        action: "assert"
+        target: "term_c"
+        asserts:
+          state:
+            type: "value"
+            expected: "uninvoiced"
+          invoice_id:
+            type: "value"
+            operator: "is_falsy"
+
+      - step: "Assert term D untouched (manually controlled)"
+        action: "assert"
+        target: "term_d"
+        asserts:
+          state:
+            type: "value"
+            expected: "manual"
+          invoice_id:
+            type: "value"
+            operator: "is_falsy"
+
+      - step: "Assert term E untouched (no date_invoice)"
+        action: "assert"
+        target: "term_e"
+        asserts:
+          state:
+            type: "value"
+            expected: "uninvoiced"
+          invoice_id:
+            type: "value"
+            operator: "is_falsy"
+
+  - name: "Create Due Invoice - Future Date End Includes Term C"
+    steps:
+      - step: "Setup - get account type ref"
+        action: "ref"
+        xml_id: "account.data_account_type_revenue"
+        save_as: "account_type"
+
+      - step: "Setup - create income account"
+        action: "create"
+        model: "account.account"
+        save_as: "account"
+        values:
+          name: "School Fee Income CDI2"
+          code: "CDI24200"
+          user_type_id: "REC: account_type.id"
+
+      - step: "Setup - create product"
+        action: "create"
+        model: "product.product"
+        save_as: "product"
+        values:
+          name: "School Fee CDI2"
+          type: "service"
+          list_price: 500000.0
+
+      - step: "Setup - create grade type"
+        action: "create"
+        model: "school_grade_type"
+        save_as: "grade_type"
+        values:
+          name: "Grade Type CDI2"
+          code: "GTCDI2"
+          sequence: 10
+
+      - step: "Setup - create academic year"
+        action: "create"
+        model: "school_academic_year"
+        save_as: "academic_year"
+        values:
+          name: "2024/2025 CDI2"
+          code: "AYCDI2"
+          date_start: "2024-07-01"
+          date_end: "2025-06-30"
+
+      - step: "Setup - create academic term"
+        action: "create"
+        model: "school_academic_term"
+        save_as: "academic_term"
+        values:
+          name: "Semester CDI2"
+          code: "SMCDI2"
+          date_start: "2024-07-01"
+          date_end: "2025-06-30"
+          year_id: "REC: academic_year.id"
+          enrollment_state: "open"
+
+      - step: "Setup - create school"
+        action: "create"
+        model: "school"
+        save_as: "school"
+        values:
+          name: "School CDI2"
+          code: "SCHCDI2"
+          grade_type_id: "REC: grade_type.id"
+
+      - step: "Setup - create grade"
+        action: "create"
+        model: "school_grade"
+        save_as: "grade"
+        values:
+          name: "Grade CDI2"
+          code: "GCDI2"
+          sequence: 10
+          type_id: "REC: grade_type.id"
+
+      - step: "Setup - create grade class"
+        action: "create"
+        model: "school_grade_class"
+        save_as: "grade_class"
+        values:
+          name: "Class CDI2"
+          code: "CLACDI2"
+          school_id: "REC: school.id"
+          grade_id: "REC: grade.id"
+
+      - step: "Setup - get receivable journal"
+        action: "search"
+        model: "account.journal"
+        domain: [["type", "=", "sale"]]
+        save_as: "receivable_journal"
+        limit: 1
+
+      - step: "Setup - create student contact"
+        action: "create"
+        model: "res.partner"
+        save_as: "contact"
+        values:
+          name: "Student Contact CDI2"
+
+      - step: "Setup - create student"
+        action: "create"
+        model: "school_student"
+        save_as: "student"
+        values:
+          name: "Student CDI2"
+          code: "STUCDI2"
+          contact_id: "REC: contact.id"
+          school_id: "REC: school.id"
+
+      - step: "Create enrollment"
+        action: "create"
+        model: "school_enrollment"
+        save_as: "enrollment"
+        values:
+          date: "2024-07-01"
+          academic_year_id: "REC: academic_year.id"
+          academic_term_id: "REC: academic_term.id"
+          school_id: "REC: school.id"
+          grade_id: "REC: grade.id"
+          grade_class_id: "REC: grade_class.id"
+          student_id: "REC: student.id"
+          currency_id: "REC: company.currency_id.id"
+          receivable_journal_id: "REC: receivable_journal.id"
+
+      - step: "Confirm enrollment"
+        action: "call"
+        target: "enrollment"
+        method: "action_confirm"
+        as_user: "base.user_admin"
+
+      - step: "Invalidate enrollment cache before approve"
+        action: "call"
+        target: "enrollment"
+        method: "invalidate_cache"
+
+      - step: "Approve enrollment"
+        action: "call"
+        target: "enrollment"
+        method: "action_approve_approval"
+        as_user: "base.user_admin"
+        asserts:
+          state:
+            type: "value"
+            expected: "open"
+
+      - step: "Create term A (10 days ago, uninvoiced)"
+        action: "create"
+        model: "school_enrollment_payment_term"
+        save_as: "term_a"
+        values:
+          enrollment_id: "REC: enrollment.id"
+          name: "Term A CDI2"
+          sequence: 10
+          date_invoice: "EVAL: (datetime.now() + timedelta(days=-10)).date()"
+          detail_ids:
+            - - 0
+              - 0
+              - product_id: "REC: product.id"
+                name: "Fee A CDI2"
+                account_id: "REC: account.id"
+                uom_quantity: 1.0
+                uom_id: "REF: uom.product_uom_unit"
+                price_unit: 500000.0
+
+      - step: "Create term B (today, uninvoiced)"
+        action: "create"
+        model: "school_enrollment_payment_term"
+        save_as: "term_b"
+        values:
+          enrollment_id: "REC: enrollment.id"
+          name: "Term B CDI2"
+          sequence: 20
+          date_invoice: "EVAL: datetime.now().date()"
+          detail_ids:
+            - - 0
+              - 0
+              - product_id: "REC: product.id"
+                name: "Fee B CDI2"
+                account_id: "REC: account.id"
+                uom_quantity: 1.0
+                uom_id: "REF: uom.product_uom_unit"
+                price_unit: 500000.0
+
+      - step: "Create term C (10 days from now, uninvoiced)"
+        action: "create"
+        model: "school_enrollment_payment_term"
+        save_as: "term_c"
+        values:
+          enrollment_id: "REC: enrollment.id"
+          name: "Term C CDI2"
+          sequence: 30
+          date_invoice: "EVAL: (datetime.now() + timedelta(days=10)).date()"
+          detail_ids:
+            - - 0
+              - 0
+              - product_id: "REC: product.id"
+                name: "Fee C CDI2"
+                account_id: "REC: account.id"
+                uom_quantity: 1.0
+                uom_id: "REF: uom.product_uom_unit"
+                price_unit: 500000.0
+
+      - step: "Create term D (manually controlled, yesterday)"
+        action: "create"
+        model: "school_enrollment_payment_term"
+        save_as: "term_d"
+        values:
+          enrollment_id: "REC: enrollment.id"
+          name: "Term D CDI2"
+          sequence: 40
+          manually_control: true
+          date_invoice: "EVAL: (datetime.now() + timedelta(days=-1)).date()"
+
+      - step: "Create term E (uninvoiced, no date_invoice)"
+        action: "create"
+        model: "school_enrollment_payment_term"
+        save_as: "term_e"
+        values:
+          enrollment_id: "REC: enrollment.id"
+          name: "Term E CDI2"
+          sequence: 50
+
+      - step: "Create wizard with date_end 15 days in the future"
+        action: "create"
+        model: "school_enrollment.wizard_create_due_invoice"
+        save_as: "wizard"
+        values:
+          enrollment_ids:
+            - - 6
+              - 0
+              - - "REC: enrollment.id"
+          date_end: "EVAL: (datetime.now() + timedelta(days=15)).date()"
+
+      - step: "Run create due invoice (future date_end)"
+        action: "call"
+        target: "wizard"
+        method: "action_create_due_invoice"
+
+      - step: "Assert term A invoiced"
+        action: "assert"
+        target: "term_a"
+        asserts:
+          state:
+            type: "value"
+            expected: "invoiced"
+
+      - step: "Assert term B invoiced"
+        action: "assert"
+        target: "term_b"
+        asserts:
+          state:
+            type: "value"
+            expected: "invoiced"
+
+      - step: "Assert term C invoiced"
+        action: "assert"
+        target: "term_c"
+        asserts:
+          state:
+            type: "value"
+            expected: "invoiced"
+          invoice_id:
+            type: "value"
+            operator: "is_truthy"
+
+      - step: "Assert term D untouched (manually controlled)"
+        action: "assert"
+        target: "term_d"
+        asserts:
+          state:
+            type: "value"
+            expected: "manual"
+
+      - step: "Assert term E untouched (no date_invoice)"
+        action: "assert"
+        target: "term_e"
+        asserts:
+          state:
+            type: "value"
+            expected: "uninvoiced"
+
+  - name: "Create Due Invoice - Date Start Only Excludes Past And Future Terms"
+    steps:
+      - step: "Setup - get account type ref"
+        action: "ref"
+        xml_id: "account.data_account_type_revenue"
+        save_as: "account_type"
+
+      - step: "Setup - create income account"
+        action: "create"
+        model: "account.account"
+        save_as: "account"
+        values:
+          name: "School Fee Income CDI3"
+          code: "CDI34200"
+          user_type_id: "REC: account_type.id"
+
+      - step: "Setup - create product"
+        action: "create"
+        model: "product.product"
+        save_as: "product"
+        values:
+          name: "School Fee CDI3"
+          type: "service"
+          list_price: 500000.0
+
+      - step: "Setup - create grade type"
+        action: "create"
+        model: "school_grade_type"
+        save_as: "grade_type"
+        values:
+          name: "Grade Type CDI3"
+          code: "GTCDI3"
+          sequence: 10
+
+      - step: "Setup - create academic year"
+        action: "create"
+        model: "school_academic_year"
+        save_as: "academic_year"
+        values:
+          name: "2024/2025 CDI3"
+          code: "AYCDI3"
+          date_start: "2024-07-01"
+          date_end: "2025-06-30"
+
+      - step: "Setup - create academic term"
+        action: "create"
+        model: "school_academic_term"
+        save_as: "academic_term"
+        values:
+          name: "Semester CDI3"
+          code: "SMCDI3"
+          date_start: "2024-07-01"
+          date_end: "2025-06-30"
+          year_id: "REC: academic_year.id"
+          enrollment_state: "open"
+
+      - step: "Setup - create school"
+        action: "create"
+        model: "school"
+        save_as: "school"
+        values:
+          name: "School CDI3"
+          code: "SCHCDI3"
+          grade_type_id: "REC: grade_type.id"
+
+      - step: "Setup - create grade"
+        action: "create"
+        model: "school_grade"
+        save_as: "grade"
+        values:
+          name: "Grade CDI3"
+          code: "GCDI3"
+          sequence: 10
+          type_id: "REC: grade_type.id"
+
+      - step: "Setup - create grade class"
+        action: "create"
+        model: "school_grade_class"
+        save_as: "grade_class"
+        values:
+          name: "Class CDI3"
+          code: "CLACDI3"
+          school_id: "REC: school.id"
+          grade_id: "REC: grade.id"
+
+      - step: "Setup - get receivable journal"
+        action: "search"
+        model: "account.journal"
+        domain: [["type", "=", "sale"]]
+        save_as: "receivable_journal"
+        limit: 1
+
+      - step: "Setup - create student contact"
+        action: "create"
+        model: "res.partner"
+        save_as: "contact"
+        values:
+          name: "Student Contact CDI3"
+
+      - step: "Setup - create student"
+        action: "create"
+        model: "school_student"
+        save_as: "student"
+        values:
+          name: "Student CDI3"
+          code: "STUCDI3"
+          contact_id: "REC: contact.id"
+          school_id: "REC: school.id"
+
+      - step: "Create enrollment"
+        action: "create"
+        model: "school_enrollment"
+        save_as: "enrollment"
+        values:
+          date: "2024-07-01"
+          academic_year_id: "REC: academic_year.id"
+          academic_term_id: "REC: academic_term.id"
+          school_id: "REC: school.id"
+          grade_id: "REC: grade.id"
+          grade_class_id: "REC: grade_class.id"
+          student_id: "REC: student.id"
+          currency_id: "REC: company.currency_id.id"
+          receivable_journal_id: "REC: receivable_journal.id"
+
+      - step: "Confirm enrollment"
+        action: "call"
+        target: "enrollment"
+        method: "action_confirm"
+        as_user: "base.user_admin"
+
+      - step: "Invalidate enrollment cache before approve"
+        action: "call"
+        target: "enrollment"
+        method: "invalidate_cache"
+
+      - step: "Approve enrollment"
+        action: "call"
+        target: "enrollment"
+        method: "action_approve_approval"
+        as_user: "base.user_admin"
+        asserts:
+          state:
+            type: "value"
+            expected: "open"
+
+      - step: "Create term A (10 days ago, uninvoiced)"
+        action: "create"
+        model: "school_enrollment_payment_term"
+        save_as: "term_a"
+        values:
+          enrollment_id: "REC: enrollment.id"
+          name: "Term A CDI3"
+          sequence: 10
+          date_invoice: "EVAL: (datetime.now() + timedelta(days=-10)).date()"
+          detail_ids:
+            - - 0
+              - 0
+              - product_id: "REC: product.id"
+                name: "Fee A CDI3"
+                account_id: "REC: account.id"
+                uom_quantity: 1.0
+                uom_id: "REF: uom.product_uom_unit"
+                price_unit: 500000.0
+
+      - step: "Create term B (today, uninvoiced)"
+        action: "create"
+        model: "school_enrollment_payment_term"
+        save_as: "term_b"
+        values:
+          enrollment_id: "REC: enrollment.id"
+          name: "Term B CDI3"
+          sequence: 20
+          date_invoice: "EVAL: datetime.now().date()"
+          detail_ids:
+            - - 0
+              - 0
+              - product_id: "REC: product.id"
+                name: "Fee B CDI3"
+                account_id: "REC: account.id"
+                uom_quantity: 1.0
+                uom_id: "REF: uom.product_uom_unit"
+                price_unit: 500000.0
+
+      - step: "Create term C (10 days from now, uninvoiced)"
+        action: "create"
+        model: "school_enrollment_payment_term"
+        save_as: "term_c"
+        values:
+          enrollment_id: "REC: enrollment.id"
+          name: "Term C CDI3"
+          sequence: 30
+          date_invoice: "EVAL: (datetime.now() + timedelta(days=10)).date()"
+          detail_ids:
+            - - 0
+              - 0
+              - product_id: "REC: product.id"
+                name: "Fee C CDI3"
+                account_id: "REC: account.id"
+                uom_quantity: 1.0
+                uom_id: "REF: uom.product_uom_unit"
+                price_unit: 500000.0
+
+      - step: "Create term D (manually controlled, yesterday)"
+        action: "create"
+        model: "school_enrollment_payment_term"
+        save_as: "term_d"
+        values:
+          enrollment_id: "REC: enrollment.id"
+          name: "Term D CDI3"
+          sequence: 40
+          manually_control: true
+          date_invoice: "EVAL: (datetime.now() + timedelta(days=-1)).date()"
+
+      - step: "Create term E (uninvoiced, no date_invoice)"
+        action: "create"
+        model: "school_enrollment_payment_term"
+        save_as: "term_e"
+        values:
+          enrollment_id: "REC: enrollment.id"
+          name: "Term E CDI3"
+          sequence: 50
+
+      - step: "Create wizard with date_start yesterday, no date_end"
+        action: "create"
+        model: "school_enrollment.wizard_create_due_invoice"
+        save_as: "wizard"
+        values:
+          enrollment_ids:
+            - - 6
+              - 0
+              - - "REC: enrollment.id"
+          date_start: "EVAL: (datetime.now() + timedelta(days=-1)).date()"
+
+      - step: "Run create due invoice (date_start only)"
+        action: "call"
+        target: "wizard"
+        method: "action_create_due_invoice"
+
+      - step: "Assert term A untouched (before date_start)"
+        action: "assert"
+        target: "term_a"
+        asserts:
+          state:
+            type: "value"
+            expected: "uninvoiced"
+
+      - step: "Assert term B invoiced"
+        action: "assert"
+        target: "term_b"
+        asserts:
+          state:
+            type: "value"
+            expected: "invoiced"
+          invoice_id:
+            type: "value"
+            operator: "is_truthy"
+
+      - step: "Assert term C untouched (in the future)"
+        action: "assert"
+        target: "term_c"
+        asserts:
+          state:
+            type: "value"
+            expected: "uninvoiced"
+
+      - step: "Assert term D untouched (manually controlled)"
+        action: "assert"
+        target: "term_d"
+        asserts:
+          state:
+            type: "value"
+            expected: "manual"
+
+      - step: "Assert term E untouched (no date_invoice)"
+        action: "assert"
+        target: "term_e"
+        asserts:
+          state:
+            type: "value"
+            expected: "uninvoiced"
+
+  - name: "Create Due Invoice - Both Dates Set Narrows To Term A Only"
+    steps:
+      - step: "Setup - get account type ref"
+        action: "ref"
+        xml_id: "account.data_account_type_revenue"
+        save_as: "account_type"
+
+      - step: "Setup - create income account"
+        action: "create"
+        model: "account.account"
+        save_as: "account"
+        values:
+          name: "School Fee Income CDI4"
+          code: "CDI44200"
+          user_type_id: "REC: account_type.id"
+
+      - step: "Setup - create product"
+        action: "create"
+        model: "product.product"
+        save_as: "product"
+        values:
+          name: "School Fee CDI4"
+          type: "service"
+          list_price: 500000.0
+
+      - step: "Setup - create grade type"
+        action: "create"
+        model: "school_grade_type"
+        save_as: "grade_type"
+        values:
+          name: "Grade Type CDI4"
+          code: "GTCDI4"
+          sequence: 10
+
+      - step: "Setup - create academic year"
+        action: "create"
+        model: "school_academic_year"
+        save_as: "academic_year"
+        values:
+          name: "2024/2025 CDI4"
+          code: "AYCDI4"
+          date_start: "2024-07-01"
+          date_end: "2025-06-30"
+
+      - step: "Setup - create academic term"
+        action: "create"
+        model: "school_academic_term"
+        save_as: "academic_term"
+        values:
+          name: "Semester CDI4"
+          code: "SMCDI4"
+          date_start: "2024-07-01"
+          date_end: "2025-06-30"
+          year_id: "REC: academic_year.id"
+          enrollment_state: "open"
+
+      - step: "Setup - create school"
+        action: "create"
+        model: "school"
+        save_as: "school"
+        values:
+          name: "School CDI4"
+          code: "SCHCDI4"
+          grade_type_id: "REC: grade_type.id"
+
+      - step: "Setup - create grade"
+        action: "create"
+        model: "school_grade"
+        save_as: "grade"
+        values:
+          name: "Grade CDI4"
+          code: "GCDI4"
+          sequence: 10
+          type_id: "REC: grade_type.id"
+
+      - step: "Setup - create grade class"
+        action: "create"
+        model: "school_grade_class"
+        save_as: "grade_class"
+        values:
+          name: "Class CDI4"
+          code: "CLACDI4"
+          school_id: "REC: school.id"
+          grade_id: "REC: grade.id"
+
+      - step: "Setup - get receivable journal"
+        action: "search"
+        model: "account.journal"
+        domain: [["type", "=", "sale"]]
+        save_as: "receivable_journal"
+        limit: 1
+
+      - step: "Setup - create student contact"
+        action: "create"
+        model: "res.partner"
+        save_as: "contact"
+        values:
+          name: "Student Contact CDI4"
+
+      - step: "Setup - create student"
+        action: "create"
+        model: "school_student"
+        save_as: "student"
+        values:
+          name: "Student CDI4"
+          code: "STUCDI4"
+          contact_id: "REC: contact.id"
+          school_id: "REC: school.id"
+
+      - step: "Create enrollment"
+        action: "create"
+        model: "school_enrollment"
+        save_as: "enrollment"
+        values:
+          date: "2024-07-01"
+          academic_year_id: "REC: academic_year.id"
+          academic_term_id: "REC: academic_term.id"
+          school_id: "REC: school.id"
+          grade_id: "REC: grade.id"
+          grade_class_id: "REC: grade_class.id"
+          student_id: "REC: student.id"
+          currency_id: "REC: company.currency_id.id"
+          receivable_journal_id: "REC: receivable_journal.id"
+
+      - step: "Confirm enrollment"
+        action: "call"
+        target: "enrollment"
+        method: "action_confirm"
+        as_user: "base.user_admin"
+
+      - step: "Invalidate enrollment cache before approve"
+        action: "call"
+        target: "enrollment"
+        method: "invalidate_cache"
+
+      - step: "Approve enrollment"
+        action: "call"
+        target: "enrollment"
+        method: "action_approve_approval"
+        as_user: "base.user_admin"
+        asserts:
+          state:
+            type: "value"
+            expected: "open"
+
+      - step: "Create term A (10 days ago, uninvoiced)"
+        action: "create"
+        model: "school_enrollment_payment_term"
+        save_as: "term_a"
+        values:
+          enrollment_id: "REC: enrollment.id"
+          name: "Term A CDI4"
+          sequence: 10
+          date_invoice: "EVAL: (datetime.now() + timedelta(days=-10)).date()"
+          detail_ids:
+            - - 0
+              - 0
+              - product_id: "REC: product.id"
+                name: "Fee A CDI4"
+                account_id: "REC: account.id"
+                uom_quantity: 1.0
+                uom_id: "REF: uom.product_uom_unit"
+                price_unit: 500000.0
+
+      - step: "Create term B (today, uninvoiced)"
+        action: "create"
+        model: "school_enrollment_payment_term"
+        save_as: "term_b"
+        values:
+          enrollment_id: "REC: enrollment.id"
+          name: "Term B CDI4"
+          sequence: 20
+          date_invoice: "EVAL: datetime.now().date()"
+          detail_ids:
+            - - 0
+              - 0
+              - product_id: "REC: product.id"
+                name: "Fee B CDI4"
+                account_id: "REC: account.id"
+                uom_quantity: 1.0
+                uom_id: "REF: uom.product_uom_unit"
+                price_unit: 500000.0
+
+      - step: "Create term C (10 days from now, uninvoiced)"
+        action: "create"
+        model: "school_enrollment_payment_term"
+        save_as: "term_c"
+        values:
+          enrollment_id: "REC: enrollment.id"
+          name: "Term C CDI4"
+          sequence: 30
+          date_invoice: "EVAL: (datetime.now() + timedelta(days=10)).date()"
+          detail_ids:
+            - - 0
+              - 0
+              - product_id: "REC: product.id"
+                name: "Fee C CDI4"
+                account_id: "REC: account.id"
+                uom_quantity: 1.0
+                uom_id: "REF: uom.product_uom_unit"
+                price_unit: 500000.0
+
+      - step: "Create term D (manually controlled, yesterday)"
+        action: "create"
+        model: "school_enrollment_payment_term"
+        save_as: "term_d"
+        values:
+          enrollment_id: "REC: enrollment.id"
+          name: "Term D CDI4"
+          sequence: 40
+          manually_control: true
+          date_invoice: "EVAL: (datetime.now() + timedelta(days=-1)).date()"
+
+      - step: "Create term E (uninvoiced, no date_invoice)"
+        action: "create"
+        model: "school_enrollment_payment_term"
+        save_as: "term_e"
+        values:
+          enrollment_id: "REC: enrollment.id"
+          name: "Term E CDI4"
+          sequence: 50
+
+      - step: "Create wizard with date_start -15 days and date_end -5 days"
+        action: "create"
+        model: "school_enrollment.wizard_create_due_invoice"
+        save_as: "wizard"
+        values:
+          enrollment_ids:
+            - - 6
+              - 0
+              - - "REC: enrollment.id"
+          date_start: "EVAL: (datetime.now() + timedelta(days=-15)).date()"
+          date_end: "EVAL: (datetime.now() + timedelta(days=-5)).date()"
+
+      - step: "Run create due invoice (narrow past range)"
+        action: "call"
+        target: "wizard"
+        method: "action_create_due_invoice"
+
+      - step: "Assert term A invoiced"
+        action: "assert"
+        target: "term_a"
+        asserts:
+          state:
+            type: "value"
+            expected: "invoiced"
+          invoice_id:
+            type: "value"
+            operator: "is_truthy"
+
+      - step: "Assert term B untouched (after the range)"
+        action: "assert"
+        target: "term_b"
+        asserts:
+          state:
+            type: "value"
+            expected: "uninvoiced"
+
+      - step: "Assert term C untouched (after the range)"
+        action: "assert"
+        target: "term_c"
+        asserts:
+          state:
+            type: "value"
+            expected: "uninvoiced"
+
+      - step: "Assert term D untouched (manually controlled)"
+        action: "assert"
+        target: "term_d"
+        asserts:
+          state:
+            type: "value"
+            expected: "manual"
+
+      - step: "Assert term E untouched (no date_invoice)"
+        action: "assert"
+        target: "term_e"
+        asserts:
+          state:
+            type: "value"
+            expected: "uninvoiced"
+
+  - name: "Create Due Invoice - Idempotent On Repeated Run"
+    steps:
+      - step: "Setup - get account type ref"
+        action: "ref"
+        xml_id: "account.data_account_type_revenue"
+        save_as: "account_type"
+
+      - step: "Setup - create income account"
+        action: "create"
+        model: "account.account"
+        save_as: "account"
+        values:
+          name: "School Fee Income CDI5"
+          code: "CDI54200"
+          user_type_id: "REC: account_type.id"
+
+      - step: "Setup - create product"
+        action: "create"
+        model: "product.product"
+        save_as: "product"
+        values:
+          name: "School Fee CDI5"
+          type: "service"
+          list_price: 500000.0
+
+      - step: "Setup - create grade type"
+        action: "create"
+        model: "school_grade_type"
+        save_as: "grade_type"
+        values:
+          name: "Grade Type CDI5"
+          code: "GTCDI5"
+          sequence: 10
+
+      - step: "Setup - create academic year"
+        action: "create"
+        model: "school_academic_year"
+        save_as: "academic_year"
+        values:
+          name: "2024/2025 CDI5"
+          code: "AYCDI5"
+          date_start: "2024-07-01"
+          date_end: "2025-06-30"
+
+      - step: "Setup - create academic term"
+        action: "create"
+        model: "school_academic_term"
+        save_as: "academic_term"
+        values:
+          name: "Semester CDI5"
+          code: "SMCDI5"
+          date_start: "2024-07-01"
+          date_end: "2025-06-30"
+          year_id: "REC: academic_year.id"
+          enrollment_state: "open"
+
+      - step: "Setup - create school"
+        action: "create"
+        model: "school"
+        save_as: "school"
+        values:
+          name: "School CDI5"
+          code: "SCHCDI5"
+          grade_type_id: "REC: grade_type.id"
+
+      - step: "Setup - create grade"
+        action: "create"
+        model: "school_grade"
+        save_as: "grade"
+        values:
+          name: "Grade CDI5"
+          code: "GCDI5"
+          sequence: 10
+          type_id: "REC: grade_type.id"
+
+      - step: "Setup - create grade class"
+        action: "create"
+        model: "school_grade_class"
+        save_as: "grade_class"
+        values:
+          name: "Class CDI5"
+          code: "CLACDI5"
+          school_id: "REC: school.id"
+          grade_id: "REC: grade.id"
+
+      - step: "Setup - get receivable journal"
+        action: "search"
+        model: "account.journal"
+        domain: [["type", "=", "sale"]]
+        save_as: "receivable_journal"
+        limit: 1
+
+      - step: "Setup - create student contact"
+        action: "create"
+        model: "res.partner"
+        save_as: "contact"
+        values:
+          name: "Student Contact CDI5"
+
+      - step: "Setup - create student"
+        action: "create"
+        model: "school_student"
+        save_as: "student"
+        values:
+          name: "Student CDI5"
+          code: "STUCDI5"
+          contact_id: "REC: contact.id"
+          school_id: "REC: school.id"
+
+      - step: "Create enrollment"
+        action: "create"
+        model: "school_enrollment"
+        save_as: "enrollment"
+        values:
+          date: "2024-07-01"
+          academic_year_id: "REC: academic_year.id"
+          academic_term_id: "REC: academic_term.id"
+          school_id: "REC: school.id"
+          grade_id: "REC: grade.id"
+          grade_class_id: "REC: grade_class.id"
+          student_id: "REC: student.id"
+          currency_id: "REC: company.currency_id.id"
+          receivable_journal_id: "REC: receivable_journal.id"
+
+      - step: "Confirm enrollment"
+        action: "call"
+        target: "enrollment"
+        method: "action_confirm"
+        as_user: "base.user_admin"
+
+      - step: "Invalidate enrollment cache before approve"
+        action: "call"
+        target: "enrollment"
+        method: "invalidate_cache"
+
+      - step: "Approve enrollment"
+        action: "call"
+        target: "enrollment"
+        method: "action_approve_approval"
+        as_user: "base.user_admin"
+        asserts:
+          state:
+            type: "value"
+            expected: "open"
+
+      - step: "Create term A (10 days ago, uninvoiced)"
+        action: "create"
+        model: "school_enrollment_payment_term"
+        save_as: "term_a"
+        values:
+          enrollment_id: "REC: enrollment.id"
+          name: "Term A CDI5"
+          sequence: 10
+          date_invoice: "EVAL: (datetime.now() + timedelta(days=-10)).date()"
+          detail_ids:
+            - - 0
+              - 0
+              - product_id: "REC: product.id"
+                name: "Fee A CDI5"
+                account_id: "REC: account.id"
+                uom_quantity: 1.0
+                uom_id: "REF: uom.product_uom_unit"
+                price_unit: 500000.0
+
+      - step: "Create term B (today, uninvoiced)"
+        action: "create"
+        model: "school_enrollment_payment_term"
+        save_as: "term_b"
+        values:
+          enrollment_id: "REC: enrollment.id"
+          name: "Term B CDI5"
+          sequence: 20
+          date_invoice: "EVAL: datetime.now().date()"
+          detail_ids:
+            - - 0
+              - 0
+              - product_id: "REC: product.id"
+                name: "Fee B CDI5"
+                account_id: "REC: account.id"
+                uom_quantity: 1.0
+                uom_id: "REF: uom.product_uom_unit"
+                price_unit: 500000.0
+
+      - step: "Create wizard with no date range"
+        action: "create"
+        model: "school_enrollment.wizard_create_due_invoice"
+        save_as: "wizard"
+        values:
+          enrollment_ids:
+            - - 6
+              - 0
+              - - "REC: enrollment.id"
+
+      - step: "Run create due invoice (first run)"
+        action: "call"
+        target: "wizard"
+        method: "action_create_due_invoice"
+
+      - step: "Assert two invoices exist after the first run"
+        action: "search"
+        model: "account.move"
+        domain: [["invoice_origin", "=", "REC: enrollment.name"]]
+        save_as: "invoices_after_run1"
+        expect_count: 2
+
+      - step: "Run create due invoice again (second run)"
+        action: "call"
+        target: "wizard"
+        method: "action_create_due_invoice"
+
+      - step: "Assert invoice count is unchanged after the second run"
+        action: "search"
+        model: "account.move"
+        domain: [["invoice_origin", "=", "REC: enrollment.name"]]
+        save_as: "invoices_after_run2"
+        expect_count: 2
+
+      - step: "Assert term A invoice still present"
+        action: "assert"
+        target: "term_a"
+        asserts:
+          state:
+            type: "value"
+            expected: "invoiced"
+          invoice_id:
+            type: "value"
+            operator: "is_truthy"
+
+      - step: "Assert term B invoice still present"
+        action: "assert"
+        target: "term_b"
+        asserts:
+          state:
+            type: "value"
+            expected: "invoiced"
+          invoice_id:
+            type: "value"
+            operator: "is_truthy"
+
+  - name: "Create Due Invoice - Blocked When Selection Includes A Non-Open Enrollment"
+    steps:
+      - step: "Setup - get account type ref"
+        action: "ref"
+        xml_id: "account.data_account_type_revenue"
+        save_as: "account_type"
+
+      - step: "Setup - create income account"
+        action: "create"
+        model: "account.account"
+        save_as: "account"
+        values:
+          name: "School Fee Income CDI6"
+          code: "CDI64200"
+          user_type_id: "REC: account_type.id"
+
+      - step: "Setup - create product"
+        action: "create"
+        model: "product.product"
+        save_as: "product"
+        values:
+          name: "School Fee CDI6"
+          type: "service"
+          list_price: 500000.0
+
+      - step: "Setup - create grade type"
+        action: "create"
+        model: "school_grade_type"
+        save_as: "grade_type"
+        values:
+          name: "Grade Type CDI6"
+          code: "GTCDI6"
+          sequence: 10
+
+      - step: "Setup - create academic year"
+        action: "create"
+        model: "school_academic_year"
+        save_as: "academic_year"
+        values:
+          name: "2024/2025 CDI6"
+          code: "AYCDI6"
+          date_start: "2024-07-01"
+          date_end: "2025-06-30"
+
+      - step: "Setup - create academic term"
+        action: "create"
+        model: "school_academic_term"
+        save_as: "academic_term"
+        values:
+          name: "Semester CDI6"
+          code: "SMCDI6"
+          date_start: "2024-07-01"
+          date_end: "2025-06-30"
+          year_id: "REC: academic_year.id"
+          enrollment_state: "open"
+
+      - step: "Setup - create school"
+        action: "create"
+        model: "school"
+        save_as: "school"
+        values:
+          name: "School CDI6"
+          code: "SCHCDI6"
+          grade_type_id: "REC: grade_type.id"
+
+      - step: "Setup - create grade"
+        action: "create"
+        model: "school_grade"
+        save_as: "grade"
+        values:
+          name: "Grade CDI6"
+          code: "GCDI6"
+          sequence: 10
+          type_id: "REC: grade_type.id"
+
+      - step: "Setup - create grade class"
+        action: "create"
+        model: "school_grade_class"
+        save_as: "grade_class"
+        values:
+          name: "Class CDI6"
+          code: "CLACDI6"
+          school_id: "REC: school.id"
+          grade_id: "REC: grade.id"
+
+      - step: "Setup - get receivable journal"
+        action: "search"
+        model: "account.journal"
+        domain: [["type", "=", "sale"]]
+        save_as: "receivable_journal"
+        limit: 1
+
+      - step: "Setup - create student contact"
+        action: "create"
+        model: "res.partner"
+        save_as: "contact"
+        values:
+          name: "Student Contact CDI6"
+
+      - step: "Setup - create student"
+        action: "create"
+        model: "school_student"
+        save_as: "student"
+        values:
+          name: "Student CDI6"
+          code: "STUCDI6"
+          contact_id: "REC: contact.id"
+          school_id: "REC: school.id"
+
+      - step: "Create enrollment"
+        action: "create"
+        model: "school_enrollment"
+        save_as: "enrollment"
+        values:
+          date: "2024-07-01"
+          academic_year_id: "REC: academic_year.id"
+          academic_term_id: "REC: academic_term.id"
+          school_id: "REC: school.id"
+          grade_id: "REC: grade.id"
+          grade_class_id: "REC: grade_class.id"
+          student_id: "REC: student.id"
+          currency_id: "REC: company.currency_id.id"
+          receivable_journal_id: "REC: receivable_journal.id"
+
+      - step: "Confirm enrollment"
+        action: "call"
+        target: "enrollment"
+        method: "action_confirm"
+        as_user: "base.user_admin"
+
+      - step: "Invalidate enrollment cache before approve"
+        action: "call"
+        target: "enrollment"
+        method: "invalidate_cache"
+
+      - step: "Approve enrollment"
+        action: "call"
+        target: "enrollment"
+        method: "action_approve_approval"
+        as_user: "base.user_admin"
+        asserts:
+          state:
+            type: "value"
+            expected: "open"
+
+      - step: "Create term A (10 days ago, uninvoiced)"
+        action: "create"
+        model: "school_enrollment_payment_term"
+        save_as: "term_a"
+        values:
+          enrollment_id: "REC: enrollment.id"
+          name: "Term A CDI6"
+          sequence: 10
+          date_invoice: "EVAL: (datetime.now() + timedelta(days=-10)).date()"
+          detail_ids:
+            - - 0
+              - 0
+              - product_id: "REC: product.id"
+                name: "Fee A CDI6"
+                account_id: "REC: account.id"
+                uom_quantity: 1.0
+                uom_id: "REF: uom.product_uom_unit"
+                price_unit: 500000.0
+
+      - step: "Setup - create second student contact for the draft enrollment"
+        action: "create"
+        model: "res.partner"
+        save_as: "contact2"
+        values:
+          name: "Student Contact 2 CDI6"
+
+      - step: "Setup - create second student for the draft enrollment"
+        action: "create"
+        model: "school_student"
+        save_as: "student2"
+        values:
+          name: "Student 2 CDI6"
+          code: "STU2CDI6"
+          contact_id: "REC: contact2.id"
+          school_id: "REC: school.id"
+
+      - step: "Create second enrollment, left in draft"
+        action: "create"
+        model: "school_enrollment"
+        save_as: "enrollment_draft"
+        values:
+          date: "2024-07-01"
+          academic_year_id: "REC: academic_year.id"
+          academic_term_id: "REC: academic_term.id"
+          school_id: "REC: school.id"
+          grade_id: "REC: grade.id"
+          grade_class_id: "REC: grade_class.id"
+          student_id: "REC: student2.id"
+          currency_id: "REC: company.currency_id.id"
+
+      - step: "Assert draft enrollment is not allowed to create due invoice"
+        action: "assert"
+        target: "enrollment_draft"
+        asserts:
+          create_invoice_ok:
+            type: "value"
+            expected: false
+
+      - step: "Create wizard selecting both the open and the draft enrollment"
+        action: "create"
+        model: "school_enrollment.wizard_create_due_invoice"
+        save_as: "wizard"
+        values:
+          enrollment_ids:
+            - - 6
+              - 0
+              - - "REC: enrollment.id"
+                - "REC: enrollment_draft.id"
+
+      - step: "Run create due invoice must fail because of the draft enrollment"
+        action: "call"
+        target: "wizard"
+        method: "action_create_due_invoice"
+        expect_error:
+          type: "UserError"
+
+      - step: "Assert term A on the valid enrollment is still uninvoiced"
+        action: "assert"
+        target: "term_a"
+        asserts:
+          state:
+            type: "value"
+            expected: "uninvoiced"
+          invoice_id:
+            type: "value"
+            operator: "is_falsy"
+
+      - step: "Assert no invoice was created for the valid enrollment either"
+        action: "search"
+        model: "account.move"
+        domain: [["invoice_origin", "=", "REC: enrollment.name"]]
+        save_as: "invoices_after_failed_run"
+        expect_count: 0
+
+  - name: "Create Due Invoice - Blocked When Date Start Is Later Than Date End"
+    steps:
+      - step: "Setup - get account type ref"
+        action: "ref"
+        xml_id: "account.data_account_type_revenue"
+        save_as: "account_type"
+
+      - step: "Setup - create income account"
+        action: "create"
+        model: "account.account"
+        save_as: "account"
+        values:
+          name: "School Fee Income CDI7"
+          code: "CDI74200"
+          user_type_id: "REC: account_type.id"
+
+      - step: "Setup - create product"
+        action: "create"
+        model: "product.product"
+        save_as: "product"
+        values:
+          name: "School Fee CDI7"
+          type: "service"
+          list_price: 500000.0
+
+      - step: "Setup - create grade type"
+        action: "create"
+        model: "school_grade_type"
+        save_as: "grade_type"
+        values:
+          name: "Grade Type CDI7"
+          code: "GTCDI7"
+          sequence: 10
+
+      - step: "Setup - create academic year"
+        action: "create"
+        model: "school_academic_year"
+        save_as: "academic_year"
+        values:
+          name: "2024/2025 CDI7"
+          code: "AYCDI7"
+          date_start: "2024-07-01"
+          date_end: "2025-06-30"
+
+      - step: "Setup - create academic term"
+        action: "create"
+        model: "school_academic_term"
+        save_as: "academic_term"
+        values:
+          name: "Semester CDI7"
+          code: "SMCDI7"
+          date_start: "2024-07-01"
+          date_end: "2025-06-30"
+          year_id: "REC: academic_year.id"
+          enrollment_state: "open"
+
+      - step: "Setup - create school"
+        action: "create"
+        model: "school"
+        save_as: "school"
+        values:
+          name: "School CDI7"
+          code: "SCHCDI7"
+          grade_type_id: "REC: grade_type.id"
+
+      - step: "Setup - create grade"
+        action: "create"
+        model: "school_grade"
+        save_as: "grade"
+        values:
+          name: "Grade CDI7"
+          code: "GCDI7"
+          sequence: 10
+          type_id: "REC: grade_type.id"
+
+      - step: "Setup - create grade class"
+        action: "create"
+        model: "school_grade_class"
+        save_as: "grade_class"
+        values:
+          name: "Class CDI7"
+          code: "CLACDI7"
+          school_id: "REC: school.id"
+          grade_id: "REC: grade.id"
+
+      - step: "Setup - get receivable journal"
+        action: "search"
+        model: "account.journal"
+        domain: [["type", "=", "sale"]]
+        save_as: "receivable_journal"
+        limit: 1
+
+      - step: "Setup - create student contact"
+        action: "create"
+        model: "res.partner"
+        save_as: "contact"
+        values:
+          name: "Student Contact CDI7"
+
+      - step: "Setup - create student"
+        action: "create"
+        model: "school_student"
+        save_as: "student"
+        values:
+          name: "Student CDI7"
+          code: "STUCDI7"
+          contact_id: "REC: contact.id"
+          school_id: "REC: school.id"
+
+      - step: "Create enrollment"
+        action: "create"
+        model: "school_enrollment"
+        save_as: "enrollment"
+        values:
+          date: "2024-07-01"
+          academic_year_id: "REC: academic_year.id"
+          academic_term_id: "REC: academic_term.id"
+          school_id: "REC: school.id"
+          grade_id: "REC: grade.id"
+          grade_class_id: "REC: grade_class.id"
+          student_id: "REC: student.id"
+          currency_id: "REC: company.currency_id.id"
+          receivable_journal_id: "REC: receivable_journal.id"
+
+      - step: "Confirm enrollment"
+        action: "call"
+        target: "enrollment"
+        method: "action_confirm"
+        as_user: "base.user_admin"
+
+      - step: "Invalidate enrollment cache before approve"
+        action: "call"
+        target: "enrollment"
+        method: "invalidate_cache"
+
+      - step: "Approve enrollment"
+        action: "call"
+        target: "enrollment"
+        method: "action_approve_approval"
+        as_user: "base.user_admin"
+        asserts:
+          state:
+            type: "value"
+            expected: "open"
+
+      - step: "Create term A (10 days ago, uninvoiced)"
+        action: "create"
+        model: "school_enrollment_payment_term"
+        save_as: "term_a"
+        values:
+          enrollment_id: "REC: enrollment.id"
+          name: "Term A CDI7"
+          sequence: 10
+          date_invoice: "EVAL: (datetime.now() + timedelta(days=-10)).date()"
+          detail_ids:
+            - - 0
+              - 0
+              - product_id: "REC: product.id"
+                name: "Fee A CDI7"
+                account_id: "REC: account.id"
+                uom_quantity: 1.0
+                uom_id: "REF: uom.product_uom_unit"
+                price_unit: 500000.0
+
+      - step: "Create wizard with date_start tomorrow (later than effective date_end)"
+        action: "create"
+        model: "school_enrollment.wizard_create_due_invoice"
+        save_as: "wizard"
+        values:
+          enrollment_ids:
+            - - 6
+              - 0
+              - - "REC: enrollment.id"
+          date_start: "EVAL: (datetime.now() + timedelta(days=1)).date()"
+
+      - step: "Run create due invoice must fail because of the reversed date range"
+        action: "call"
+        target: "wizard"
+        method: "action_create_due_invoice"
+        expect_error:
+          type: "UserError"
+
+      - step: "Assert term A is still uninvoiced"
+        action: "assert"
+        target: "term_a"
+        asserts:
+          state:
+            type: "value"
+            expected: "uninvoiced"
+          invoice_id:
+            type: "value"
+            operator: "is_falsy"
+
+      - step: "Assert no invoice was created"
+        action: "search"
+        model: "account.move"
+        domain: [["invoice_origin", "=", "REC: enrollment.name"]]
+        save_as: "invoices_after_failed_range"
+        expect_count: 0

--- a/ssi_school/tests/test_school_enrollment_create_due_invoice.py
+++ b/ssi_school/tests/test_school_enrollment_create_due_invoice.py
@@ -1,0 +1,13 @@
+# Copyright 2026 OpenSynergy Indonesia
+# Copyright 2026 PT. Simetri Sinergi Indonesia
+# License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl).
+
+from odoo_yaml_test import YamlTransactionCase
+
+from odoo.tests import tagged
+
+
+@tagged("post_install", "-at_install")
+class TestSchoolEnrollmentCreateDueInvoice(YamlTransactionCase):
+    def test_enrollment_create_due_invoice(self):
+        self.run_yaml_scenario("test_data_enrollment_create_due_invoice.yaml")

--- a/ssi_school/views/school_enrollment.xml
+++ b/ssi_school/views/school_enrollment.xml
@@ -119,6 +119,12 @@
                         attrs="{'invisible':[('graduate_ok','=',False)]}"
                         groups="ssi_school.school_enrollment_user_group"
                     />
+                <button
+                        name="action_open_create_due_invoice_wizard"
+                        type="object"
+                        string="Create Due Invoice"
+                        attrs="{'invisible':[('create_invoice_ok','=',False)]}"
+                    />
             </xpath>
             <xpath expr="//field[@name='user_id']" position="after">
                 <label for="academic_term_id" string="Year/Term" />
@@ -294,6 +300,7 @@
                 <field name="drop_out_ok" />
                 <field name="graduate_ok" />
                 <field name="addendum_ok" />
+                <field name="create_invoice_ok" />
             </xpath>
         </data>
     </field>

--- a/ssi_school/wizards/__init__.py
+++ b/ssi_school/wizards/__init__.py
@@ -4,3 +4,4 @@
 
 from . import school_enrollment_payment_term_duplicate  # noqa: F401
 from . import school_enrollment_copy_payment_term  # noqa: F401
+from . import school_enrollment_create_due_invoice  # noqa: F401

--- a/ssi_school/wizards/school_enrollment_create_due_invoice.py
+++ b/ssi_school/wizards/school_enrollment_create_due_invoice.py
@@ -1,0 +1,128 @@
+# Copyright 2026 OpenSynergy Indonesia
+# Copyright 2026 PT. Simetri Sinergi Indonesia
+# License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl).
+
+from odoo import _, api, fields, models
+from odoo.exceptions import UserError
+
+
+class SchoolEnrollmentWizardCreateDueInvoice(models.TransientModel):
+    """
+    Wizard that creates invoices for all uninvoiced payment terms whose
+    estimated invoice date (date_invoice) falls within a given date range, for
+    one or more enrollments selected from the school_enrollment list view or
+    from a single enrollment's form. Every selected enrollment must be allowed
+    by the create_invoice_ok policy (state and group, configurable via Policy
+    Template). All enrollments are validated before any invoice is created.
+    """
+
+    _name = "school_enrollment.wizard_create_due_invoice"
+    _description = "Create Due Invoice for Enrollment Payment Terms"
+
+    enrollment_ids = fields.Many2many(
+        string="Enrollments",
+        comodel_name="school_enrollment",
+        relation="rel_school_enrollment_create_due_invoice",
+        column1="wizard_id",
+        column2="enrollment_id",
+        readonly=True,
+        help="Enrollments whose due payment terms will be invoiced.",
+    )
+    date_start = fields.Date(
+        string="Date Start",
+        help=(
+            "Earliest estimated invoice date to process. "
+            "Leave empty for no lower bound."
+        ),
+    )
+    date_end = fields.Date(
+        string="Date End",
+        help=(
+            "Latest estimated invoice date to process. "
+            "Leave empty to process up to today."
+        ),
+    )
+
+    @api.model
+    def default_get(self, fields_list):
+        res = super().default_get(fields_list)
+        if self.env.context.get("active_model") == "school_enrollment":
+            active_ids = self.env.context.get("active_ids", [])
+            res["enrollment_ids"] = [(6, 0, active_ids)]
+        return res
+
+    def action_create_due_invoice(self):
+        for record in self.sudo():
+            record._create_due_invoice()  # pylint: disable=protected-access
+        return {"type": "ir.actions.act_window_close"}
+
+    def _create_due_invoice(self):
+        self.ensure_one()
+        self._check_enrollments()
+        self._check_date_range()
+        for enrollment in self.enrollment_ids:
+            enrollment._create_due_invoice(  # pylint: disable=protected-access
+                self.date_start, self.date_end
+            )
+
+    def _check_enrollments(self):
+        self.ensure_one()
+        if not self.enrollment_ids:
+            error_message = (
+                _(
+                    """
+Context: Create due invoice for enrollments
+Database ID: %s
+Problem: No enrollment selected
+Solution: Select at least one enrollment from the list view before running this wizard
+"""
+                )
+                % (self.id,)
+            )
+            raise UserError(error_message)
+        problems = []
+        for enrollment in self.enrollment_ids:
+            if not enrollment.create_invoice_ok:
+                problems.append(
+                    _("- %s: not allowed to create due invoice (check state/policy)")
+                    % enrollment.name
+                )
+        if problems:
+            error_message = (
+                _(
+                    """
+Context: Create due invoice for enrollments
+Database ID: %s
+Problem: The following enrollment(s) are not allowed to create due invoice:
+%s
+Solution: Deselect the listed enrollment(s), or make sure they are open and allowed
+by the create due invoice policy
+"""
+                )
+                % (
+                    self.id,
+                    "\n".join(problems),
+                )
+            )
+            raise UserError(error_message)
+
+    def _check_date_range(self):
+        self.ensure_one()
+        effective_end = self.date_end or fields.Date.context_today(self)
+        if self.date_start and self.date_start > effective_end:
+            error_message = (
+                _(
+                    """
+Context: Create due invoice for enrollments
+Database ID: %s
+Problem: Date Start '%s' is later than Date End '%s'
+Solution: Choose a Date Start that is not later than Date End
+"""
+                )
+                % (
+                    self.id,
+                    self.date_start,
+                    effective_end,
+                )
+            )
+            raise UserError(error_message)

--- a/ssi_school/wizards/school_enrollment_create_due_invoice.xml
+++ b/ssi_school/wizards/school_enrollment_create_due_invoice.xml
@@ -1,0 +1,42 @@
+<?xml version="1.0" encoding="utf-8" ?>
+<!-- Copyright 2026 OpenSynergy Indonesia
+     Copyright 2026 PT. Simetri Sinergi Indonesia
+     License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl). -->
+<odoo>
+
+<record id="school_enrollment_wizard_create_due_invoice_view_form" model="ir.ui.view">
+    <field name="name">school_enrollment.wizard_create_due_invoice - form</field>
+    <field name="model">school_enrollment.wizard_create_due_invoice</field>
+    <field name="arch" type="xml">
+        <form string="Create Due Invoice">
+            <group name="main" colspan="4" col="2">
+                <field name="enrollment_ids" widget="many2many_tags" colspan="2" />
+                <field name="date_start" />
+                <field name="date_end" />
+            </group>
+            <footer>
+                <button
+                        name="action_create_due_invoice"
+                        type="object"
+                        string="Create Due Invoice"
+                        class="btn-primary"
+                    />
+                <button string="Cancel" class="btn-default" special="cancel" />
+            </footer>
+        </form>
+    </field>
+</record>
+
+<record
+        id="school_enrollment_wizard_create_due_invoice_action"
+        model="ir.actions.act_window"
+    >
+    <field name="name">Create Due Invoice</field>
+    <field name="type">ir.actions.act_window</field>
+    <field name="res_model">school_enrollment.wizard_create_due_invoice</field>
+    <field name="view_mode">form</field>
+    <field name="target">new</field>
+    <field name="binding_model_id" ref="model_school_enrollment" />
+</record>
+
+</odoo>

--- a/ssi_school_admission/__manifest__.py
+++ b/ssi_school_admission/__manifest__.py
@@ -63,6 +63,7 @@
         "ir_model_access/school_admission_payment_term.xml",
         "ir_model_access/school_admission_payment_term_wizard_duplicate.xml",
         "ir_model_access/school_admission_wizard_copy_payment_term.xml",
+        "ir_model_access/school_admission_wizard_create_due_invoice.xml",
         "ir_rule/school_admission.xml",
         "ir_sequence/school_admission.xml",
         "sequence_template/school_admission.xml",
@@ -74,6 +75,7 @@
         "views/school_admission.xml",
         "wizards/school_admission_payment_term_duplicate.xml",
         "wizards/school_admission_copy_payment_term.xml",
+        "wizards/school_admission_create_due_invoice.xml",
     ],
     "demo": [
         "demo/account_account_demo.xml",

--- a/ssi_school_admission/ir_model_access/school_admission_wizard_create_due_invoice.xml
+++ b/ssi_school_admission/ir_model_access/school_admission_wizard_create_due_invoice.xml
@@ -1,0 +1,20 @@
+<?xml version="1.0" encoding="utf-8" ?>
+<!-- Copyright 2026 OpenSynergy Indonesia
+     Copyright 2026 PT. Simetri Sinergi Indonesia
+     License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl). -->
+<odoo>
+
+<record
+        id="school_admission_wizard_create_due_invoice_user_access"
+        model="ir.model.access"
+    >
+    <field name="name">school_admission.wizard_create_due_invoice - user</field>
+    <field name="model_id" ref="model_school_admission_wizard_create_due_invoice" />
+    <field name="group_id" ref="school_admission_user_group" />
+    <field name="perm_read" eval="1" />
+    <field name="perm_create" eval="1" />
+    <field name="perm_write" eval="1" />
+    <field name="perm_unlink" eval="1" />
+</record>
+
+</odoo>

--- a/ssi_school_admission/models/school_admission.py
+++ b/ssi_school_admission/models/school_admission.py
@@ -270,6 +270,16 @@ class SchoolAdmission(models.Model):
             "before the addendum remain locked."
         ),
     )
+    create_invoice_ok = fields.Boolean(
+        string="Can Create Due Invoice",
+        compute="_compute_policy",
+        store=False,
+        compute_sudo=True,
+        help=(
+            "Policy that determines whether invoices may be created for "
+            "payment terms that are due, via the Create Due Invoice wizard."
+        ),
+    )
 
     def _compute_policy(self):  # pylint: disable=missing-return
         _super = super()
@@ -408,6 +418,62 @@ class SchoolAdmission(models.Model):
         for record in self.sudo():
             record._lock_payment_term()  # pylint: disable=protected-access
 
+    def action_open_create_due_invoice_wizard(self):
+        for record in self.sudo():
+            # pylint: disable=protected-access
+            result = record._open_create_due_invoice_wizard()
+        return result
+
+    def _open_create_due_invoice_wizard(self):
+        self.ensure_one()
+        waction = self.env.ref(
+            "ssi_school_admission.school_admission_wizard_create_due_invoice_action"
+        ).read()[0]
+        waction.update(
+            {
+                "context": {
+                    "active_model": "school_admission",
+                    "active_id": self.id,
+                    "active_ids": [self.id],
+                },
+            }
+        )
+        return waction
+
+    def _create_due_invoice(self, date_start=False, date_end=False):
+        self.ensure_one()
+        self._check_create_invoice_policy()
+        for term in self._get_due_payment_term(date_start, date_end):
+            term._create_invoice()  # pylint: disable=protected-access
+
+    def _get_due_payment_term(self, date_start=False, date_end=False):
+        self.ensure_one()
+        date_end = date_end or fields.Date.context_today(self)
+        return self.payment_term_ids.filtered(
+            lambda r: r.state == "uninvoiced"
+            and r.date_invoice
+            and (not date_start or r.date_invoice >= date_start)
+            and r.date_invoice <= date_end
+        )
+
+    def _check_create_invoice_policy(self):
+        self.ensure_one()
+        if self.env.context.get("bypass_policy_check", False):
+            return True
+        if not self.create_invoice_ok:
+            error_message = (
+                _(
+                    """
+Context: Create due invoice
+Database ID: %s
+Problem: Document is not allowed to create due invoice
+Solution: Check create due invoice policy prerequisite
+"""
+                )
+                % (self.id,)
+            )
+            raise UserError(error_message)
+
     def _lock_payment_term(self):
         self.ensure_one()
         Term = self.env["school_admission_payment_term"]  # pylint: disable=invalid-name
@@ -496,6 +562,7 @@ Solution: Delete or disconnect the invoice on the payment term before cancelling
             "manual_number_ok",
             "copy_payment_term_ok",
             "addendum_ok",
+            "create_invoice_ok",
         ]
         res += policy_field
         return res

--- a/ssi_school_admission/policy_template/school_admission.xml
+++ b/ssi_school_admission/policy_template/school_admission.xml
@@ -71,6 +71,27 @@
     <field name="restrict_additional" eval="0" />
 </record>
 
+<!-- Create Due Invoice -->
+<record
+        id="policy_template_school_admission_create_invoice"
+        model="policy.template_detail"
+    >
+    <field name="template_id" ref="policy_template_school_admission" />
+    <field
+            name="field_id"
+            search="[('model_id.model','=','school_admission'),('name','=','create_invoice_ok')]"
+        />
+    <field name="restrict_state" eval="1" />
+    <field
+            name="state_ids"
+            search="[('field_id.model_id.model','=','school_admission'),('value','=','open')]"
+        />
+    <field name="restrict_user" eval="1" />
+    <field name="computation_method">use_group</field>
+    <field name="group_ids" eval="[(6,0,[ref('school_admission_user_group')])]" />
+    <field name="restrict_additional" eval="0" />
+</record>
+
 <!-- Done -->
 <record id="policy_template_school_admission_done" model="policy.template_detail">
     <field name="template_id" ref="policy_template_school_admission" />

--- a/ssi_school_admission/tests/__init__.py
+++ b/ssi_school_admission/tests/__init__.py
@@ -12,6 +12,7 @@ from . import (  # noqa: F401
     test_school_admission_restart_unlock,
     test_school_admission_payment_term_duplicate,
     test_school_admission_copy_payment_term,
+    test_school_admission_create_due_invoice,
     test_school_admission_payment_product_configurator,
     test_school_admission_product_summary,
     test_school_admission_test,

--- a/ssi_school_admission/tests/test_data_admission_create_due_invoice.yaml
+++ b/ssi_school_admission/tests/test_data_admission_create_due_invoice.yaml
@@ -123,6 +123,11 @@ scenarios:
             type: "value"
             expected: "open"
 
+      - step: "Invalidate admission cache after approve"
+        action: "call"
+        target: "admission"
+        method: "invalidate_cache"
+
       - step: "Assert admission is allowed to create due invoice"
         action: "assert"
         target: "admission"

--- a/ssi_school_admission/tests/test_data_admission_create_due_invoice.yaml
+++ b/ssi_school_admission/tests/test_data_admission_create_due_invoice.yaml
@@ -1,0 +1,1666 @@
+options:
+  auto_refresh: true
+scenarios:
+  - name: "Create Due Invoice - No Range Invoices Only Due Terms"
+    steps:
+      - step: "Setup - get account type ref"
+        action: "ref"
+        xml_id: "account.data_account_type_revenue"
+        save_as: "account_type"
+
+      - step: "Setup - create income account"
+        action: "create"
+        model: "account.account"
+        save_as: "account"
+        values:
+          name: "Admission Fee Income CDIA1"
+          code: "CDIA14200"
+          user_type_id: "REC: account_type.id"
+
+      - step: "Setup - create product"
+        action: "create"
+        model: "product.product"
+        save_as: "product"
+        values:
+          name: "Admission Fee CDIA1"
+          type: "service"
+          list_price: 500000.0
+
+      - step: "Setup - create grade type"
+        action: "create"
+        model: "school_grade_type"
+        save_as: "grade_type"
+        values:
+          name: "Grade Type CDIA1"
+          code: "GTCDIA1"
+          sequence: 10
+
+      - step: "Setup - create academic year"
+        action: "create"
+        model: "school_academic_year"
+        save_as: "academic_year"
+        values:
+          name: "2024/2025 CDIA1"
+          code: "AYCDIA1"
+          date_start: "2024-07-01"
+          date_end: "2025-06-30"
+
+      - step: "Setup - create academic term"
+        action: "create"
+        model: "school_academic_term"
+        save_as: "academic_term"
+        values:
+          name: "Semester CDIA1"
+          code: "SMCDIA1"
+          date_start: "2024-07-01"
+          date_end: "2025-06-30"
+          year_id: "REC: academic_year.id"
+          enrollment_state: "open"
+
+      - step: "Setup - create school"
+        action: "create"
+        model: "school"
+        save_as: "school"
+        values:
+          name: "School CDIA1"
+          code: "SCHCDIA1"
+          grade_type_id: "REC: grade_type.id"
+
+      - step: "Setup - create grade"
+        action: "create"
+        model: "school_grade"
+        save_as: "grade"
+        values:
+          name: "Grade CDIA1"
+          code: "GCDIA1"
+          sequence: 10
+          type_id: "REC: grade_type.id"
+
+      - step: "Setup - get receivable journal"
+        action: "search"
+        model: "account.journal"
+        domain: [["type", "=", "sale"]]
+        save_as: "receivable_journal"
+        limit: 1
+
+      - step: "Setup - create student contact"
+        action: "create"
+        model: "res.partner"
+        save_as: "student_contact"
+        values:
+          name: "Student Contact CDIA1"
+
+      - step: "Create admission"
+        action: "create"
+        model: "school_admission"
+        save_as: "admission"
+        values:
+          date: "2024-07-01"
+          academic_year_id: "REC: academic_year.id"
+          academic_term_id: "REC: academic_term.id"
+          school_id: "REC: school.id"
+          grade_id: "REC: grade.id"
+          student_id: "REC: student_contact.id"
+          currency_id: "REC: company.currency_id.id"
+          receivable_journal_id: "REC: receivable_journal.id"
+
+      - step: "Confirm admission"
+        action: "call"
+        target: "admission"
+        method: "action_confirm"
+        as_user: "base.user_admin"
+
+      - step: "Invalidate admission cache before approve"
+        action: "call"
+        target: "admission"
+        method: "invalidate_cache"
+
+      - step: "Approve admission"
+        action: "call"
+        target: "admission"
+        method: "action_approve_approval"
+        as_user: "base.user_admin"
+        asserts:
+          state:
+            type: "value"
+            expected: "open"
+
+      - step: "Assert admission is allowed to create due invoice"
+        action: "assert"
+        target: "admission"
+        asserts:
+          create_invoice_ok:
+            type: "value"
+            expected: true
+
+      - step: "Create term A (10 days ago, uninvoiced)"
+        action: "create"
+        model: "school_admission_payment_term"
+        save_as: "term_a"
+        values:
+          admission_id: "REC: admission.id"
+          name: "Term A CDIA1"
+          sequence: 10
+          date_invoice: "EVAL: (datetime.now() + timedelta(days=-10)).date()"
+          detail_ids:
+            - - 0
+              - 0
+              - product_id: "REC: product.id"
+                name: "Fee A CDIA1"
+                account_id: "REC: account.id"
+                uom_quantity: 1.0
+                uom_id: "REF: uom.product_uom_unit"
+                price_unit: 500000.0
+
+      - step: "Create term B (today, uninvoiced)"
+        action: "create"
+        model: "school_admission_payment_term"
+        save_as: "term_b"
+        values:
+          admission_id: "REC: admission.id"
+          name: "Term B CDIA1"
+          sequence: 20
+          date_invoice: "EVAL: datetime.now().date()"
+          detail_ids:
+            - - 0
+              - 0
+              - product_id: "REC: product.id"
+                name: "Fee B CDIA1"
+                account_id: "REC: account.id"
+                uom_quantity: 1.0
+                uom_id: "REF: uom.product_uom_unit"
+                price_unit: 500000.0
+
+      - step: "Create term C (10 days from now, uninvoiced)"
+        action: "create"
+        model: "school_admission_payment_term"
+        save_as: "term_c"
+        values:
+          admission_id: "REC: admission.id"
+          name: "Term C CDIA1"
+          sequence: 30
+          date_invoice: "EVAL: (datetime.now() + timedelta(days=10)).date()"
+          detail_ids:
+            - - 0
+              - 0
+              - product_id: "REC: product.id"
+                name: "Fee C CDIA1"
+                account_id: "REC: account.id"
+                uom_quantity: 1.0
+                uom_id: "REF: uom.product_uom_unit"
+                price_unit: 500000.0
+
+      - step: "Create term D (manually controlled, yesterday)"
+        action: "create"
+        model: "school_admission_payment_term"
+        save_as: "term_d"
+        values:
+          admission_id: "REC: admission.id"
+          name: "Term D CDIA1"
+          sequence: 40
+          manually_control: true
+          date_invoice: "EVAL: (datetime.now() + timedelta(days=-1)).date()"
+
+      - step: "Create term E (uninvoiced, no date_invoice)"
+        action: "create"
+        model: "school_admission_payment_term"
+        save_as: "term_e"
+        values:
+          admission_id: "REC: admission.id"
+          name: "Term E CDIA1"
+          sequence: 50
+
+      - step: "Create wizard with no date range"
+        action: "create"
+        model: "school_admission.wizard_create_due_invoice"
+        save_as: "wizard"
+        values:
+          admission_ids:
+            - - 6
+              - 0
+              - - "REC: admission.id"
+
+      - step: "Run create due invoice (no range)"
+        action: "call"
+        target: "wizard"
+        method: "action_create_due_invoice"
+
+      - step: "Assert term A invoiced"
+        action: "assert"
+        target: "term_a"
+        asserts:
+          state:
+            type: "value"
+            expected: "invoiced"
+          invoice_id:
+            type: "value"
+            operator: "is_truthy"
+
+      - step: "Assert term B invoiced"
+        action: "assert"
+        target: "term_b"
+        asserts:
+          state:
+            type: "value"
+            expected: "invoiced"
+          invoice_id:
+            type: "value"
+            operator: "is_truthy"
+
+      - step: "Assert term C untouched (in the future)"
+        action: "assert"
+        target: "term_c"
+        asserts:
+          state:
+            type: "value"
+            expected: "uninvoiced"
+          invoice_id:
+            type: "value"
+            operator: "is_falsy"
+
+      - step: "Assert term D untouched (manually controlled)"
+        action: "assert"
+        target: "term_d"
+        asserts:
+          state:
+            type: "value"
+            expected: "manual"
+          invoice_id:
+            type: "value"
+            operator: "is_falsy"
+
+      - step: "Assert term E untouched (no date_invoice)"
+        action: "assert"
+        target: "term_e"
+        asserts:
+          state:
+            type: "value"
+            expected: "uninvoiced"
+          invoice_id:
+            type: "value"
+            operator: "is_falsy"
+
+  - name: "Create Due Invoice - Future Date End Includes Term C"
+    steps:
+      - step: "Setup - get account type ref"
+        action: "ref"
+        xml_id: "account.data_account_type_revenue"
+        save_as: "account_type"
+
+      - step: "Setup - create income account"
+        action: "create"
+        model: "account.account"
+        save_as: "account"
+        values:
+          name: "Admission Fee Income CDIA2"
+          code: "CDIA24200"
+          user_type_id: "REC: account_type.id"
+
+      - step: "Setup - create product"
+        action: "create"
+        model: "product.product"
+        save_as: "product"
+        values:
+          name: "Admission Fee CDIA2"
+          type: "service"
+          list_price: 500000.0
+
+      - step: "Setup - create grade type"
+        action: "create"
+        model: "school_grade_type"
+        save_as: "grade_type"
+        values:
+          name: "Grade Type CDIA2"
+          code: "GTCDIA2"
+          sequence: 10
+
+      - step: "Setup - create academic year"
+        action: "create"
+        model: "school_academic_year"
+        save_as: "academic_year"
+        values:
+          name: "2024/2025 CDIA2"
+          code: "AYCDIA2"
+          date_start: "2024-07-01"
+          date_end: "2025-06-30"
+
+      - step: "Setup - create academic term"
+        action: "create"
+        model: "school_academic_term"
+        save_as: "academic_term"
+        values:
+          name: "Semester CDIA2"
+          code: "SMCDIA2"
+          date_start: "2024-07-01"
+          date_end: "2025-06-30"
+          year_id: "REC: academic_year.id"
+          enrollment_state: "open"
+
+      - step: "Setup - create school"
+        action: "create"
+        model: "school"
+        save_as: "school"
+        values:
+          name: "School CDIA2"
+          code: "SCHCDIA2"
+          grade_type_id: "REC: grade_type.id"
+
+      - step: "Setup - create grade"
+        action: "create"
+        model: "school_grade"
+        save_as: "grade"
+        values:
+          name: "Grade CDIA2"
+          code: "GCDIA2"
+          sequence: 10
+          type_id: "REC: grade_type.id"
+
+      - step: "Setup - get receivable journal"
+        action: "search"
+        model: "account.journal"
+        domain: [["type", "=", "sale"]]
+        save_as: "receivable_journal"
+        limit: 1
+
+      - step: "Setup - create student contact"
+        action: "create"
+        model: "res.partner"
+        save_as: "student_contact"
+        values:
+          name: "Student Contact CDIA2"
+
+      - step: "Create admission"
+        action: "create"
+        model: "school_admission"
+        save_as: "admission"
+        values:
+          date: "2024-07-01"
+          academic_year_id: "REC: academic_year.id"
+          academic_term_id: "REC: academic_term.id"
+          school_id: "REC: school.id"
+          grade_id: "REC: grade.id"
+          student_id: "REC: student_contact.id"
+          currency_id: "REC: company.currency_id.id"
+          receivable_journal_id: "REC: receivable_journal.id"
+
+      - step: "Confirm admission"
+        action: "call"
+        target: "admission"
+        method: "action_confirm"
+        as_user: "base.user_admin"
+
+      - step: "Invalidate admission cache before approve"
+        action: "call"
+        target: "admission"
+        method: "invalidate_cache"
+
+      - step: "Approve admission"
+        action: "call"
+        target: "admission"
+        method: "action_approve_approval"
+        as_user: "base.user_admin"
+        asserts:
+          state:
+            type: "value"
+            expected: "open"
+
+      - step: "Create term A (10 days ago, uninvoiced)"
+        action: "create"
+        model: "school_admission_payment_term"
+        save_as: "term_a"
+        values:
+          admission_id: "REC: admission.id"
+          name: "Term A CDIA2"
+          sequence: 10
+          date_invoice: "EVAL: (datetime.now() + timedelta(days=-10)).date()"
+          detail_ids:
+            - - 0
+              - 0
+              - product_id: "REC: product.id"
+                name: "Fee A CDIA2"
+                account_id: "REC: account.id"
+                uom_quantity: 1.0
+                uom_id: "REF: uom.product_uom_unit"
+                price_unit: 500000.0
+
+      - step: "Create term B (today, uninvoiced)"
+        action: "create"
+        model: "school_admission_payment_term"
+        save_as: "term_b"
+        values:
+          admission_id: "REC: admission.id"
+          name: "Term B CDIA2"
+          sequence: 20
+          date_invoice: "EVAL: datetime.now().date()"
+          detail_ids:
+            - - 0
+              - 0
+              - product_id: "REC: product.id"
+                name: "Fee B CDIA2"
+                account_id: "REC: account.id"
+                uom_quantity: 1.0
+                uom_id: "REF: uom.product_uom_unit"
+                price_unit: 500000.0
+
+      - step: "Create term C (10 days from now, uninvoiced)"
+        action: "create"
+        model: "school_admission_payment_term"
+        save_as: "term_c"
+        values:
+          admission_id: "REC: admission.id"
+          name: "Term C CDIA2"
+          sequence: 30
+          date_invoice: "EVAL: (datetime.now() + timedelta(days=10)).date()"
+          detail_ids:
+            - - 0
+              - 0
+              - product_id: "REC: product.id"
+                name: "Fee C CDIA2"
+                account_id: "REC: account.id"
+                uom_quantity: 1.0
+                uom_id: "REF: uom.product_uom_unit"
+                price_unit: 500000.0
+
+      - step: "Create term D (manually controlled, yesterday)"
+        action: "create"
+        model: "school_admission_payment_term"
+        save_as: "term_d"
+        values:
+          admission_id: "REC: admission.id"
+          name: "Term D CDIA2"
+          sequence: 40
+          manually_control: true
+          date_invoice: "EVAL: (datetime.now() + timedelta(days=-1)).date()"
+
+      - step: "Create term E (uninvoiced, no date_invoice)"
+        action: "create"
+        model: "school_admission_payment_term"
+        save_as: "term_e"
+        values:
+          admission_id: "REC: admission.id"
+          name: "Term E CDIA2"
+          sequence: 50
+
+      - step: "Create wizard with date_end 15 days in the future"
+        action: "create"
+        model: "school_admission.wizard_create_due_invoice"
+        save_as: "wizard"
+        values:
+          admission_ids:
+            - - 6
+              - 0
+              - - "REC: admission.id"
+          date_end: "EVAL: (datetime.now() + timedelta(days=15)).date()"
+
+      - step: "Run create due invoice (future date_end)"
+        action: "call"
+        target: "wizard"
+        method: "action_create_due_invoice"
+
+      - step: "Assert term A invoiced"
+        action: "assert"
+        target: "term_a"
+        asserts:
+          state:
+            type: "value"
+            expected: "invoiced"
+
+      - step: "Assert term B invoiced"
+        action: "assert"
+        target: "term_b"
+        asserts:
+          state:
+            type: "value"
+            expected: "invoiced"
+
+      - step: "Assert term C invoiced"
+        action: "assert"
+        target: "term_c"
+        asserts:
+          state:
+            type: "value"
+            expected: "invoiced"
+          invoice_id:
+            type: "value"
+            operator: "is_truthy"
+
+      - step: "Assert term D untouched (manually controlled)"
+        action: "assert"
+        target: "term_d"
+        asserts:
+          state:
+            type: "value"
+            expected: "manual"
+
+      - step: "Assert term E untouched (no date_invoice)"
+        action: "assert"
+        target: "term_e"
+        asserts:
+          state:
+            type: "value"
+            expected: "uninvoiced"
+
+  - name: "Create Due Invoice - Date Start Only Excludes Past And Future Terms"
+    steps:
+      - step: "Setup - get account type ref"
+        action: "ref"
+        xml_id: "account.data_account_type_revenue"
+        save_as: "account_type"
+
+      - step: "Setup - create income account"
+        action: "create"
+        model: "account.account"
+        save_as: "account"
+        values:
+          name: "Admission Fee Income CDIA3"
+          code: "CDIA34200"
+          user_type_id: "REC: account_type.id"
+
+      - step: "Setup - create product"
+        action: "create"
+        model: "product.product"
+        save_as: "product"
+        values:
+          name: "Admission Fee CDIA3"
+          type: "service"
+          list_price: 500000.0
+
+      - step: "Setup - create grade type"
+        action: "create"
+        model: "school_grade_type"
+        save_as: "grade_type"
+        values:
+          name: "Grade Type CDIA3"
+          code: "GTCDIA3"
+          sequence: 10
+
+      - step: "Setup - create academic year"
+        action: "create"
+        model: "school_academic_year"
+        save_as: "academic_year"
+        values:
+          name: "2024/2025 CDIA3"
+          code: "AYCDIA3"
+          date_start: "2024-07-01"
+          date_end: "2025-06-30"
+
+      - step: "Setup - create academic term"
+        action: "create"
+        model: "school_academic_term"
+        save_as: "academic_term"
+        values:
+          name: "Semester CDIA3"
+          code: "SMCDIA3"
+          date_start: "2024-07-01"
+          date_end: "2025-06-30"
+          year_id: "REC: academic_year.id"
+          enrollment_state: "open"
+
+      - step: "Setup - create school"
+        action: "create"
+        model: "school"
+        save_as: "school"
+        values:
+          name: "School CDIA3"
+          code: "SCHCDIA3"
+          grade_type_id: "REC: grade_type.id"
+
+      - step: "Setup - create grade"
+        action: "create"
+        model: "school_grade"
+        save_as: "grade"
+        values:
+          name: "Grade CDIA3"
+          code: "GCDIA3"
+          sequence: 10
+          type_id: "REC: grade_type.id"
+
+      - step: "Setup - get receivable journal"
+        action: "search"
+        model: "account.journal"
+        domain: [["type", "=", "sale"]]
+        save_as: "receivable_journal"
+        limit: 1
+
+      - step: "Setup - create student contact"
+        action: "create"
+        model: "res.partner"
+        save_as: "student_contact"
+        values:
+          name: "Student Contact CDIA3"
+
+      - step: "Create admission"
+        action: "create"
+        model: "school_admission"
+        save_as: "admission"
+        values:
+          date: "2024-07-01"
+          academic_year_id: "REC: academic_year.id"
+          academic_term_id: "REC: academic_term.id"
+          school_id: "REC: school.id"
+          grade_id: "REC: grade.id"
+          student_id: "REC: student_contact.id"
+          currency_id: "REC: company.currency_id.id"
+          receivable_journal_id: "REC: receivable_journal.id"
+
+      - step: "Confirm admission"
+        action: "call"
+        target: "admission"
+        method: "action_confirm"
+        as_user: "base.user_admin"
+
+      - step: "Invalidate admission cache before approve"
+        action: "call"
+        target: "admission"
+        method: "invalidate_cache"
+
+      - step: "Approve admission"
+        action: "call"
+        target: "admission"
+        method: "action_approve_approval"
+        as_user: "base.user_admin"
+        asserts:
+          state:
+            type: "value"
+            expected: "open"
+
+      - step: "Create term A (10 days ago, uninvoiced)"
+        action: "create"
+        model: "school_admission_payment_term"
+        save_as: "term_a"
+        values:
+          admission_id: "REC: admission.id"
+          name: "Term A CDIA3"
+          sequence: 10
+          date_invoice: "EVAL: (datetime.now() + timedelta(days=-10)).date()"
+          detail_ids:
+            - - 0
+              - 0
+              - product_id: "REC: product.id"
+                name: "Fee A CDIA3"
+                account_id: "REC: account.id"
+                uom_quantity: 1.0
+                uom_id: "REF: uom.product_uom_unit"
+                price_unit: 500000.0
+
+      - step: "Create term B (today, uninvoiced)"
+        action: "create"
+        model: "school_admission_payment_term"
+        save_as: "term_b"
+        values:
+          admission_id: "REC: admission.id"
+          name: "Term B CDIA3"
+          sequence: 20
+          date_invoice: "EVAL: datetime.now().date()"
+          detail_ids:
+            - - 0
+              - 0
+              - product_id: "REC: product.id"
+                name: "Fee B CDIA3"
+                account_id: "REC: account.id"
+                uom_quantity: 1.0
+                uom_id: "REF: uom.product_uom_unit"
+                price_unit: 500000.0
+
+      - step: "Create term C (10 days from now, uninvoiced)"
+        action: "create"
+        model: "school_admission_payment_term"
+        save_as: "term_c"
+        values:
+          admission_id: "REC: admission.id"
+          name: "Term C CDIA3"
+          sequence: 30
+          date_invoice: "EVAL: (datetime.now() + timedelta(days=10)).date()"
+          detail_ids:
+            - - 0
+              - 0
+              - product_id: "REC: product.id"
+                name: "Fee C CDIA3"
+                account_id: "REC: account.id"
+                uom_quantity: 1.0
+                uom_id: "REF: uom.product_uom_unit"
+                price_unit: 500000.0
+
+      - step: "Create term D (manually controlled, yesterday)"
+        action: "create"
+        model: "school_admission_payment_term"
+        save_as: "term_d"
+        values:
+          admission_id: "REC: admission.id"
+          name: "Term D CDIA3"
+          sequence: 40
+          manually_control: true
+          date_invoice: "EVAL: (datetime.now() + timedelta(days=-1)).date()"
+
+      - step: "Create term E (uninvoiced, no date_invoice)"
+        action: "create"
+        model: "school_admission_payment_term"
+        save_as: "term_e"
+        values:
+          admission_id: "REC: admission.id"
+          name: "Term E CDIA3"
+          sequence: 50
+
+      - step: "Create wizard with date_start yesterday, no date_end"
+        action: "create"
+        model: "school_admission.wizard_create_due_invoice"
+        save_as: "wizard"
+        values:
+          admission_ids:
+            - - 6
+              - 0
+              - - "REC: admission.id"
+          date_start: "EVAL: (datetime.now() + timedelta(days=-1)).date()"
+
+      - step: "Run create due invoice (date_start only)"
+        action: "call"
+        target: "wizard"
+        method: "action_create_due_invoice"
+
+      - step: "Assert term A untouched (before date_start)"
+        action: "assert"
+        target: "term_a"
+        asserts:
+          state:
+            type: "value"
+            expected: "uninvoiced"
+
+      - step: "Assert term B invoiced"
+        action: "assert"
+        target: "term_b"
+        asserts:
+          state:
+            type: "value"
+            expected: "invoiced"
+          invoice_id:
+            type: "value"
+            operator: "is_truthy"
+
+      - step: "Assert term C untouched (in the future)"
+        action: "assert"
+        target: "term_c"
+        asserts:
+          state:
+            type: "value"
+            expected: "uninvoiced"
+
+      - step: "Assert term D untouched (manually controlled)"
+        action: "assert"
+        target: "term_d"
+        asserts:
+          state:
+            type: "value"
+            expected: "manual"
+
+      - step: "Assert term E untouched (no date_invoice)"
+        action: "assert"
+        target: "term_e"
+        asserts:
+          state:
+            type: "value"
+            expected: "uninvoiced"
+
+  - name: "Create Due Invoice - Both Dates Set Narrows To Term A Only"
+    steps:
+      - step: "Setup - get account type ref"
+        action: "ref"
+        xml_id: "account.data_account_type_revenue"
+        save_as: "account_type"
+
+      - step: "Setup - create income account"
+        action: "create"
+        model: "account.account"
+        save_as: "account"
+        values:
+          name: "Admission Fee Income CDIA4"
+          code: "CDIA44200"
+          user_type_id: "REC: account_type.id"
+
+      - step: "Setup - create product"
+        action: "create"
+        model: "product.product"
+        save_as: "product"
+        values:
+          name: "Admission Fee CDIA4"
+          type: "service"
+          list_price: 500000.0
+
+      - step: "Setup - create grade type"
+        action: "create"
+        model: "school_grade_type"
+        save_as: "grade_type"
+        values:
+          name: "Grade Type CDIA4"
+          code: "GTCDIA4"
+          sequence: 10
+
+      - step: "Setup - create academic year"
+        action: "create"
+        model: "school_academic_year"
+        save_as: "academic_year"
+        values:
+          name: "2024/2025 CDIA4"
+          code: "AYCDIA4"
+          date_start: "2024-07-01"
+          date_end: "2025-06-30"
+
+      - step: "Setup - create academic term"
+        action: "create"
+        model: "school_academic_term"
+        save_as: "academic_term"
+        values:
+          name: "Semester CDIA4"
+          code: "SMCDIA4"
+          date_start: "2024-07-01"
+          date_end: "2025-06-30"
+          year_id: "REC: academic_year.id"
+          enrollment_state: "open"
+
+      - step: "Setup - create school"
+        action: "create"
+        model: "school"
+        save_as: "school"
+        values:
+          name: "School CDIA4"
+          code: "SCHCDIA4"
+          grade_type_id: "REC: grade_type.id"
+
+      - step: "Setup - create grade"
+        action: "create"
+        model: "school_grade"
+        save_as: "grade"
+        values:
+          name: "Grade CDIA4"
+          code: "GCDIA4"
+          sequence: 10
+          type_id: "REC: grade_type.id"
+
+      - step: "Setup - get receivable journal"
+        action: "search"
+        model: "account.journal"
+        domain: [["type", "=", "sale"]]
+        save_as: "receivable_journal"
+        limit: 1
+
+      - step: "Setup - create student contact"
+        action: "create"
+        model: "res.partner"
+        save_as: "student_contact"
+        values:
+          name: "Student Contact CDIA4"
+
+      - step: "Create admission"
+        action: "create"
+        model: "school_admission"
+        save_as: "admission"
+        values:
+          date: "2024-07-01"
+          academic_year_id: "REC: academic_year.id"
+          academic_term_id: "REC: academic_term.id"
+          school_id: "REC: school.id"
+          grade_id: "REC: grade.id"
+          student_id: "REC: student_contact.id"
+          currency_id: "REC: company.currency_id.id"
+          receivable_journal_id: "REC: receivable_journal.id"
+
+      - step: "Confirm admission"
+        action: "call"
+        target: "admission"
+        method: "action_confirm"
+        as_user: "base.user_admin"
+
+      - step: "Invalidate admission cache before approve"
+        action: "call"
+        target: "admission"
+        method: "invalidate_cache"
+
+      - step: "Approve admission"
+        action: "call"
+        target: "admission"
+        method: "action_approve_approval"
+        as_user: "base.user_admin"
+        asserts:
+          state:
+            type: "value"
+            expected: "open"
+
+      - step: "Create term A (10 days ago, uninvoiced)"
+        action: "create"
+        model: "school_admission_payment_term"
+        save_as: "term_a"
+        values:
+          admission_id: "REC: admission.id"
+          name: "Term A CDIA4"
+          sequence: 10
+          date_invoice: "EVAL: (datetime.now() + timedelta(days=-10)).date()"
+          detail_ids:
+            - - 0
+              - 0
+              - product_id: "REC: product.id"
+                name: "Fee A CDIA4"
+                account_id: "REC: account.id"
+                uom_quantity: 1.0
+                uom_id: "REF: uom.product_uom_unit"
+                price_unit: 500000.0
+
+      - step: "Create term B (today, uninvoiced)"
+        action: "create"
+        model: "school_admission_payment_term"
+        save_as: "term_b"
+        values:
+          admission_id: "REC: admission.id"
+          name: "Term B CDIA4"
+          sequence: 20
+          date_invoice: "EVAL: datetime.now().date()"
+          detail_ids:
+            - - 0
+              - 0
+              - product_id: "REC: product.id"
+                name: "Fee B CDIA4"
+                account_id: "REC: account.id"
+                uom_quantity: 1.0
+                uom_id: "REF: uom.product_uom_unit"
+                price_unit: 500000.0
+
+      - step: "Create term C (10 days from now, uninvoiced)"
+        action: "create"
+        model: "school_admission_payment_term"
+        save_as: "term_c"
+        values:
+          admission_id: "REC: admission.id"
+          name: "Term C CDIA4"
+          sequence: 30
+          date_invoice: "EVAL: (datetime.now() + timedelta(days=10)).date()"
+          detail_ids:
+            - - 0
+              - 0
+              - product_id: "REC: product.id"
+                name: "Fee C CDIA4"
+                account_id: "REC: account.id"
+                uom_quantity: 1.0
+                uom_id: "REF: uom.product_uom_unit"
+                price_unit: 500000.0
+
+      - step: "Create term D (manually controlled, yesterday)"
+        action: "create"
+        model: "school_admission_payment_term"
+        save_as: "term_d"
+        values:
+          admission_id: "REC: admission.id"
+          name: "Term D CDIA4"
+          sequence: 40
+          manually_control: true
+          date_invoice: "EVAL: (datetime.now() + timedelta(days=-1)).date()"
+
+      - step: "Create term E (uninvoiced, no date_invoice)"
+        action: "create"
+        model: "school_admission_payment_term"
+        save_as: "term_e"
+        values:
+          admission_id: "REC: admission.id"
+          name: "Term E CDIA4"
+          sequence: 50
+
+      - step: "Create wizard with date_start -15 days and date_end -5 days"
+        action: "create"
+        model: "school_admission.wizard_create_due_invoice"
+        save_as: "wizard"
+        values:
+          admission_ids:
+            - - 6
+              - 0
+              - - "REC: admission.id"
+          date_start: "EVAL: (datetime.now() + timedelta(days=-15)).date()"
+          date_end: "EVAL: (datetime.now() + timedelta(days=-5)).date()"
+
+      - step: "Run create due invoice (narrow past range)"
+        action: "call"
+        target: "wizard"
+        method: "action_create_due_invoice"
+
+      - step: "Assert term A invoiced"
+        action: "assert"
+        target: "term_a"
+        asserts:
+          state:
+            type: "value"
+            expected: "invoiced"
+          invoice_id:
+            type: "value"
+            operator: "is_truthy"
+
+      - step: "Assert term B untouched (after the range)"
+        action: "assert"
+        target: "term_b"
+        asserts:
+          state:
+            type: "value"
+            expected: "uninvoiced"
+
+      - step: "Assert term C untouched (after the range)"
+        action: "assert"
+        target: "term_c"
+        asserts:
+          state:
+            type: "value"
+            expected: "uninvoiced"
+
+      - step: "Assert term D untouched (manually controlled)"
+        action: "assert"
+        target: "term_d"
+        asserts:
+          state:
+            type: "value"
+            expected: "manual"
+
+      - step: "Assert term E untouched (no date_invoice)"
+        action: "assert"
+        target: "term_e"
+        asserts:
+          state:
+            type: "value"
+            expected: "uninvoiced"
+
+  - name: "Create Due Invoice - Idempotent On Repeated Run"
+    steps:
+      - step: "Setup - get account type ref"
+        action: "ref"
+        xml_id: "account.data_account_type_revenue"
+        save_as: "account_type"
+
+      - step: "Setup - create income account"
+        action: "create"
+        model: "account.account"
+        save_as: "account"
+        values:
+          name: "Admission Fee Income CDIA5"
+          code: "CDIA54200"
+          user_type_id: "REC: account_type.id"
+
+      - step: "Setup - create product"
+        action: "create"
+        model: "product.product"
+        save_as: "product"
+        values:
+          name: "Admission Fee CDIA5"
+          type: "service"
+          list_price: 500000.0
+
+      - step: "Setup - create grade type"
+        action: "create"
+        model: "school_grade_type"
+        save_as: "grade_type"
+        values:
+          name: "Grade Type CDIA5"
+          code: "GTCDIA5"
+          sequence: 10
+
+      - step: "Setup - create academic year"
+        action: "create"
+        model: "school_academic_year"
+        save_as: "academic_year"
+        values:
+          name: "2024/2025 CDIA5"
+          code: "AYCDIA5"
+          date_start: "2024-07-01"
+          date_end: "2025-06-30"
+
+      - step: "Setup - create academic term"
+        action: "create"
+        model: "school_academic_term"
+        save_as: "academic_term"
+        values:
+          name: "Semester CDIA5"
+          code: "SMCDIA5"
+          date_start: "2024-07-01"
+          date_end: "2025-06-30"
+          year_id: "REC: academic_year.id"
+          enrollment_state: "open"
+
+      - step: "Setup - create school"
+        action: "create"
+        model: "school"
+        save_as: "school"
+        values:
+          name: "School CDIA5"
+          code: "SCHCDIA5"
+          grade_type_id: "REC: grade_type.id"
+
+      - step: "Setup - create grade"
+        action: "create"
+        model: "school_grade"
+        save_as: "grade"
+        values:
+          name: "Grade CDIA5"
+          code: "GCDIA5"
+          sequence: 10
+          type_id: "REC: grade_type.id"
+
+      - step: "Setup - get receivable journal"
+        action: "search"
+        model: "account.journal"
+        domain: [["type", "=", "sale"]]
+        save_as: "receivable_journal"
+        limit: 1
+
+      - step: "Setup - create student contact"
+        action: "create"
+        model: "res.partner"
+        save_as: "student_contact"
+        values:
+          name: "Student Contact CDIA5"
+
+      - step: "Create admission"
+        action: "create"
+        model: "school_admission"
+        save_as: "admission"
+        values:
+          date: "2024-07-01"
+          academic_year_id: "REC: academic_year.id"
+          academic_term_id: "REC: academic_term.id"
+          school_id: "REC: school.id"
+          grade_id: "REC: grade.id"
+          student_id: "REC: student_contact.id"
+          currency_id: "REC: company.currency_id.id"
+          receivable_journal_id: "REC: receivable_journal.id"
+
+      - step: "Confirm admission"
+        action: "call"
+        target: "admission"
+        method: "action_confirm"
+        as_user: "base.user_admin"
+
+      - step: "Invalidate admission cache before approve"
+        action: "call"
+        target: "admission"
+        method: "invalidate_cache"
+
+      - step: "Approve admission"
+        action: "call"
+        target: "admission"
+        method: "action_approve_approval"
+        as_user: "base.user_admin"
+        asserts:
+          state:
+            type: "value"
+            expected: "open"
+
+      - step: "Create term A (10 days ago, uninvoiced)"
+        action: "create"
+        model: "school_admission_payment_term"
+        save_as: "term_a"
+        values:
+          admission_id: "REC: admission.id"
+          name: "Term A CDIA5"
+          sequence: 10
+          date_invoice: "EVAL: (datetime.now() + timedelta(days=-10)).date()"
+          detail_ids:
+            - - 0
+              - 0
+              - product_id: "REC: product.id"
+                name: "Fee A CDIA5"
+                account_id: "REC: account.id"
+                uom_quantity: 1.0
+                uom_id: "REF: uom.product_uom_unit"
+                price_unit: 500000.0
+
+      - step: "Create term B (today, uninvoiced)"
+        action: "create"
+        model: "school_admission_payment_term"
+        save_as: "term_b"
+        values:
+          admission_id: "REC: admission.id"
+          name: "Term B CDIA5"
+          sequence: 20
+          date_invoice: "EVAL: datetime.now().date()"
+          detail_ids:
+            - - 0
+              - 0
+              - product_id: "REC: product.id"
+                name: "Fee B CDIA5"
+                account_id: "REC: account.id"
+                uom_quantity: 1.0
+                uom_id: "REF: uom.product_uom_unit"
+                price_unit: 500000.0
+
+      - step: "Create wizard with no date range"
+        action: "create"
+        model: "school_admission.wizard_create_due_invoice"
+        save_as: "wizard"
+        values:
+          admission_ids:
+            - - 6
+              - 0
+              - - "REC: admission.id"
+
+      - step: "Run create due invoice (first run)"
+        action: "call"
+        target: "wizard"
+        method: "action_create_due_invoice"
+
+      - step: "Assert two invoices exist after the first run"
+        action: "search"
+        model: "account.move"
+        domain: [["invoice_origin", "=", "REC: admission.name"]]
+        save_as: "invoices_after_run1"
+        expect_count: 2
+
+      - step: "Run create due invoice again (second run)"
+        action: "call"
+        target: "wizard"
+        method: "action_create_due_invoice"
+
+      - step: "Assert invoice count is unchanged after the second run"
+        action: "search"
+        model: "account.move"
+        domain: [["invoice_origin", "=", "REC: admission.name"]]
+        save_as: "invoices_after_run2"
+        expect_count: 2
+
+      - step: "Assert term A invoice still present"
+        action: "assert"
+        target: "term_a"
+        asserts:
+          state:
+            type: "value"
+            expected: "invoiced"
+          invoice_id:
+            type: "value"
+            operator: "is_truthy"
+
+      - step: "Assert term B invoice still present"
+        action: "assert"
+        target: "term_b"
+        asserts:
+          state:
+            type: "value"
+            expected: "invoiced"
+          invoice_id:
+            type: "value"
+            operator: "is_truthy"
+
+  - name: "Create Due Invoice - Blocked When Selection Includes A Non-Open Admission"
+    steps:
+      - step: "Setup - get account type ref"
+        action: "ref"
+        xml_id: "account.data_account_type_revenue"
+        save_as: "account_type"
+
+      - step: "Setup - create income account"
+        action: "create"
+        model: "account.account"
+        save_as: "account"
+        values:
+          name: "Admission Fee Income CDIA6"
+          code: "CDIA64200"
+          user_type_id: "REC: account_type.id"
+
+      - step: "Setup - create product"
+        action: "create"
+        model: "product.product"
+        save_as: "product"
+        values:
+          name: "Admission Fee CDIA6"
+          type: "service"
+          list_price: 500000.0
+
+      - step: "Setup - create grade type"
+        action: "create"
+        model: "school_grade_type"
+        save_as: "grade_type"
+        values:
+          name: "Grade Type CDIA6"
+          code: "GTCDIA6"
+          sequence: 10
+
+      - step: "Setup - create academic year"
+        action: "create"
+        model: "school_academic_year"
+        save_as: "academic_year"
+        values:
+          name: "2024/2025 CDIA6"
+          code: "AYCDIA6"
+          date_start: "2024-07-01"
+          date_end: "2025-06-30"
+
+      - step: "Setup - create academic term"
+        action: "create"
+        model: "school_academic_term"
+        save_as: "academic_term"
+        values:
+          name: "Semester CDIA6"
+          code: "SMCDIA6"
+          date_start: "2024-07-01"
+          date_end: "2025-06-30"
+          year_id: "REC: academic_year.id"
+          enrollment_state: "open"
+
+      - step: "Setup - create school"
+        action: "create"
+        model: "school"
+        save_as: "school"
+        values:
+          name: "School CDIA6"
+          code: "SCHCDIA6"
+          grade_type_id: "REC: grade_type.id"
+
+      - step: "Setup - create grade"
+        action: "create"
+        model: "school_grade"
+        save_as: "grade"
+        values:
+          name: "Grade CDIA6"
+          code: "GCDIA6"
+          sequence: 10
+          type_id: "REC: grade_type.id"
+
+      - step: "Setup - get receivable journal"
+        action: "search"
+        model: "account.journal"
+        domain: [["type", "=", "sale"]]
+        save_as: "receivable_journal"
+        limit: 1
+
+      - step: "Setup - create student contact"
+        action: "create"
+        model: "res.partner"
+        save_as: "student_contact"
+        values:
+          name: "Student Contact CDIA6"
+
+      - step: "Create admission"
+        action: "create"
+        model: "school_admission"
+        save_as: "admission"
+        values:
+          date: "2024-07-01"
+          academic_year_id: "REC: academic_year.id"
+          academic_term_id: "REC: academic_term.id"
+          school_id: "REC: school.id"
+          grade_id: "REC: grade.id"
+          student_id: "REC: student_contact.id"
+          currency_id: "REC: company.currency_id.id"
+          receivable_journal_id: "REC: receivable_journal.id"
+
+      - step: "Confirm admission"
+        action: "call"
+        target: "admission"
+        method: "action_confirm"
+        as_user: "base.user_admin"
+
+      - step: "Invalidate admission cache before approve"
+        action: "call"
+        target: "admission"
+        method: "invalidate_cache"
+
+      - step: "Approve admission"
+        action: "call"
+        target: "admission"
+        method: "action_approve_approval"
+        as_user: "base.user_admin"
+        asserts:
+          state:
+            type: "value"
+            expected: "open"
+
+      - step: "Create term A (10 days ago, uninvoiced)"
+        action: "create"
+        model: "school_admission_payment_term"
+        save_as: "term_a"
+        values:
+          admission_id: "REC: admission.id"
+          name: "Term A CDIA6"
+          sequence: 10
+          date_invoice: "EVAL: (datetime.now() + timedelta(days=-10)).date()"
+          detail_ids:
+            - - 0
+              - 0
+              - product_id: "REC: product.id"
+                name: "Fee A CDIA6"
+                account_id: "REC: account.id"
+                uom_quantity: 1.0
+                uom_id: "REF: uom.product_uom_unit"
+                price_unit: 500000.0
+
+      - step: "Setup - create second student contact for the draft admission"
+        action: "create"
+        model: "res.partner"
+        save_as: "student_contact2"
+        values:
+          name: "Student Contact 2 CDIA6"
+
+      - step: "Create second admission, left in draft"
+        action: "create"
+        model: "school_admission"
+        save_as: "admission_draft"
+        values:
+          date: "2024-07-01"
+          academic_year_id: "REC: academic_year.id"
+          academic_term_id: "REC: academic_term.id"
+          school_id: "REC: school.id"
+          grade_id: "REC: grade.id"
+          student_id: "REC: student_contact2.id"
+          currency_id: "REC: company.currency_id.id"
+
+      - step: "Assert draft admission is not allowed to create due invoice"
+        action: "assert"
+        target: "admission_draft"
+        asserts:
+          create_invoice_ok:
+            type: "value"
+            expected: false
+
+      - step: "Create wizard selecting both the open and the draft admission"
+        action: "create"
+        model: "school_admission.wizard_create_due_invoice"
+        save_as: "wizard"
+        values:
+          admission_ids:
+            - - 6
+              - 0
+              - - "REC: admission.id"
+                - "REC: admission_draft.id"
+
+      - step: "Run create due invoice must fail because of the draft admission"
+        action: "call"
+        target: "wizard"
+        method: "action_create_due_invoice"
+        expect_error:
+          type: "UserError"
+
+      - step: "Assert term A on the valid admission is still uninvoiced"
+        action: "assert"
+        target: "term_a"
+        asserts:
+          state:
+            type: "value"
+            expected: "uninvoiced"
+          invoice_id:
+            type: "value"
+            operator: "is_falsy"
+
+      - step: "Assert no invoice was created for the valid admission either"
+        action: "search"
+        model: "account.move"
+        domain: [["invoice_origin", "=", "REC: admission.name"]]
+        save_as: "invoices_after_failed_run"
+        expect_count: 0
+
+  - name: "Create Due Invoice - Blocked When Date Start Is Later Than Date End"
+    steps:
+      - step: "Setup - get account type ref"
+        action: "ref"
+        xml_id: "account.data_account_type_revenue"
+        save_as: "account_type"
+
+      - step: "Setup - create income account"
+        action: "create"
+        model: "account.account"
+        save_as: "account"
+        values:
+          name: "Admission Fee Income CDIA7"
+          code: "CDIA74200"
+          user_type_id: "REC: account_type.id"
+
+      - step: "Setup - create product"
+        action: "create"
+        model: "product.product"
+        save_as: "product"
+        values:
+          name: "Admission Fee CDIA7"
+          type: "service"
+          list_price: 500000.0
+
+      - step: "Setup - create grade type"
+        action: "create"
+        model: "school_grade_type"
+        save_as: "grade_type"
+        values:
+          name: "Grade Type CDIA7"
+          code: "GTCDIA7"
+          sequence: 10
+
+      - step: "Setup - create academic year"
+        action: "create"
+        model: "school_academic_year"
+        save_as: "academic_year"
+        values:
+          name: "2024/2025 CDIA7"
+          code: "AYCDIA7"
+          date_start: "2024-07-01"
+          date_end: "2025-06-30"
+
+      - step: "Setup - create academic term"
+        action: "create"
+        model: "school_academic_term"
+        save_as: "academic_term"
+        values:
+          name: "Semester CDIA7"
+          code: "SMCDIA7"
+          date_start: "2024-07-01"
+          date_end: "2025-06-30"
+          year_id: "REC: academic_year.id"
+          enrollment_state: "open"
+
+      - step: "Setup - create school"
+        action: "create"
+        model: "school"
+        save_as: "school"
+        values:
+          name: "School CDIA7"
+          code: "SCHCDIA7"
+          grade_type_id: "REC: grade_type.id"
+
+      - step: "Setup - create grade"
+        action: "create"
+        model: "school_grade"
+        save_as: "grade"
+        values:
+          name: "Grade CDIA7"
+          code: "GCDIA7"
+          sequence: 10
+          type_id: "REC: grade_type.id"
+
+      - step: "Setup - get receivable journal"
+        action: "search"
+        model: "account.journal"
+        domain: [["type", "=", "sale"]]
+        save_as: "receivable_journal"
+        limit: 1
+
+      - step: "Setup - create student contact"
+        action: "create"
+        model: "res.partner"
+        save_as: "student_contact"
+        values:
+          name: "Student Contact CDIA7"
+
+      - step: "Create admission"
+        action: "create"
+        model: "school_admission"
+        save_as: "admission"
+        values:
+          date: "2024-07-01"
+          academic_year_id: "REC: academic_year.id"
+          academic_term_id: "REC: academic_term.id"
+          school_id: "REC: school.id"
+          grade_id: "REC: grade.id"
+          student_id: "REC: student_contact.id"
+          currency_id: "REC: company.currency_id.id"
+          receivable_journal_id: "REC: receivable_journal.id"
+
+      - step: "Confirm admission"
+        action: "call"
+        target: "admission"
+        method: "action_confirm"
+        as_user: "base.user_admin"
+
+      - step: "Invalidate admission cache before approve"
+        action: "call"
+        target: "admission"
+        method: "invalidate_cache"
+
+      - step: "Approve admission"
+        action: "call"
+        target: "admission"
+        method: "action_approve_approval"
+        as_user: "base.user_admin"
+        asserts:
+          state:
+            type: "value"
+            expected: "open"
+
+      - step: "Create term A (10 days ago, uninvoiced)"
+        action: "create"
+        model: "school_admission_payment_term"
+        save_as: "term_a"
+        values:
+          admission_id: "REC: admission.id"
+          name: "Term A CDIA7"
+          sequence: 10
+          date_invoice: "EVAL: (datetime.now() + timedelta(days=-10)).date()"
+          detail_ids:
+            - - 0
+              - 0
+              - product_id: "REC: product.id"
+                name: "Fee A CDIA7"
+                account_id: "REC: account.id"
+                uom_quantity: 1.0
+                uom_id: "REF: uom.product_uom_unit"
+                price_unit: 500000.0
+
+      - step: "Create wizard with date_start tomorrow (later than effective date_end)"
+        action: "create"
+        model: "school_admission.wizard_create_due_invoice"
+        save_as: "wizard"
+        values:
+          admission_ids:
+            - - 6
+              - 0
+              - - "REC: admission.id"
+          date_start: "EVAL: (datetime.now() + timedelta(days=1)).date()"
+
+      - step: "Run create due invoice must fail because of the reversed date range"
+        action: "call"
+        target: "wizard"
+        method: "action_create_due_invoice"
+        expect_error:
+          type: "UserError"
+
+      - step: "Assert term A is still uninvoiced"
+        action: "assert"
+        target: "term_a"
+        asserts:
+          state:
+            type: "value"
+            expected: "uninvoiced"
+          invoice_id:
+            type: "value"
+            operator: "is_falsy"
+
+      - step: "Assert no invoice was created"
+        action: "search"
+        model: "account.move"
+        domain: [["invoice_origin", "=", "REC: admission.name"]]
+        save_as: "invoices_after_failed_range"
+        expect_count: 0

--- a/ssi_school_admission/tests/test_data_admission_create_due_invoice.yaml
+++ b/ssi_school_admission/tests/test_data_admission_create_due_invoice.yaml
@@ -1,5 +1,3 @@
-options:
-  auto_refresh: true
 scenarios:
   - name: "Create Due Invoice - No Range Invoices Only Due Terms"
     steps:

--- a/ssi_school_admission/tests/test_school_admission_create_due_invoice.py
+++ b/ssi_school_admission/tests/test_school_admission_create_due_invoice.py
@@ -1,0 +1,13 @@
+# Copyright 2026 OpenSynergy Indonesia
+# Copyright 2026 PT. Simetri Sinergi Indonesia
+# License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl).
+
+from odoo_yaml_test import YamlTransactionCase
+
+from odoo.tests import tagged
+
+
+@tagged("post_install", "-at_install")
+class TestSchoolAdmissionCreateDueInvoice(YamlTransactionCase):
+    def test_admission_create_due_invoice(self):
+        self.run_yaml_scenario("test_data_admission_create_due_invoice.yaml")

--- a/ssi_school_admission/views/school_admission.xml
+++ b/ssi_school_admission/views/school_admission.xml
@@ -78,6 +78,14 @@
     <field name="inherit_id" ref="ssi_transaction_mixin.mixin_transaction_view_form" />
     <field name="arch" type="xml">
         <data>
+            <xpath expr="//header" position="inside">
+                <button
+                        name="action_open_create_due_invoice_wizard"
+                        type="object"
+                        string="Create Due Invoice"
+                        attrs="{'invisible':[('create_invoice_ok','=',False)]}"
+                    />
+            </xpath>
             <xpath expr="//field[@name='user_id']" position="after">
                 <label for="academic_term_id" string="Year/Term" />
                 <div class="o_row">
@@ -245,6 +253,7 @@
             </xpath>
             <xpath expr="//group[@name='policy_2']" position="inside">
                 <field name="addendum_ok" />
+                <field name="create_invoice_ok" />
             </xpath>
         </data>
     </field>

--- a/ssi_school_admission/wizards/__init__.py
+++ b/ssi_school_admission/wizards/__init__.py
@@ -4,6 +4,7 @@
 
 from . import (  # noqa: F401
     school_admission_copy_payment_term,
+    school_admission_create_due_invoice,
     school_admission_form_create_admission,
     school_admission_payment_term_duplicate,
     school_admission_test_create_admission,

--- a/ssi_school_admission/wizards/school_admission_create_due_invoice.py
+++ b/ssi_school_admission/wizards/school_admission_create_due_invoice.py
@@ -1,0 +1,128 @@
+# Copyright 2026 OpenSynergy Indonesia
+# Copyright 2026 PT. Simetri Sinergi Indonesia
+# License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl).
+
+from odoo import _, api, fields, models
+from odoo.exceptions import UserError
+
+
+class SchoolAdmissionWizardCreateDueInvoice(models.TransientModel):
+    """
+    Wizard that creates invoices for all uninvoiced payment terms whose
+    estimated invoice date (date_invoice) falls within a given date range, for
+    one or more admissions selected from the school_admission list view or
+    from a single admission's form. Every selected admission must be allowed
+    by the create_invoice_ok policy (state and group, configurable via Policy
+    Template). All admissions are validated before any invoice is created.
+    """
+
+    _name = "school_admission.wizard_create_due_invoice"
+    _description = "Create Due Invoice for Admission Payment Terms"
+
+    admission_ids = fields.Many2many(
+        string="Admissions",
+        comodel_name="school_admission",
+        relation="rel_school_admission_create_due_invoice",
+        column1="wizard_id",
+        column2="admission_id",
+        readonly=True,
+        help="Admissions whose due payment terms will be invoiced.",
+    )
+    date_start = fields.Date(
+        string="Date Start",
+        help=(
+            "Earliest estimated invoice date to process. "
+            "Leave empty for no lower bound."
+        ),
+    )
+    date_end = fields.Date(
+        string="Date End",
+        help=(
+            "Latest estimated invoice date to process. "
+            "Leave empty to process up to today."
+        ),
+    )
+
+    @api.model
+    def default_get(self, fields_list):
+        res = super().default_get(fields_list)
+        if self.env.context.get("active_model") == "school_admission":
+            active_ids = self.env.context.get("active_ids", [])
+            res["admission_ids"] = [(6, 0, active_ids)]
+        return res
+
+    def action_create_due_invoice(self):
+        for record in self.sudo():
+            record._create_due_invoice()  # pylint: disable=protected-access
+        return {"type": "ir.actions.act_window_close"}
+
+    def _create_due_invoice(self):
+        self.ensure_one()
+        self._check_admissions()
+        self._check_date_range()
+        for admission in self.admission_ids:
+            admission._create_due_invoice(  # pylint: disable=protected-access
+                self.date_start, self.date_end
+            )
+
+    def _check_admissions(self):
+        self.ensure_one()
+        if not self.admission_ids:
+            error_message = (
+                _(
+                    """
+Context: Create due invoice for admissions
+Database ID: %s
+Problem: No admission selected
+Solution: Select at least one admission from the list view before running this wizard
+"""
+                )
+                % (self.id,)
+            )
+            raise UserError(error_message)
+        problems = []
+        for admission in self.admission_ids:
+            if not admission.create_invoice_ok:
+                problems.append(
+                    _("- %s: not allowed to create due invoice (check state/policy)")
+                    % admission.name
+                )
+        if problems:
+            error_message = (
+                _(
+                    """
+Context: Create due invoice for admissions
+Database ID: %s
+Problem: The following admission(s) are not allowed to create due invoice:
+%s
+Solution: Deselect the listed admission(s), or make sure they are open and allowed
+by the create due invoice policy
+"""
+                )
+                % (
+                    self.id,
+                    "\n".join(problems),
+                )
+            )
+            raise UserError(error_message)
+
+    def _check_date_range(self):
+        self.ensure_one()
+        effective_end = self.date_end or fields.Date.context_today(self)
+        if self.date_start and self.date_start > effective_end:
+            error_message = (
+                _(
+                    """
+Context: Create due invoice for admissions
+Database ID: %s
+Problem: Date Start '%s' is later than Date End '%s'
+Solution: Choose a Date Start that is not later than Date End
+"""
+                )
+                % (
+                    self.id,
+                    self.date_start,
+                    effective_end,
+                )
+            )
+            raise UserError(error_message)

--- a/ssi_school_admission/wizards/school_admission_create_due_invoice.xml
+++ b/ssi_school_admission/wizards/school_admission_create_due_invoice.xml
@@ -1,0 +1,42 @@
+<?xml version="1.0" encoding="utf-8" ?>
+<!-- Copyright 2026 OpenSynergy Indonesia
+     Copyright 2026 PT. Simetri Sinergi Indonesia
+     License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl). -->
+<odoo>
+
+<record id="school_admission_wizard_create_due_invoice_view_form" model="ir.ui.view">
+    <field name="name">school_admission.wizard_create_due_invoice - form</field>
+    <field name="model">school_admission.wizard_create_due_invoice</field>
+    <field name="arch" type="xml">
+        <form string="Create Due Invoice">
+            <group name="main" colspan="4" col="2">
+                <field name="admission_ids" widget="many2many_tags" colspan="2" />
+                <field name="date_start" />
+                <field name="date_end" />
+            </group>
+            <footer>
+                <button
+                        name="action_create_due_invoice"
+                        type="object"
+                        string="Create Due Invoice"
+                        class="btn-primary"
+                    />
+                <button string="Cancel" class="btn-default" special="cancel" />
+            </footer>
+        </form>
+    </field>
+</record>
+
+<record
+        id="school_admission_wizard_create_due_invoice_action"
+        model="ir.actions.act_window"
+    >
+    <field name="name">Create Due Invoice</field>
+    <field name="type">ir.actions.act_window</field>
+    <field name="res_model">school_admission.wizard_create_due_invoice</field>
+    <field name="view_mode">form</field>
+    <field name="target">new</field>
+    <field name="binding_model_id" ref="model_school_admission" />
+</record>
+
+</odoo>


### PR DESCRIPTION
## Ringkasan

* Menambahkan wizard **Create Due Invoice** pada `school_enrollment` (`ssi_school`)
  dan `school_admission` (`ssi_school_admission`) — membuat invoice sekaligus atas
  seluruh payment term yang jatuh tempo (`date_invoice` di dalam rentang tanggal
  tertentu), dapat dijalankan dari tombol form maupun mass action di list view.
* Gating sepenuhnya lewat `policy.template` (field `create_invoice_ok`, state
  `open`, group `school_{enrollment,admission}_user_group`) — tanpa hardcode
  `state=`/`groups=` di view maupun Python.
* Menambahkan unit test skenario YAML (`odoo-yaml-test`) untuk kedua modul,
  mencakup 4 kombinasi rentang tanggal, idempotensi, dan negative path (policy
  block pada seleksi massal, rentang tanggal terbalik).

## Test plan

- [ ] CI hijau (pre-commit + unit test)