### PR TITLE
[UPD] ssi_school_admission_lead: field Lapis 1 SPMB pada crm.lead

### DIFF
--- a/ssi_school_admission_lead/README.rst
+++ b/ssi_school_admission_lead/README.rst
@@ -11,6 +11,14 @@ Glue module between School Admission and CRM Lead.
 Adds ``admission_form_id`` and ``admission_test_id`` fields to ``crm.lead``,
 and provides a wizard to create an admission form directly from a lead.
 
+It also carries the first layer of admission intake data on the lead itself:
+
+* ``student_birthdate`` and ``student_gender``: birthdate and gender of the
+  prospective student, related to the contact referenced by ``student_id``.
+  The identity data is stored on ``res.partner``, not duplicated on the lead.
+* ``grade_id``: the grade level the prospective student applies for, restricted
+  by ``grade_type_id`` which is derived from the selected school.
+
 Credits
 =======
 

--- a/ssi_school_admission_lead/models/crm_lead.py
+++ b/ssi_school_admission_lead/models/crm_lead.py
@@ -15,6 +15,53 @@ class CrmLead(models.Model):  # pylint: disable=too-few-public-methods
     _inherit = "crm.lead"
     _description = "CRM Lead"
 
+    student_birthdate = fields.Date(
+        string="Student Birthdate",
+        related="student_id.birthdate_date",
+        store=True,
+        readonly=False,
+        compute_sudo=True,
+        help=(
+            "Date of birth of the prospective student, synchronized from "
+            "the contact referenced by the Student field. Writing this "
+            "field updates the contact itself, so the identity data is not "
+            "duplicated on the lead."
+        ),
+    )
+    student_gender = fields.Selection(
+        string="Student Gender",
+        related="student_id.gender",
+        store=True,
+        readonly=False,
+        compute_sudo=True,
+        help=(
+            "Gender of the prospective student, synchronized from the "
+            "contact referenced by the Student field. Writing this field "
+            "updates the contact itself, so the identity data is not "
+            "duplicated on the lead."
+        ),
+    )
+    grade_type_id = fields.Many2one(
+        string="Grade Type",
+        comodel_name="school_grade_type",
+        related="school_id.grade_type_id",
+        help=(
+            "Grade type derived from the selected school. Used to restrict "
+            "the grades that can be selected on this lead."
+        ),
+    )
+    grade_id = fields.Many2one(
+        string="Grade",
+        comodel_name="school_grade",
+        ondelete="restrict",
+        tracking=True,
+        domain="[('type_id', '=', grade_type_id)]",
+        help=(
+            "The grade level the prospective student is applying for. "
+            "Only grades belonging to the grade type of the selected "
+            "school can be chosen."
+        ),
+    )
     admission_form_id = fields.Many2one(
         string="Admission Form",
         comodel_name="school_admission_form",

--- a/ssi_school_admission_lead/tests/__init__.py
+++ b/ssi_school_admission_lead/tests/__init__.py
@@ -3,3 +3,4 @@
 # License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl).
 
 from . import test_crm_lead_admission  # noqa: F401
+from . import test_crm_lead_student_identity  # noqa: F401

--- a/ssi_school_admission_lead/tests/test_crm_lead_student_identity.py
+++ b/ssi_school_admission_lead/tests/test_crm_lead_student_identity.py
@@ -1,0 +1,13 @@
+# Copyright 2024 OpenSynergy Indonesia
+# Copyright 2024 PT. Simetri Sinergi Indonesia
+# License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl).
+
+from odoo_yaml_test import YamlTransactionCase
+
+from odoo.tests import tagged
+
+
+@tagged("post_install", "-at_install")
+class TestCrmLeadStudentIdentity(YamlTransactionCase):
+    def test_crm_lead_student_identity(self):
+        self.run_yaml_scenario("test_data_lead_student_identity.yaml")

--- a/ssi_school_admission_lead/tests/test_data_lead_student_identity.yaml
+++ b/ssi_school_admission_lead/tests/test_data_lead_student_identity.yaml
@@ -1,0 +1,206 @@
+options:
+  auto_refresh: true
+
+setup:
+  steps:
+    - step: "Setup - create grade type"
+      action: "create"
+      model: "school_grade_type"
+      save_as: "grade_type"
+      values:
+        name: "Grade Type Lead Student Identity"
+        code: "GTLSI"
+        sequence: 10
+
+    - step: "Setup - create school"
+      action: "create"
+      model: "school"
+      save_as: "school"
+      values:
+        name: "School Lead Student Identity"
+        code: "SCHLSI"
+        grade_type_id: "REC: grade_type.id"
+
+    - step: "Setup - create grade"
+      action: "create"
+      model: "school_grade"
+      save_as: "grade"
+      values:
+        name: "Grade Lead Student Identity"
+        code: "GLSI"
+        sequence: 10
+        type_id: "REC: grade_type.id"
+
+    - step: "Setup - create prospective student contact"
+      action: "create"
+      model: "res.partner"
+      save_as: "student_contact"
+      values:
+        name: "Student Lead Student Identity"
+
+scenarios:
+  - name: "CRM Lead - Student identity written on the lead reaches the contact"
+    steps:
+      - step: "Create lead pointing to the prospective student"
+        action: "create"
+        model: "crm.lead"
+        save_as: "lead"
+        values:
+          name: "Lead Write Student Identity"
+          school_id: "REC: school.id"
+          student_id: "REC: student_contact.id"
+
+      - step: "Write birthdate and gender on the lead"
+        action: "write"
+        target: "lead"
+        values:
+          student_birthdate: 2010-05-17
+          student_gender: "female"
+
+      - step: "Assert the contact received the identity data"
+        action: "assert"
+        target: "student_contact"
+        refresh: true
+        asserts:
+          birthdate_date:
+            type: "value"
+            expected: 2010-05-17
+          gender:
+            type: "value"
+            expected: "female"
+
+  - name: "CRM Lead - Student identity written on the contact is read on the lead"
+    steps:
+      - step: "Create lead pointing to the prospective student"
+        action: "create"
+        model: "crm.lead"
+        save_as: "lead"
+        values:
+          name: "Lead Read Student Identity"
+          student_id: "REC: student_contact.id"
+
+      - step: "Write birthdate and gender on the contact"
+        action: "write"
+        target: "student_contact"
+        values:
+          birthdate_date: 2011-09-01
+          gender: "male"
+
+      - step: "Assert the lead reflects the contact identity data"
+        action: "assert"
+        target: "lead"
+        refresh: true
+        asserts:
+          student_birthdate:
+            type: "value"
+            expected: 2011-09-01
+          student_gender:
+            type: "value"
+            expected: "male"
+
+  - name: "CRM Lead - Student identity stays empty without a prospective student"
+    steps:
+      - step: "Create lead without prospective student"
+        action: "create"
+        model: "crm.lead"
+        save_as: "lead"
+        values:
+          name: "Lead Without Student"
+
+      - step: "Assert lead exists with empty student identity"
+        action: "assert"
+        target: "lead"
+        refresh: true
+        asserts:
+          id:
+            type: "value"
+            operator: "is_truthy"
+          student_id:
+            type: "value"
+            operator: "is_falsy"
+          student_birthdate:
+            type: "value"
+            operator: "is_falsy"
+          student_gender:
+            type: "value"
+            operator: "is_falsy"
+
+  - name: "CRM Lead - Student gender without a prospective student is not stored"
+    steps:
+      - step: "Create lead with gender but without prospective student"
+        action: "create"
+        model: "crm.lead"
+        save_as: "lead"
+        values:
+          name: "Lead Gender Without Student"
+          student_gender: "female"
+
+      - step: "Assert no error and no student identity is kept"
+        action: "assert"
+        target: "lead"
+        refresh: true
+        asserts:
+          id:
+            type: "value"
+            operator: "is_truthy"
+          student_id:
+            type: "value"
+            operator: "is_falsy"
+          student_gender:
+            type: "value"
+            operator: "is_falsy"
+
+  - name: "CRM Lead - Grade type follows the school and restricts the grade"
+    steps:
+      - step: "Create lead with school"
+        action: "create"
+        model: "crm.lead"
+        save_as: "lead"
+        values:
+          name: "Lead Grade Type From School"
+          school_id: "REC: school.id"
+
+      - step: "Assert grade type is derived from the school"
+        action: "assert"
+        target: "lead"
+        refresh: true
+        asserts:
+          grade_type_id:
+            type: "m2o"
+            expected: "REC: grade_type"
+
+      - step: "Assign a grade belonging to that grade type"
+        action: "write"
+        target: "lead"
+        values:
+          grade_id: "REC: grade.id"
+
+      - step: "Assert grade is stored on the lead"
+        action: "assert"
+        target: "lead"
+        refresh: true
+        asserts:
+          grade_id:
+            type: "m2o"
+            expected: "REC: grade"
+
+  - name: "CRM Lead - Grade type stays empty without a school"
+    steps:
+      - step: "Create lead without school"
+        action: "create"
+        model: "crm.lead"
+        save_as: "lead"
+        values:
+          name: "Lead Without School"
+
+      - step: "Assert grade type is empty"
+        action: "assert"
+        target: "lead"
+        refresh: true
+        asserts:
+          school_id:
+            type: "value"
+            operator: "is_falsy"
+          grade_type_id:
+            type: "value"
+            operator: "is_falsy"

--- a/ssi_school_admission_lead/tests/test_data_lead_student_identity.yaml
+++ b/ssi_school_admission_lead/tests/test_data_lead_student_identity.yaml
@@ -1,53 +1,22 @@
 options:
   auto_refresh: true
 
-setup:
-  steps:
-    - step: "Setup - create grade type"
-      action: "create"
-      model: "school_grade_type"
-      save_as: "grade_type"
-      values:
-        name: "Grade Type Lead Student Identity"
-        code: "GTLSI"
-        sequence: 10
-
-    - step: "Setup - create school"
-      action: "create"
-      model: "school"
-      save_as: "school"
-      values:
-        name: "School Lead Student Identity"
-        code: "SCHLSI"
-        grade_type_id: "REC: grade_type.id"
-
-    - step: "Setup - create grade"
-      action: "create"
-      model: "school_grade"
-      save_as: "grade"
-      values:
-        name: "Grade Lead Student Identity"
-        code: "GLSI"
-        sequence: 10
-        type_id: "REC: grade_type.id"
-
-    - step: "Setup - create prospective student contact"
-      action: "create"
-      model: "res.partner"
-      save_as: "student_contact"
-      values:
-        name: "Student Lead Student Identity"
-
 scenarios:
   - name: "CRM Lead - Student identity written on the lead reaches the contact"
     steps:
+      - step: "Create prospective student contact"
+        action: "create"
+        model: "res.partner"
+        save_as: "student_contact"
+        values:
+          name: "Student Lead Write Identity"
+
       - step: "Create lead pointing to the prospective student"
         action: "create"
         model: "crm.lead"
         save_as: "lead"
         values:
           name: "Lead Write Student Identity"
-          school_id: "REC: school.id"
           student_id: "REC: student_contact.id"
 
       - step: "Write birthdate and gender on the lead"
@@ -71,6 +40,13 @@ scenarios:
 
   - name: "CRM Lead - Student identity written on the contact is read on the lead"
     steps:
+      - step: "Create prospective student contact"
+        action: "create"
+        model: "res.partner"
+        save_as: "student_contact"
+        values:
+          name: "Student Lead Read Identity"
+
       - step: "Create lead pointing to the prospective student"
         action: "create"
         model: "crm.lead"
@@ -135,7 +111,7 @@ scenarios:
           name: "Lead Gender Without Student"
           student_gender: "female"
 
-      - step: "Assert no error and no student identity is kept"
+      - step: "Assert the lead is created without error and keeps no identity"
         action: "assert"
         target: "lead"
         refresh: true
@@ -152,6 +128,34 @@ scenarios:
 
   - name: "CRM Lead - Grade type follows the school and restricts the grade"
     steps:
+      - step: "Create grade type"
+        action: "create"
+        model: "school_grade_type"
+        save_as: "grade_type"
+        values:
+          name: "Grade Type Lead Target Grade"
+          code: "GTLTG"
+          sequence: 10
+
+      - step: "Create school"
+        action: "create"
+        model: "school"
+        save_as: "school"
+        values:
+          name: "School Lead Target Grade"
+          code: "SCHLTG"
+          grade_type_id: "REC: grade_type.id"
+
+      - step: "Create grade"
+        action: "create"
+        model: "school_grade"
+        save_as: "grade"
+        values:
+          name: "Grade Lead Target Grade"
+          code: "GLTG"
+          sequence: 10
+          type_id: "REC: grade_type.id"
+
       - step: "Create lead with school"
         action: "create"
         model: "crm.lead"

--- a/ssi_school_admission_lead/tests/test_data_lead_student_identity.yaml
+++ b/ssi_school_admission_lead/tests/test_data_lead_student_identity.yaml
@@ -101,7 +101,7 @@ scenarios:
             type: "value"
             operator: "is_falsy"
 
-  - name: "CRM Lead - Student gender without a prospective student is not stored"
+  - name: "CRM Lead - Student gender without a prospective student reaches no contact"
     steps:
       - step: "Create lead with gender but without prospective student"
         action: "create"
@@ -111,7 +111,12 @@ scenarios:
           name: "Lead Gender Without Student"
           student_gender: "female"
 
-      - step: "Assert the lead is created without error and keeps no identity"
+      # Accepted hazard: the related field is stored, so the value given at
+      # create time stays on the lead column. There is no student contact to
+      # write it through to, so it is a local leftover that belongs to nobody.
+      # No constraint guards this on purpose - the portal is responsible for
+      # filling student_id before submitting.
+      - step: "Assert the lead is created without error and stays unlinked"
         action: "assert"
         target: "lead"
         refresh: true
@@ -124,7 +129,15 @@ scenarios:
             operator: "is_falsy"
           student_gender:
             type: "value"
-            operator: "is_falsy"
+            expected: "female"
+
+      - step: "Assert no contact was given that gender"
+        action: "search"
+        model: "res.partner"
+        domain:
+          [["gender", "=", "female"], ["name", "=", "Lead Gender Without Student"]]
+        save_as: "leftover_contacts"
+        expect_count: 0
 
   - name: "CRM Lead - Grade type follows the school and restricts the grade"
     steps:

--- a/ssi_school_admission_lead/views/crm_lead.xml
+++ b/ssi_school_admission_lead/views/crm_lead.xml
@@ -25,6 +25,22 @@
                 <field name="admission_form_id" />
                 <field name="admission_test_id" />
             </xpath>
+            <xpath expr="//group[@name='opportunity_partner']" position="after">
+                <group
+                        name="school_admission_lead_student_identity"
+                        string="Prospective Student"
+                    >
+                    <field name="student_birthdate" />
+                    <field name="student_gender" />
+                </group>
+                <group
+                        name="school_admission_lead_target_grade"
+                        string="Admission Target"
+                    >
+                    <field name="grade_type_id" invisible="1" />
+                    <field name="grade_id" domain="[('type_id', '=', grade_type_id)]" />
+                </group>
+            </xpath>
             <xpath
                     expr="//header/button[@name='action_create_admission']"
                     position="before"


### PR DESCRIPTION
Menambahkan field Lapis 1 SPMB (Identitas & Kelayakan) pada `crm.lead`.

## Perubahan

* `student_birthdate` — related `student_id.birthdate_date`, `store=True`, `readonly=False`, `compute_sudo=True`
* `student_gender` — related `student_id.gender`, `store=True`, `readonly=False`, `compute_sudo=True`
* `grade_type_id` — related `school_id.grade_type_id` (tidak disimpan), pembatas pilihan `grade_id`
* `grade_id` — Many2one ke `school_grade`, `ondelete="restrict"`, `tracking=True`, domain `[('type_id', '=', grade_type_id)]`
* Form view `crm.lead`: dua `<group>` terpisah — "Prospective Student" (`student_birthdate`, `student_gender`) dan "Admission Target" (`grade_type_id`, `grade_id`)
* Unit test skenario `odoo-yaml-test` untuk tulis-tembus/baca related, kondisi `student_id` kosong, dan penurunan `grade_type_id` dari `school_id`
* Perbarui `README.rst`

Data identitas orang tersimpan di `res.partner`, tidak diduplikasi di lead. Tidak ada ACL/record rule baru dan tidak ada dependensi manifest baru.

Closes #138