### PR TITLE
[UPD] ssi_school_admission: lewati jurnal & langsung done saat approve formulir gratis

### DIFF
--- a/ssi_school_admission/models/school_admission_form.py
+++ b/ssi_school_admission/models/school_admission_form.py
@@ -5,6 +5,7 @@
 from datetime import date as datetime_date
 
 from odoo import api, fields, models
+from odoo.tools import float_is_zero
 
 from odoo.addons.ssi_decorator import ssi_decorator
 
@@ -327,11 +328,27 @@ class SchoolAdmissionForm(models.Model):
         for record in self:
             record._recompute_standard_tax()  # pylint: disable=protected-access
 
+    def _is_free_admission_form(self):
+        """Return whether this admission form has zero total fee.
+
+        A free admission form has no fee to be billed, so no accounting
+        entry is relevant and the form can go straight to "done" once the
+        document number is created.
+        """
+        self.ensure_one()
+        return float_is_zero(
+            self.amount_total,
+            precision_rounding=self.currency_id.rounding,
+        )
+
     @ssi_decorator.post_open_action()
     def _10_create_accounting_entry(
         self,
     ):  # pylint: disable=inconsistent-return-statements
         self.ensure_one()
+
+        if self._is_free_admission_form():
+            return True
 
         if self.move_id:
             return True
@@ -360,6 +377,15 @@ class SchoolAdmissionForm(models.Model):
             tax._create_standard_ml()  # Mixin
 
         self._post_standard_move()  # Mixin
+
+    @ssi_decorator.post_open_action()
+    def _20_auto_done_if_free(self):
+        self.ensure_one()
+
+        if not self._is_free_admission_form():
+            return True
+
+        self.sudo().action_done()
 
     @ssi_decorator.post_cancel_action()
     def _delete_accounting_entry(self):

--- a/ssi_school_admission/tests/test_data_admission_form.yaml
+++ b/ssi_school_admission/tests/test_data_admission_form.yaml
@@ -344,3 +344,183 @@ scenarios:
         target: "admission_form"
         method: "action_create_admission_test"
         as_user: "base.user_admin"
