### PR TITLE
[UPD] ssi_school_admission_lead: tambah field tempat lahir, agama, kewarganegaraan

### DIFF
--- a/ssi_school_admission_lead/README.rst
+++ b/ssi_school_admission_lead/README.rst
@@ -16,6 +16,10 @@ It also carries the first layer of admission intake data on the lead itself:
 * ``student_birthdate`` and ``student_gender``: birthdate and gender of the
   prospective student, related to the contact referenced by ``student_id``.
   The identity data is stored on ``res.partner``, not duplicated on the lead.
+* ``birth_city``, ``religion_id`` and ``nationality_id``: place of birth,
+  religion and nationality of the prospective student, related to the
+  contact referenced by ``student_id``. The identity data is stored on
+  ``res.partner``, not duplicated on the lead.
 * ``grade_id``: the grade level the prospective student applies for, restricted
   by ``grade_type_id`` which is derived from the selected school.
 

--- a/ssi_school_admission_lead/models/crm_lead.py
+++ b/ssi_school_admission_lead/models/crm_lead.py
@@ -41,6 +41,47 @@ class CrmLead(models.Model):  # pylint: disable=too-few-public-methods
             "duplicated on the lead."
         ),
     )
+    birth_city = fields.Char(
+        string="Birth City",
+        related="student_id.birth_city",
+        store=True,
+        readonly=False,
+        compute_sudo=True,
+        help=(
+            "City of birth of the prospective student, synchronized from "
+            "the contact referenced by the Student field. Writing this "
+            "field updates the contact itself, so the identity data is not "
+            "duplicated on the lead."
+        ),
+    )
+    religion_id = fields.Many2one(
+        string="Religion",
+        comodel_name="res_partner_religion",
+        related="student_id.religion_id",
+        store=True,
+        readonly=False,
+        compute_sudo=True,
+        help=(
+            "Religion of the prospective student, synchronized from the "
+            "contact referenced by the Student field. Writing this field "
+            "updates the contact itself, so the identity data is not "
+            "duplicated on the lead."
+        ),
+    )
+    nationality_id = fields.Many2one(
+        string="Nationality",
+        comodel_name="res.country",
+        related="student_id.nationality_id",
+        store=True,
+        readonly=False,
+        compute_sudo=True,
+        help=(
+            "Nationality of the prospective student, synchronized from the "
+            "contact referenced by the Student field. Writing this field "
+            "updates the contact itself, so the identity data is not "
+            "duplicated on the lead."
+        ),
+    )
     grade_type_id = fields.Many2one(
         string="Grade Type",
         comodel_name="school_grade_type",

--- a/ssi_school_admission_lead/tests/test_crm_lead_view_architecture.py
+++ b/ssi_school_admission_lead/tests/test_crm_lead_view_architecture.py
@@ -33,9 +33,16 @@ class TestCrmLeadViewArchitecture(YamlTransactionCase):
         field_names = [f.get("name") for f in group.xpath(".//field")]
         self.assertEqual(
             field_names,
-            ["student_id", "student_birthdate", "student_gender"],
+            [
+                "student_id",
+                "student_birthdate",
+                "student_gender",
+                "birth_city",
+                "religion_id",
+                "nationality_id",
+            ],
             "Prospective Student group should list student_id, student_birthdate, "
-            "student_gender in that order",
+            "student_gender, birth_city, religion_id, nationality_id in that order",
         )
 
     def test_admission_target_group_contains_expected_fields_in_order(self):

--- a/ssi_school_admission_lead/tests/test_data_lead_student_identity.yaml
+++ b/ssi_school_admission_lead/tests/test_data_lead_student_identity.yaml
@@ -139,6 +139,114 @@ scenarios:
         save_as: "leftover_contacts"
         expect_count: 0
 
+  - name: "CRM Lead - Birth city and religion written on the lead reach the contact"
+    steps:
+      - step: "Create religion"
+        action: "create"
+        model: "res_partner_religion"
+        save_as: "religion"
+        values:
+          name: "Religion Lead Write Identity"
+          code: "RELLWI"
+
+      - step: "Create prospective student contact"
+        action: "create"
+        model: "res.partner"
+        save_as: "student_contact"
+        values:
+          name: "Student Lead Write Birth City Religion"
+
+      - step: "Create lead pointing to the prospective student"
+        action: "create"
+        model: "crm.lead"
+        save_as: "lead"
+        values:
+          name: "Lead Write Birth City Religion"
+          student_id: "REC: student_contact.id"
+
+      - step: "Write birth city and religion on the lead"
+        action: "write"
+        target: "lead"
+        values:
+          birth_city: "Semarang"
+          religion_id: "REC: religion.id"
+
+      - step: "Assert the contact received the birth city and religion"
+        action: "assert"
+        target: "student_contact"
+        refresh: true
+        asserts:
+          birth_city:
+            type: "value"
+            expected: "Semarang"
+          religion_id:
+            type: "m2o"
+            expected: "REC: religion"
+
+  - name: "CRM Lead - Nationality written on the contact is read on the lead"
+    steps:
+      - step: "Create prospective student contact"
+        action: "create"
+        model: "res.partner"
+        save_as: "student_contact"
+        values:
+          name: "Student Lead Read Nationality"
+
+      - step: "Create lead pointing to the prospective student"
+        action: "create"
+        model: "crm.lead"
+        save_as: "lead"
+        values:
+          name: "Lead Read Nationality"
+          student_id: "REC: student_contact.id"
+
+      - step: "Write nationality on the contact"
+        action: "write"
+        target: "student_contact"
+        values:
+          nationality_id: "REF: base.id"
+
+      - step: "Assert the lead reflects the contact nationality"
+        action: "assert"
+        target: "lead"
+        refresh: true
+        asserts:
+          nationality_id:
+            type: "m2o"
+            expected: "REF: base.id"
+
+  - name:
+      "CRM Lead - Birth city, religion and nationality stay empty without a prospective
+      student"
+    steps:
+      - step: "Create lead without prospective student"
+        action: "create"
+        model: "crm.lead"
+        save_as: "lead"
+        values:
+          name: "Lead Without Student Extended Identity"
+
+      - step: "Assert lead exists with empty extended identity"
+        action: "assert"
+        target: "lead"
+        refresh: true
+        asserts:
+          id:
+            type: "value"
+            operator: "is_truthy"
+          student_id:
+            type: "value"
+            operator: "is_falsy"
+          birth_city:
+            type: "value"
+            operator: "is_falsy"
+          religion_id:
+            type: "value"
+            operator: "is_falsy"
+          nationality_id:
+            type: "value"
+            operator: "is_falsy"
+
   - name: "CRM Lead - Grade type follows the school and restricts the grade"
     steps:
       - step: "Create grade type"

--- a/ssi_school_admission_lead/views/crm_lead.xml
+++ b/ssi_school_admission_lead/views/crm_lead.xml
@@ -16,6 +16,9 @@
                 >
                 <field name="student_birthdate" />
                 <field name="student_gender" />
+                <field name="birth_city" />
+                <field name="religion_id" />
+                <field name="nationality_id" />
             </xpath>
             <xpath
                     expr="//group[@name='school_lead_admission_target']//field[@name='school_id']"


### PR DESCRIPTION
## Ringkasan

Menambahkan tiga field related pada `crm.lead` (modul `ssi_school_admission_lead`):

- `birth_city` — related `student_id.birth_city`
- `religion_id` — related `student_id.religion_id`
- `nationality_id` — related `student_id.nationality_id`

Ketiganya `store=True, readonly=False, compute_sudo=True`, mengikuti pola yang sudah
dipakai `student_birthdate`/`student_gender` di modul yang sama. Tidak ada default untuk
`nationality_id`. Ketiga field ditampilkan di form view `crm.lead` pada grup
`school_lead_prospective_student` yang sudah ada. Tidak ada ACL/record rule baru dan tidak
ada dependensi manifest baru.

## Test

Skenario `odoo-yaml-test` ditambahkan pada `tests/test_data_lead_student_identity.yaml`:

- Tulis-tembus: write `birth_city`/`religion_id` di lead → nilai berubah di `res.partner`
- Baca related: write `nationality_id` di `res.partner` → nilai berubah di lead
- Kondisi kosong: lead tanpa `student_id` → ketiga field falsy tanpa error

`tests/test_crm_lead_view_architecture.py` diperbarui untuk menegakkan urutan field baru
di grup `school_lead_prospective_student`.

Closes open-synergy/ssi-school#139