### PR TITLE
[UPD] ssi_school_lead: kelompokkan field CRM lead ke group tematik

### DIFF
--- a/ssi_school_admission_lead/tests/__init__.py
+++ b/ssi_school_admission_lead/tests/__init__.py
@@ -4,3 +4,4 @@
 
 from . import test_crm_lead_admission  # noqa: F401
 from . import test_crm_lead_student_identity  # noqa: F401
+from . import test_crm_lead_view_architecture  # noqa: F401

--- a/ssi_school_admission_lead/tests/test_crm_lead_view_architecture.py
+++ b/ssi_school_admission_lead/tests/test_crm_lead_view_architecture.py
@@ -1,0 +1,89 @@
+# Copyright 2026 OpenSynergy Indonesia
+# Copyright 2026 PT. Simetri Sinergi Indonesia
+# License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl).
+
+from lxml import etree
+from odoo_yaml_test import YamlTransactionCase
+
+from odoo.tests import tagged
+
+
+@tagged("post_install", "-at_install")
+class TestCrmLeadViewArchitecture(YamlTransactionCase):
+    """Python murni — pemicu P1 (L-01: `action: call` membuang nilai balik method).
+
+    Tata letak view (posisi field di dalam sebuah `<group>`) bukan permukaan yang
+    dapat diekspresikan DSL `odoo-yaml-test` — tidak ada aksi YAML yang membaca arch
+    hasil `fields_view_get`. Regresi ini memanggil `fields_view_get` langsung dan
+    memeriksa nilai balik `arch` yang dikembalikan method tersebut.
+    """
+
+    def setUp(self):
+        super().setUp()
+        result = self.env["crm.lead"].fields_view_get(view_type="form")
+        self.arch = etree.fromstring(result["arch"])
+
+    def _group(self, name):
+        groups = self.arch.xpath("//group[@name='%s']" % name)
+        self.assertTrue(groups, "Group '%s' should exist in the form arch" % name)
+        return groups[0]
+
+    def test_prospective_student_group_contains_expected_fields_in_order(self):
+        group = self._group("school_lead_prospective_student")
+        field_names = [f.get("name") for f in group.xpath(".//field")]
+        self.assertEqual(
+            field_names,
+            ["student_id", "student_birthdate", "student_gender"],
+            "Prospective Student group should list student_id, student_birthdate, "
+            "student_gender in that order",
+        )
+
+    def test_admission_target_group_contains_expected_fields_in_order(self):
+        group = self._group("school_lead_admission_target")
+        field_names = [f.get("name") for f in group.xpath(".//field")]
+        self.assertEqual(
+            field_names,
+            ["school_id", "grade_type_id", "grade_id"],
+            "Admission Target group should list school_id, grade_type_id, "
+            "grade_id in that order",
+        )
+        grade_id_field = group.xpath(".//field[@name='grade_id']")[0]
+        self.assertEqual(
+            grade_id_field.get("domain"),
+            "[('type_id', '=', grade_type_id)]",
+            "grade_id should keep its domain filtering by grade_type_id",
+        )
+
+    def test_admission_document_group_contains_expected_fields(self):
+        group = self._group("school_lead_admission_document")
+        field_names = [f.get("name") for f in group.xpath(".//field")]
+        self.assertIn("admission_id", field_names)
+        self.assertIn("admission_form_id", field_names)
+        self.assertIn("admission_test_id", field_names)
+
+    def test_module_specific_thematic_groups_are_removed(self):
+        for group_name in (
+            "school_admission_lead_student_identity",
+            "school_admission_lead_target_grade",
+        ):
+            groups = self.arch.xpath("//group[@name='%s']" % group_name)
+            self.assertFalse(
+                groups,
+                "Group '%s' should no longer be defined by "
+                "ssi_school_admission_lead" % group_name,
+            )
+
+    def test_admission_fields_are_not_inserted_into_crm_partner_groups(self):
+        for group_name in ("lead_partner", "opportunity_partner"):
+            group = self._group(group_name)
+            field_names = [f.get("name") for f in group.xpath(".//field")]
+            self.assertNotIn(
+                "admission_form_id",
+                field_names,
+                "admission_form_id should not be a child of '%s'" % group_name,
+            )
+            self.assertNotIn(
+                "admission_test_id",
+                field_names,
+                "admission_test_id should not be a child of '%s'" % group_name,
+            )

--- a/ssi_school_admission_lead/views/crm_lead.xml
+++ b/ssi_school_admission_lead/views/crm_lead.xml
@@ -11,35 +11,26 @@
     <field name="arch" type="xml">
         <data>
             <xpath
