### PR TITLE
[UPD] ssi_school_admission_lead_operating_unit

### DIFF
--- a/ssi_school_admission_lead_operating_unit/__manifest__.py
+++ b/ssi_school_admission_lead_operating_unit/__manifest__.py
@@ -23,6 +23,9 @@
         "ssi_school_admission_lead",
         "ssi_school_admission_operating_unit",
     ],
-    "data": [],
+    "data": [
+        "views/crm_lead_create_admission_form.xml",
+        "views/crm_lead_create_admission.xml",
+    ],
     "demo": [],
 }

--- a/ssi_school_admission_lead_operating_unit/tests/__init__.py
+++ b/ssi_school_admission_lead_operating_unit/tests/__init__.py
@@ -1,0 +1,5 @@
+# Copyright 2026 OpenSynergy Indonesia
+# Copyright 2026 PT. Simetri Sinergi Indonesia
+# License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl).
+
+from . import test_crm_lead_create_admission_operating_unit  # noqa: F401

--- a/ssi_school_admission_lead_operating_unit/tests/test_crm_lead_create_admission_operating_unit.py
+++ b/ssi_school_admission_lead_operating_unit/tests/test_crm_lead_create_admission_operating_unit.py
@@ -1,0 +1,17 @@
+# Copyright 2026 OpenSynergy Indonesia
+# Copyright 2026 PT. Simetri Sinergi Indonesia
+# License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl).
+
+from odoo_yaml_test import YamlTransactionCase
+
+from odoo.tests import tagged
+
+
+@tagged("post_install", "-at_install")
+class TestCrmLeadCreateAdmissionOperatingUnit(
+    YamlTransactionCase
+):  # pylint: disable=too-few-public-methods
+    def test_crm_lead_create_admission_operating_unit(self):
+        self.run_yaml_scenario(
+            "test_data_crm_lead_create_admission_operating_unit.yaml"
+        )

