### PR TITLE
[UPD] ssi_school_admission: Pindahkan field receivable ke page Accounting

### DIFF
--- a/ssi_school_admission/views/school_admission.xml
+++ b/ssi_school_admission/views/school_admission.xml
@@ -232,11 +232,11 @@
                             <field name="amount_total" />
                         </tree>
                     </field>
-                    <group name="billing_account" colspan="4" col="2">
-                        <group name="billing_account_left" colspan="1" col="2">
-                            <field name="receivable_journal_id" />
-                            <field name="receivable_account_id" />
-                        </group>
+                </page>
+                <page name="accounting" string="Accounting">
+                    <group name="accounting_group" colspan="4" col="2">
+                        <field name="receivable_journal_id" />
+                        <field name="receivable_account_id" />
                     </group>
                 </page>
                 <page name="admission_source" string="Admission Source">


### PR DESCRIPTION
## Ringkasan

Memindahkan field `receivable_journal_id` dan `receivable_account_id` dari group `billing_account` pada page "Fee" ke page notebook baru "Accounting" pada form view `school_admission`. Kedua field bersifat akuntansi murni sehingga dipisahkan dari konfigurasi fee/billing (payment template, payment term, product summary).

- Menambah page notebook baru `name="accounting" string="Accounting"`, ditempatkan tepat setelah page "Fee".
- Memindahkan `receivable_journal_id` dan `receivable_account_id` ke page baru tersebut.
- Menghapus group `billing_account` (kosong setelah field dipindah) dari page "Fee".
- Tidak ada perubahan model/field/onchange/security/manifest — murni penataan ulang view.

Closes #154

## Test plan

- [x] Perubahan bersifat view-only (XML), diverifikasi valid via `xml.etree.ElementTree`.
- [x] Tidak ada XML ID yang diubah.
- [x] Test regresi onchange receivable yang sudah ada (`test_onchange_payment_template_sets_receivable`, `test_onchange_payment_template_clears_receivable`) tetap berjalan di CI tanpa perubahan.