+
+  - name: "Admission Form - Free Form Auto Done on Approve"
+    steps:
+      - step: "Setup - get sale journal"
+        action: "search"
+        model: "account.journal"
+        domain: [["type", "=", "sale"]]
+        save_as: "journal"
+        limit: 1
+
+      - step: "Setup - get account type ref"
+        action: "ref"
+        xml_id: "account.data_account_type_revenue"
+        save_as: "account_type"
+
+      - step: "Setup - create income account"
+        action: "create"
+        model: "account.account"
+        save_as: "account"
+        values:
+          name: "Admission Form Fee Income AFFREE"
+          code: "AFFREE4200"
+          user_type_id: "EVAL: registry['account_type'].id"
+
+      - step: "Setup - create pricelist"
+        action: "create"
+        model: "product.pricelist"
+        save_as: "pricelist"
+        values:
+          name: "Pricelist AFFREE"
+          currency_id: "EVAL: env.company.currency_id.id"
+
+      - step: "Setup - create grade type"
+        action: "create"
+        model: "school_grade_type"
+        save_as: "grade_type"
+        values:
+          name: "Grade Type AFFREE"
+          code: "GTAFFREE"
+          sequence: 10
+
+      - step: "Setup - create academic year"
+        action: "create"
+        model: "school_academic_year"
+        save_as: "academic_year"
+        values:
+          name: "2024/2025 AFFREE"
+          code: "AYAFFREE"
+          date_start: "2024-07-01"
+          date_end: "2025-06-30"
+
+      - step: "Setup - create academic term"
+        action: "create"
+        model: "school_academic_term"
+        save_as: "academic_term"
+        values:
+          name: "Semester AFFREE"
+          code: "SMAFFREE"
+          date_start: "2024-07-01"
+          date_end: "2025-06-30"
+          year_id: "EVAL: registry['academic_year'].id"
+          enrollment_state: "open"
+
+      - step: "Setup - create school"
+        action: "create"
+        model: "school"
+        save_as: "school"
+        values:
+          name: "School AFFREE"
+          code: "SCHAFFREE"
+          grade_type_id: "EVAL: registry['grade_type'].id"
+
+      - step: "Setup - create grade"
+        action: "create"
+        model: "school_grade"
+        save_as: "grade"
+        values:
+          name: "Grade AFFREE"
+          code: "GAFFREE"
+          sequence: 10
+          type_id: "EVAL: registry['grade_type'].id"
+
+      - step: "Setup - create student contact"
+        action: "create"
+        model: "res.partner"
+        save_as: "student_contact"
+        values:
+          name: "Student Contact AFFREE"
+
+      - step: "Setup - create parent contact"
+        action: "create"
+        model: "res.partner"
+        save_as: "parent_contact"
+        values:
+          name: "Parent Contact AFFREE"
+
+      - step: "Create admission form without fee lines (free form)"
+        action: "create"
+        model: "school_admission_form"
+        save_as: "admission_form"
+        as_user: "base.user_admin"
+        values:
+          date: "2024-07-01"
+          academic_year_id: "EVAL: registry['academic_year'].id"
+          academic_term_id: "EVAL: registry['academic_term'].id"
+          school_id: "EVAL: registry['school'].id"
+          grade_id: "EVAL: registry['grade'].id"
+          student_id: "EVAL: registry['student_contact'].id"
+          parent_id: "EVAL: registry['parent_contact'].id"
+          pricelist_id: "EVAL: registry['pricelist'].id"
+          currency_id: "EVAL: env.company.currency_id.id"
+          journal_id: "EVAL: registry['journal'].id"
+          account_id: "EVAL: registry['account'].id"
+
+      - step: "Assert amount_total is zero (no fee lines)"
+        action: "assert"
+        target: "admission_form"
+        asserts:
+          amount_total:
+            type: "value"
+            expected: 0.0
+
+      - step: "Confirm free admission form"
+        action: "call"
+        target: "admission_form"
+        method: "action_confirm"
+        as_user: "base.user_admin"
+        asserts:
+          state:
+            type: "value"
+            expected: "confirm"
+
+      - step: "Invalidate admission form cache before approve"
+        action: "call"
+        target: "admission_form"
+        method: "invalidate_cache"
+
+      - step: "Approve free admission form (auto-done, no journal entry)"
+        action: "call"
+        target: "admission_form"
+        method: "action_approve_approval"
+        as_user: "base.user_admin"
+        asserts:
+          state:
+            type: "value"
+            expected: "done"
+
+      - step: "Invalidate admission form cache after auto-done"
+        action: "call"
+        target: "admission_form"
+        method: "invalidate_cache"
+
+      - step: "Assert no accounting entry created for free form"
+        action: "assert"
+        target: "admission_form"
+        asserts:
+          move_id:
+            type: "value"
+            operator: "is_falsy"
+
+      - step: "Assert document number is generated for free form"
+        action: "assert"
+        target: "admission_form"
+        asserts:
+          name:
+            type: "value"
+            operator: "not_equals"
+            expected: "/"
+
+      - step: "Cancel done free admission form does not error"
+        action: "call"
+        target: "admission_form"
+        method: "action_cancel"
+        as_user: "base.user_admin"
+        context:
+          bypass_policy_check: true
+        asserts:
+          state:
+            type: "value"
+            expected: "cancel"


### PR DESCRIPTION
## Ringkasan

Formulir pendaftaran (`school_admission_form`) yang gratis (`amount_total = 0`, diuji dengan
`float_is_zero` presisi `currency_id`) kini:

- **Tidak** membuat `account.move` saat disetujui (guard di `_10_create_accounting_entry`).
- **Langsung berakhir di state `done`** lewat `post_open_action` baru `_20_auto_done_if_free`
  (berjalan setelah `_10_` karena urutan alfabetis `getmembers`), memakai `self.sudo().action_done()`.
- **Tetap memperoleh nomor dokumen** karena `_create_sequence_state = "open"` tidak diubah —
  record tetap melintasi state `open` (tempat sequence dibuat) sebelum auto-done.

Definisi "gratis" tunggal lewat method baru `_is_free_admission_form()` (dapat di-override),
tanpa field/checkbox baru.

Formulir berbayar tidak berubah perilakunya: tetap berhenti di `open` dengan `move_id` terisi,
menunggu `realized` via base.automation seperti sebelumnya.

## Unit Test

Skenario baru di `test_data_admission_form.yaml`:
- Formulir gratis (tanpa fee line) → confirm → approve → `state == "done"`, `move_id` kosong,
  `name` terisi (bukan `/`), dan cancel dari state `done` tidak error.
- Regresi: skenario existing formulir berbayar tetap diassert `state == "open"` dengan
  `move_id` terisi (tidak melompat ke `done`).

Closes #156