--- a/ssi_school_admission_lead_operating_unit/tests/test_data_crm_lead_create_admission_operating_unit.yaml
+++ b/ssi_school_admission_lead_operating_unit/tests/test_data_crm_lead_create_admission_operating_unit.yaml
@@ -1,0 +1,401 @@
+scenarios:
+  - name: "Create Admission Form from Lead - operating_unit_id defaulted from lead"
+    steps:
+      - step: "Get main company operating unit"
+        action: "search"
+        model: "operating.unit"
+        domain: [["company_id", "=", "REF: base.main_company"]]
+        save_as: "operating_unit"
+        limit: 1
+
+      - step: "Setup - get sale journal"
+        action: "search"
+        model: "account.journal"
+        domain: [["type", "=", "sale"]]
+        save_as: "journal"
+        limit: 1
+
+      - step: "Setup - get account type ref"
+        action: "ref"
+        xml_id: "account.data_account_type_revenue"
+        save_as: "account_type"
+
+      - step: "Setup - create income account"
+        action: "create"
+        model: "account.account"
+        save_as: "account"
+        values:
+          name: "Admission Form Lead OU Fee Income"
+          code: "ADMLFOU1"
+          user_type_id: "REC: account_type.id"
+
+      - step: "Setup - create pricelist"
+        action: "create"
+        model: "product.pricelist"
+        save_as: "pricelist"
+        values:
+          name: "Pricelist Admission Lead OU 1"
+          currency_id: "REC: company.currency_id.id"
+
+      - step: "Setup - create grade type"
+        action: "create"
+        model: "school_grade_type"
+        save_as: "grade_type"
+        values:
+          name: "Grade Type Admission Lead OU 1"
+          code: "GTLDFOU1"
+          sequence: 10
+
+      - step: "Setup - create school"
+        action: "create"
+        model: "school"
+        save_as: "school"
+        values:
+          name: "School Admission Lead OU 1"
+          code: "SCHLDFOU1"
+          grade_type_id: "REC: grade_type.id"
+
+      - step: "Setup - create grade"
+        action: "create"
+        model: "school_grade"
+        save_as: "grade"
+        values:
+          name: "Grade Admission Lead OU 1"
+          code: "GLDFOU1"
+          sequence: 10
+          type_id: "REC: grade_type.id"
+
+      - step: "Setup - create academic year"
+        action: "create"
+        model: "school_academic_year"
+        save_as: "academic_year"
+        values:
+          name: "2025/2026 Admission Lead OU 1"
+          code: "AYLDFOU1"
+          date_start: "2025-07-01"
+          date_end: "2026-06-30"
+
+      - step: "Setup - create academic term"
+        action: "create"
+        model: "school_academic_term"
+        save_as: "academic_term"
+        values:
+          name: "Semester Admission Lead OU 1"
+          code: "SMLDFOU1"
+          date_start: "2025-07-01"
+          date_end: "2025-12-31"
+          year_id: "REC: academic_year.id"
+          enrollment_state: "open"
+          is_open_admission: true
+
+      - step: "Setup - create student contact"
+        action: "create"
+        model: "res.partner"
+        save_as: "student"
+        values:
+          name: "Student Admission Lead OU 1"
+
+      - step: "Setup - create parent contact"
+        action: "create"
+        model: "res.partner"
+        save_as: "parent"
+        values:
+          name: "Parent Admission Lead OU 1"
+
+      - step: "Setup - create fee template"
+        action: "create"
+        model: "school_admission_fee_template"
+        save_as: "fee_template"
+        values:
+          name: "Fee Template Admission Lead OU 1"
+          code: "FTLDFOU1"
+          journal_id: "REC: journal.id"
+          account_id: "REC: account.id"
+
+      - step: "Create lead with operating unit"
+        action: "create"
+        model: "crm.lead"
+        save_as: "lead"
+        values:
+          name: "Lead Admission Form OU 1"
+          operating_unit_id: "REC: operating_unit.id"
+
+      - step: "Open Create Admission Form wizard with lead's context"
+        action: "form"
+        model: "crm.lead.create_admission_form"
+        save_as: "wizard"
+        context:
+          default_lead_id: "REC: lead.id"
+          default_operating_unit_id: "REC: lead.operating_unit_id.id"
+        values:
+          date: "2025-07-15"
+          academic_year_id: "REC: academic_year"
+          academic_term_id: "REC: academic_term"
+          school_id: "REC: school"
+          grade_id: "REC: grade"
+          student_id: "REC: student"
+          parent_id: "REC: parent"
+          pricelist_id: "REC: pricelist"
+          fee_template_id: "REC: fee_template"
+        asserts:
+          operating_unit_id:
+            type: "m2o"
+            expected: "REC: operating_unit"
+        save: true
+
+      - step: "Confirm the wizard"
+        action: "call"
+        target: "wizard"
+        method: "action_confirm"
+
+      - step: "Fetch the admission form created for this student"
+        action: "search"
+        model: "school_admission_form"
+        domain: [["student_id", "=", "REC: student.id"]]
+        save_as: "created_form"
+        limit: 1
+
+      - step: "Assert admission form created has the lead's operating unit"
+        action: "assert"
+        target: "created_form"
+        asserts:
+          operating_unit_id:
+            type: "m2o"
+            expected: "REC: operating_unit"
+
+  - name: "Create Admission from Lead - operating_unit_id defaulted from lead"
+    steps:
+      - step: "Get main company operating unit"
+        action: "search"
+        model: "operating.unit"
+        domain: [["company_id", "=", "REF: base.main_company"]]
+        save_as: "operating_unit"
+        limit: 1
+
+      - step: "Setup - create grade type"
+        action: "create"
+        model: "school_grade_type"
+        save_as: "grade_type"
+        values:
+          name: "Grade Type Admission Lead OU 2"
+          code: "GTLDAOU2"
+          sequence: 10
+
+      - step: "Setup - create school"
+        action: "create"
+        model: "school"
+        save_as: "school"
+        values:
+          name: "School Admission Lead OU 2"
+          code: "SCHLDAOU2"
+          grade_type_id: "REC: grade_type.id"
+
+      - step: "Setup - create grade"
+        action: "create"
+        model: "school_grade"
+        save_as: "grade"
+        values:
+          name: "Grade Admission Lead OU 2"
+          code: "GLDAOU2"
+          sequence: 10
+          type_id: "REC: grade_type.id"
+
+      - step: "Setup - create academic year"
+        action: "create"
+        model: "school_academic_year"
+        save_as: "academic_year"
+        values:
+          name: "2025/2026 Admission Lead OU 2"
+          code: "AYLDAOU2"
+          date_start: "2025-07-01"
+          date_end: "2026-06-30"
+
+      - step: "Setup - create academic term"
+        action: "create"
+        model: "school_academic_term"
+        save_as: "academic_term"
+        values:
+          name: "Semester Admission Lead OU 2"
+          code: "SMLDAOU2"
+          date_start: "2025-07-01"
+          date_end: "2025-12-31"
+          year_id: "REC: academic_year.id"
+          enrollment_state: "open"
+          is_open_admission: true
+
+      - step: "Setup - create student contact"
+        action: "create"
+        model: "res.partner"
+        save_as: "student"
+        values:
+          name: "Student Admission Lead OU 2"
+
+      - step: "Create lead with operating unit"
+        action: "create"
+        model: "crm.lead"
+        save_as: "lead"
+        values:
+          name: "Lead Admission OU 2"
+          operating_unit_id: "REC: operating_unit.id"
+
+      - step: "Open Create Admission wizard with lead's context"
+        action: "form"
+        model: "crm.lead.create_admission"
+        save_as: "wizard"
+        context:
+          default_lead_id: "REC: lead.id"
+          default_operating_unit_id: "REC: lead.operating_unit_id.id"
+        values:
+          date: "2025-07-15"
+          academic_year_id: "REC: academic_year"
+          academic_term_id: "REC: academic_term"
+          school_id: "REC: school"
+          grade_id: "REC: grade"
+          student_id: "REC: student"
+        asserts:
+          operating_unit_id:
+            type: "m2o"
+            expected: "REC: operating_unit"
+        save: true
+
+      - step: "Confirm the wizard"
+        action: "call"
+        target: "wizard"
+        method: "action_confirm"
+
+      - step: "Fetch the admission created for this student"
+        action: "search"
+        model: "school_admission"
+        domain: [["student_id", "=", "REC: student.id"]]
+        save_as: "created_admission"
+        limit: 1
+
+      - step: "Assert admission created has the lead's operating unit"
+        action: "assert"
+        target: "created_admission"
+        asserts:
+          operating_unit_id:
+            type: "m2o"
+            expected: "REC: operating_unit"
+
+  - name:
+      "Create Admission from Lead - empty operating_unit_id is not forced onto document"
+    steps:
+      - step: "Get main company operating unit"
+        action: "search"
+        model: "operating.unit"
+        domain: [["company_id", "=", "REF: base.main_company"]]
+        save_as: "operating_unit"
+        limit: 1
+
+      - step: "Give the executing user a default operating unit"
+        action: "write"
+        target: "user"
+        values:
+          default_operating_unit_id: "REC: operating_unit.id"
+
+      - step: "Setup - create grade type"
+        action: "create"
+        model: "school_grade_type"
+        save_as: "grade_type"
+        values:
+          name: "Grade Type Admission Lead OU 3"
+          code: "GTLDAOU3"
+          sequence: 10
+
+      - step: "Setup - create school"
+        action: "create"
+        model: "school"
+        save_as: "school"
+        values:
+          name: "School Admission Lead OU 3"
+          code: "SCHLDAOU3"
+          grade_type_id: "REC: grade_type.id"
+
+      - step: "Setup - create grade"
+        action: "create"
+        model: "school_grade"
+        save_as: "grade"
+        values:
+          name: "Grade Admission Lead OU 3"
+          code: "GLDAOU3"
+          sequence: 10
+          type_id: "REC: grade_type.id"
+
+      - step: "Setup - create academic year"
+        action: "create"
+        model: "school_academic_year"
+        save_as: "academic_year"
+        values:
+          name: "2025/2026 Admission Lead OU 3"
+          code: "AYLDAOU3"
+          date_start: "2025-07-01"
+          date_end: "2026-06-30"
+
+      - step: "Setup - create academic term"
+        action: "create"
+        model: "school_academic_term"
+        save_as: "academic_term"
+        values:
+          name: "Semester Admission Lead OU 3"
+          code: "SMLDAOU3"
+          date_start: "2025-07-01"
+          date_end: "2025-12-31"
+          year_id: "REC: academic_year.id"
+          enrollment_state: "open"
+          is_open_admission: true
+
+      - step: "Setup - create student contact"
+        action: "create"
+        model: "res.partner"
+        save_as: "student"
+        values:
+          name: "Student Admission Lead OU 3"
+
+      - step: "Create lead without operating unit"
+        action: "create"
+        model: "crm.lead"
+        save_as: "lead"
+        values:
+          name: "Lead Admission OU 3"
+          operating_unit_id: false
+
+      - step: "Open Create Admission wizard with lead's empty context"
+        action: "form"
+        model: "crm.lead.create_admission"
+        save_as: "wizard"
+        context:
+          default_lead_id: "REC: lead.id"
+          default_operating_unit_id: "REC: lead.operating_unit_id.id"
+        values:
+          date: "2025-07-15"
+          academic_year_id: "REC: academic_year"
+          academic_term_id: "REC: academic_term"
+          school_id: "REC: school"
+          grade_id: "REC: grade"
+          student_id: "REC: student"
+        asserts:
+          operating_unit_id:
+            type: "value"
+            operator: "is_falsy"
+        save: true
+
+      - step: "Confirm the wizard - must not fail even with empty operating unit"
+        action: "call"
+        target: "wizard"
+        method: "action_confirm"
+
+      - step: "Fetch the admission created for this student"
+        action: "search"
+        model: "school_admission"
+        domain: [["student_id", "=", "REC: student.id"]]
+        save_as: "created_admission"
+        limit: 1
+
+      - step: "Assert admission keeps the mixin default, not forced empty"
+        action: "assert"
+        target: "created_admission"
+        asserts:
+          operating_unit_id:
+            type: "m2o"
+            expected: "REC: operating_unit"