-                    expr="//group[@name='opportunity_partner']//field[@name='student_id']"
+                    expr="//group[@name='school_lead_prospective_student']//field[@name='student_id']"
+                    position="after"
+                >
+                <field name="student_birthdate" />
+                <field name="student_gender" />
+            </xpath>
+            <xpath
+                    expr="//group[@name='school_lead_admission_target']//field[@name='school_id']"
+                    position="after"
+                >
+                <field name="grade_type_id" invisible="1" />
+                <field name="grade_id" domain="[('type_id', '=', grade_type_id)]" />
+            </xpath>
+            <xpath
+                    expr="//group[@name='school_lead_admission_document']//field[@name='admission_id']"
                     position="after"
                 >
                 <field name="admission_form_id" />
                 <field name="admission_test_id" />
                 <field name="create_admission_form_ok" invisible="1" />
-            </xpath>
-            <xpath
-                    expr="//group[@name='lead_partner']//field[@name='student_id']"
-                    position="after"
-                >
-                <field name="admission_form_id" />
-                <field name="admission_test_id" />
-            </xpath>
-            <xpath expr="//group[@name='opportunity_partner']" position="after">
-                <group
-                        name="school_admission_lead_student_identity"
-                        string="Prospective Student"
-                    >
-                    <field name="student_birthdate" />
-                    <field name="student_gender" />
-                </group>
-                <group
-                        name="school_admission_lead_target_grade"
-                        string="Admission Target"
-                    >
-                    <field name="grade_type_id" invisible="1" />
-                    <field name="grade_id" domain="[('type_id', '=', grade_type_id)]" />
-                </group>
             </xpath>
             <xpath
                     expr="//header/button[@name='action_create_admission']"

--- a/ssi_school_lead/tests/test_school_lead.py
+++ b/ssi_school_lead/tests/test_school_lead.py
@@ -2,6 +2,7 @@
 # Copyright 2024 PT. Simetri Sinergi Indonesia
 # License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl).
 
+from lxml import etree
 from odoo_yaml_test import YamlTransactionCase
 
 from odoo.tests import Form, tagged
@@ -222,3 +223,56 @@ class TestSchoolLead(YamlTransactionCase):
         self.assertTrue(admission)
         self.assertEqual(admission.receivable_journal_id, journal)
         self.assertEqual(admission.receivable_account_id, account)
+
+    def test_crm_lead_form_view_groups_school_fields(self):
+        """Python murni — pemicu P1 (L-01): tata letak view (arch hasil
+        `fields_view_get`) bukan permukaan yang bisa dibaca DSL `odoo-yaml-test`,
+        dan `action: call` membuang nilai balik method.
+
+        `student_id` harus berada di group `school_lead_prospective_student`,
+        `school_id` di `school_lead_admission_target`, dan `admission_id` di
+        `school_lead_admission_document` — bukan lagi anak langsung dari group
+        bawaan CRM `lead_partner`/`opportunity_partner`, yang tetap memuat
+        `partner_id` dan berjudul `Parent/Guardian`.
+        """
+        result = self.env["crm.lead"].fields_view_get(view_type="form")
+        arch = etree.fromstring(result["arch"])
+
+        for group_name, expected_string, expected_fields in (
+            ("school_lead_prospective_student", "Prospective Student", ["student_id"]),
+            ("school_lead_admission_target", "Admission Target", ["school_id"]),
+            (
+                "school_lead_admission_document",
+                "Admission Document",
+                ["admission_id", "create_admission_ok"],
+            ),
+        ):
+            group = arch.find(".//group[@name='%s']" % group_name)
+            self.assertIsNotNone(group, "Group %s not found in arch" % group_name)
+            self.assertEqual(group.get("string"), expected_string)
+            child_field_names = [
+                field.get("name") for field in group.findall("./field")
+            ]
+            self.assertEqual(sorted(child_field_names), sorted(expected_fields))
+
+        school_field_names = {
+            "school_id",
+            "student_id",
+            "admission_id",
+            "create_admission_ok",
+        }
+        for partner_group_name in ("lead_partner", "opportunity_partner"):
+            group = arch.find(".//group[@name='%s']" % partner_group_name)
+            self.assertIsNotNone(
+                group, "Group %s not found in arch" % partner_group_name
+            )
+            self.assertEqual(group.get("string"), "Parent/Guardian")
+            child_field_names = {
+                field.get("name") for field in group.findall("./field")
+            }
+            self.assertIn("partner_id", child_field_names)
+            self.assertFalse(
+                child_field_names & school_field_names,
+                "School fields leaked into group %s: %s"
+                % (partner_group_name, child_field_names & school_field_names),
+            )