--- a/ssi_school_admission_lead_operating_unit/views/crm_lead_create_admission.xml
+++ b/ssi_school_admission_lead_operating_unit/views/crm_lead_create_admission.xml
@@ -1,0 +1,23 @@
+<?xml version="1.0" encoding="utf-8" ?>
+<!-- Copyright 2026 OpenSynergy Indonesia
+     Copyright 2026 PT. Simetri Sinergi Indonesia
+     License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl). -->
+<odoo>
+
+<record id="crm_lead_create_admission_view_form_ou" model="ir.ui.view">
+    <field name="name">crm.lead.create_admission form - operating unit</field>
+    <field name="model">crm.lead.create_admission</field>
+    <field
+            name="inherit_id"
+            ref="ssi_school_lead.crm_lead_create_admission_view_form"
+        />
+    <field name="arch" type="xml">
+        <data>
+            <xpath expr="//field[@name='student_id']" position="after">
+                <field name="operating_unit_id" />
+            </xpath>
+        </data>
+    </field>
+</record>
+
+</odoo>

--- a/ssi_school_admission_lead_operating_unit/views/crm_lead_create_admission_form.xml
+++ b/ssi_school_admission_lead_operating_unit/views/crm_lead_create_admission_form.xml
@@ -1,0 +1,23 @@
+<?xml version="1.0" encoding="utf-8" ?>
+<!-- Copyright 2026 OpenSynergy Indonesia
+     Copyright 2026 PT. Simetri Sinergi Indonesia
+     License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl). -->
+<odoo>
+
+<record id="crm_lead_create_admission_form_view_form_ou" model="ir.ui.view">
+    <field name="name">crm.lead.create_admission_form form - operating unit</field>
+    <field name="model">crm.lead.create_admission_form</field>
+    <field
+            name="inherit_id"
+            ref="ssi_school_admission_lead.crm_lead_create_admission_form_view_form"
+        />
+    <field name="arch" type="xml">
+        <data>
+            <xpath expr="//field[@name='student_id']" position="after">
+                <field name="operating_unit_id" />
+            </xpath>
+        </data>
+    </field>
+</record>
+
+</odoo>


### PR DESCRIPTION
## Ringkasan

Menambahkan field `operating_unit_id` ke arch form wizard "Create Admission Form"
(`crm.lead.create_admission_form`) dan "Create Admission" (`crm.lead.create_admission`)
lewat view inherit baru di `views/`.

Sebelumnya field ini hanya dideklarasikan secara Python pada kedua wizard tanpa pernah
muncul di view manapun (modul tidak punya folder `views/` maupun entri `data`), sehingga
context `default_operating_unit_id` yang di-set `models/crm_lead.py` (dari OU lead)
tidak pernah diterima `default_get()` saat wizard dibuka dari UI. Akibatnya membuka
wizard dari lead selalu menghasilkan `operating_unit_id` kosong, dan `action_confirm()`
tidak pernah menulis OU ke dokumen yang dibuat — meski kode Python-nya benar dan lolos
test level-model (yang membuat record langsung lewat `create()`, melewati `default_get`).

## Perubahan

- `views/crm_lead_create_admission_form.xml` (baru) — inherit view form wizard basis
  milik `ssi_school_admission_lead`, tambah field `operating_unit_id`.
- `views/crm_lead_create_admission.xml` (baru) — inherit view form wizard basis milik
  `ssi_school_lead`, tambah field `operating_unit_id`.
- `__manifest__.py` — daftarkan kedua file view baru di `data`.
- `tests/` — skenario unit test `odoo-yaml-test` (`action: form`) yang membuka kedua
  wizard dengan context `default_lead_id`/`default_operating_unit_id` (meniru context
  sungguhan dari `crm_lead.py`), memverifikasi `operating_unit_id` ter-default terisi
  dari lead lalu ikut tersalin ke `school_admission_form`/`school_admission` yang
  dibuat, serta skenario negatif `operating_unit_id` kosong yang tidak memaksa dokumen
  jadi kosong (tetap memakai default `mixin.single_operating_unit`).

## Kriteria Penerimaan

- [x] Field `operating_unit_id` muncul di arch form `crm.lead.create_admission_form`
      dan `crm.lead.create_admission`
- [x] Membuka wizard "Create Admission Form" dengan context
      `default_operating_unit_id` terisi menghasilkan wizard dengan
      `operating_unit_id` ter-default terisi, bukan kosong
- [x] Menekan Confirm pada wizard tersebut menulis `operating_unit_id` yang sama ke
      `school_admission_form` / `school_admission` yang dibuat

Closes open-synergy/ssi-school#158