--- a/ssi_school_lead/tests/test_school_lead.py
+++ b/ssi_school_lead/tests/test_school_lead.py
@@ -234,11 +234,17 @@ class TestSchoolLead(YamlTransactionCase):
         `school_lead_admission_document` — bukan lagi anak langsung dari group
         bawaan CRM `lead_partner`/`opportunity_partner`, yang tetap memuat
         `partner_id` dan berjudul `Parent/Guardian`.
+
+        Ketiga nama group ini adalah kontrak publik yang sengaja diperluas modul
+        lain (mis. `ssi_school_admission_lead`) lewat `xpath`, sehingga assertion
+        di sini memeriksa **keberadaan** (`assertIn`) field wajib milik
+        `ssi_school_lead`, bukan daftar tertutup — sesuai Skenario Uji #147
+        ("arch form memuat ...").
         """
         result = self.env["crm.lead"].fields_view_get(view_type="form")
         arch = etree.fromstring(result["arch"])
 
-        for group_name, expected_string, expected_fields in (
+        for group_name, expected_string, required_fields in (
             ("school_lead_prospective_student", "Prospective Student", ["student_id"]),
             ("school_lead_admission_target", "Admission Target", ["school_id"]),
             (
@@ -253,7 +259,12 @@ class TestSchoolLead(YamlTransactionCase):
             child_field_names = [
                 field.get("name") for field in group.findall("./field")
             ]
-            self.assertEqual(sorted(child_field_names), sorted(expected_fields))
+            for required_field in required_fields:
+                self.assertIn(
+                    required_field,
+                    child_field_names,
+                    "Group %s should contain field %s" % (group_name, required_field),
+                )
 
         school_field_names = {
             "school_id",

--- a/ssi_school_lead/views/crm_lead_views.xml
+++ b/ssi_school_lead/views/crm_lead_views.xml
@@ -10,22 +10,29 @@
 
     <field name="arch" type="xml">
         <data>
-            <xpath
-                    expr="//group[@name='opportunity_partner']//field[@name='partner_id']"
-                    position="after"
-                >
-                <field name="school_id" />
-                <field name="student_id" />
-                <field name="admission_id" />
-                <field name="create_admission_ok" invisible="1" />
+            <xpath expr="//group[@name='lead_partner']" position="attributes">
+                <attribute name="string">Parent/Guardian</attribute>
             </xpath>
-            <xpath
-                    expr="//group[@name='lead_partner']//field[@name='partner_id']"
-                    position="after"
-                >
-                <field name="school_id" />
-                <field name="student_id" />
-                <field name="admission_id" />
+            <xpath expr="//group[@name='opportunity_partner']" position="attributes">
+                <attribute name="string">Parent/Guardian</attribute>
+            </xpath>
+            <xpath expr="//group[@name='opportunity_partner']" position="after">
+                <group
+                        name="school_lead_prospective_student"
+                        string="Prospective Student"
+                    >
+                    <field name="student_id" />
+                </group>
+                <group name="school_lead_admission_target" string="Admission Target">
+                    <field name="school_id" />
+                </group>
+                <group
+                        name="school_lead_admission_document"
+                        string="Admission Document"
+                    >
+                    <field name="admission_id" />
+                    <field name="create_admission_ok" invisible="1" />
+                </group>
             </xpath>
             <xpath expr="//header" position="inside">
                 <button


### PR DESCRIPTION
## Ringkasan

- Retitle group bawaan CRM `lead_partner` dan `opportunity_partner` menjadi `Parent/Guardian`.
- Keluarkan `school_id`, `student_id`, `admission_id`, dan `create_admission_ok` dari kedua group tersebut.
- Tambahkan tiga group tematik baru pada form `crm.lead`:
  - `school_lead_prospective_student` ("Prospective Student") — `student_id`
  - `school_lead_admission_target` ("Admission Target") — `school_id`
  - `school_lead_admission_document` ("Admission Document") — `admission_id`, `create_admission_ok`
- Tambahkan regresi Python murni (`fields_view_get`) yang memverifikasi arch hasil sesuai keputusan desain issue.
- Pindahkan field `ssi_school_admission_lead` (`student_birthdate`, `student_gender`, `grade_type_id`, `grade_id`, `admission_form_id`, `admission_test_id`, `create_admission_form_ok`) ke group tematik `ssi_school_lead` di atas, menghapus dua group duplikat serta xpath ke group partner bawaan CRM yang jadi tidak valid setelah perubahan `ssi_school_lead`.

Closes #147
Closes #148

## Test plan

- [x] Unit test baru ditulis (`test_crm_lead_form_view_groups_school_fields`, `TestCrmLeadViewArchitecture`), dijalankan di CI.
- [ ] CI hijau (menunggu hasil).
