### PR TITLE
[UPD] ssi_school_lead - Tambah field kontak parent_* related stored dari partner_id di crm.lead

### DIFF
--- a/ssi_school_lead/models/crm_lead.py
+++ b/ssi_school_lead/models/crm_lead.py
@@ -39,6 +39,63 @@ class CrmLead(models.Model):
         compute_sudo=True,
         help="Indicates whether an admission can still be created for this lead.",
     )
+    parent_street = fields.Char(
+        string="Parent Street",
+        related="partner_id.street",
+        store=True,
+        help="Street address of the parent/guardian, mirrored from their contact record.",
+    )
+    parent_street2 = fields.Char(
+        string="Parent Street2",
+        related="partner_id.street2",
+        store=True,
+        help="Additional street address of the parent/guardian, mirrored from their "
+        "contact record.",
+    )
+    parent_city = fields.Char(
+        string="Parent City",
+        related="partner_id.city",
+        store=True,
+        help="City of the parent/guardian, mirrored from their contact record.",
+    )
+    parent_state_id = fields.Many2one(
+        comodel_name="res.country.state",
+        string="Parent State",
+        related="partner_id.state_id",
+        store=True,
+        help="State/province of the parent/guardian, mirrored from their contact record.",
+    )
+    parent_zip = fields.Char(
+        string="Parent Zip",
+        related="partner_id.zip",
+        store=True,
+        help="Postal/zip code of the parent/guardian, mirrored from their contact record.",
+    )
+    parent_country_id = fields.Many2one(
+        comodel_name="res.country",
+        string="Parent Country",
+        related="partner_id.country_id",
+        store=True,
+        help="Country of the parent/guardian, mirrored from their contact record.",
+    )
+    parent_mobile = fields.Char(
+        string="Parent Mobile",
+        related="partner_id.mobile",
+        store=True,
+        help="Mobile number of the parent/guardian, mirrored from their contact record.",
+    )
+    parent_phone = fields.Char(
+        string="Parent Phone",
+        related="partner_id.phone",
+        store=True,
+        help="Phone number of the parent/guardian, mirrored from their contact record.",
+    )
+    parent_email = fields.Char(
+        string="Parent Email",
+        related="partner_id.email",
+        store=True,
+        help="Email address of the parent/guardian, mirrored from their contact record.",
+    )
 
     @api.depends("admission_id")
     def _compute_create_admission_ok(self):

--- a/ssi_school_lead/tests/__init__.py
+++ b/ssi_school_lead/tests/__init__.py
@@ -3,3 +3,4 @@
 # License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl).
 
 from . import test_school_lead  # noqa: F401
+from . import test_crm_lead_parent_contact  # noqa: F401

--- a/ssi_school_lead/tests/test_crm_lead_parent_contact.py
+++ b/ssi_school_lead/tests/test_crm_lead_parent_contact.py
@@ -1,0 +1,13 @@
+# Copyright 2024 OpenSynergy Indonesia
+# Copyright 2024 PT. Simetri Sinergi Indonesia
+# License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl).
+
+from odoo_yaml_test import YamlTransactionCase
+
+from odoo.tests import tagged
+
+
+@tagged("post_install", "-at_install")
+class TestCrmLeadParentContact(YamlTransactionCase):
+    def test_crm_lead_parent_contact(self):
+        self.run_yaml_scenario("test_data_crm_lead_parent_contact.yaml")

--- a/ssi_school_lead/tests/test_data_crm_lead_parent_contact.yaml
+++ b/ssi_school_lead/tests/test_data_crm_lead_parent_contact.yaml
@@ -1,0 +1,276 @@
+options:
+  auto_refresh: true
+
+scenarios:
+  - name: "CRM Lead Parent Contact - Create with full partner contact info"
+    steps:
+      - step: "Create parent partner with full contact info"
+        action: "create"
+        model: "res.partner"
+        save_as: "parent"
+        values:
+          name: "Parent Contact Full PC1"
+          street: "Jl. Merdeka No. 1"
+          street2: "Building A"
+          city: "Jakarta"
+          state_id: "REF: base.state_id_jk"
+          zip: "10110"
+          country_id: "REF: base.id"
+          mobile: "081234567890"
+          phone: "0213456789"
+          email: "parent.full.pc1@example.com"
+
+      - step: "Create CRM lead with partner_id"
+        action: "create"
+        model: "crm.lead"
+        save_as: "lead"
+        as_user: "base.user_admin"
+        values:
+          name: "Lead Parent Contact Full PC1"
+          partner_id: "REC: parent.id"
+
+      - step: "Assert parent_* fields mirror partner contact info"
+        action: "assert"
+        target: "lead"
+        asserts:
+          parent_street:
+            type: "value"
+            expected: "Jl. Merdeka No. 1"
+          parent_street2:
+            type: "value"
+            expected: "Building A"
+          parent_city:
+            type: "value"
+            expected: "Jakarta"
+          parent_state_id:
+            type: "m2o"
+            expected_xml_id: "base.state_id_jk"
+          parent_zip:
+            type: "value"
+            expected: "10110"
+          parent_country_id:
+            type: "m2o"
+            expected_xml_id: "base.id"
+          parent_mobile:
+            type: "value"
+            expected: "081234567890"
+          parent_phone:
+            type: "value"
+            expected: "0213456789"
+          parent_email:
+            type: "value"
+            expected: "parent.full.pc1@example.com"
+
+  - name: "CRM Lead Parent Contact - Propagates when partner is updated"
+    steps:
+      - step: "Create parent partner with initial contact info"
+        action: "create"
+        model: "res.partner"
+        save_as: "parent"
+        values:
+          name: "Parent Contact Initial PC2"
+          street: "Jl. Awal No. 1"
+          mobile: "081100000000"
+
+      - step: "Create CRM lead with partner_id"
+        action: "create"
+        model: "crm.lead"
+        save_as: "lead"
+        as_user: "base.user_admin"
+        values:
+          name: "Lead Parent Contact Propagation PC2"
+          partner_id: "REC: parent.id"
+
+      - step: "Assert parent_* fields mirror initial partner contact info"
+        action: "assert"
+        target: "lead"
+        asserts:
+          parent_street:
+            type: "value"
+            expected: "Jl. Awal No. 1"
+          parent_mobile:
+            type: "value"
+            expected: "081100000000"
+
+      - step: "Update partner street and mobile"
+        action: "write"
+        target: "parent"
+        values:
+          street: "Jl. Baru No. 99"
+          mobile: "081199999999"
+
+      - step: "Assert parent_* fields on lead follow updated partner values"
+        action: "assert"
+        target: "lead"
+        asserts:
+          parent_street:
+            type: "value"
+            expected: "Jl. Baru No. 99"
+          parent_mobile:
+            type: "value"
+            expected: "081199999999"
+
+  - name: "CRM Lead Parent Contact - Propagates when partner_id is changed"
+    steps:
+      - step: "Create first parent partner"
+        action: "create"
+        model: "res.partner"
+        save_as: "parent_a"
+        values:
+          name: "Parent Contact A PC3"
+          street: "Jl. Partner A"
+          city: "Jakarta"
+          email: "parent.a.pc3@example.com"
+
+      - step: "Create second parent partner with different address and email"
+        action: "create"
+        model: "res.partner"
+        save_as: "parent_b"
+        values:
+          name: "Parent Contact B PC3"
+          street: "Jl. Partner B"
+          city: "Bandung"
+          email: "parent.b.pc3@example.com"
+
+      - step: "Create CRM lead with first partner_id"
+        action: "create"
+        model: "crm.lead"
+        save_as: "lead"
+        as_user: "base.user_admin"
+        values:
+          name: "Lead Parent Contact Change Partner PC3"
+          partner_id: "REC: parent_a.id"
+
+      - step: "Assert parent_* fields mirror first partner"
+        action: "assert"
+        target: "lead"
+        asserts:
+          parent_street:
+            type: "value"
+            expected: "Jl. Partner A"
+          parent_city:
+            type: "value"
+            expected: "Jakarta"
+          parent_email:
+            type: "value"
+            expected: "parent.a.pc3@example.com"
+
+      - step: "Change lead partner_id to second partner"
+        action: "write"
+        target: "lead"
+        values:
+          partner_id: "REC: parent_b.id"
+
+      - step: "Assert parent_* fields now mirror second partner"
+        action: "assert"
+        target: "lead"
+        asserts:
+          parent_street:
+            type: "value"
+            expected: "Jl. Partner B"
+          parent_city:
+            type: "value"
+            expected: "Bandung"
+          parent_email:
+            type: "value"
+            expected: "parent.b.pc3@example.com"
+
+  - name: "CRM Lead Parent Contact - Negative, no partner_id"
+    steps:
+      - step: "Create CRM lead without partner_id"
+        action: "create"
+        model: "crm.lead"
+        save_as: "lead"
+        as_user: "base.user_admin"
+        values:
+          name: "Lead Parent Contact No Partner PC4"
+
+      - step: "Assert all parent_* fields are falsy"
+        action: "assert"
+        target: "lead"
+        asserts:
+          parent_street:
+            type: "value"
+            operator: "is_falsy"
+          parent_street2:
+            type: "value"
+            operator: "is_falsy"
+          parent_city:
+            type: "value"
+            operator: "is_falsy"
+          parent_state_id:
+            type: "value"
+            operator: "is_falsy"
+          parent_zip:
+            type: "value"
+            operator: "is_falsy"
+          parent_country_id:
+            type: "value"
+            operator: "is_falsy"
+          parent_mobile:
+            type: "value"
+            operator: "is_falsy"
+          parent_phone:
+            type: "value"
+            operator: "is_falsy"
+          parent_email:
+            type: "value"
+            operator: "is_falsy"
+
+  - name: "CRM Lead Parent Contact - Negative, partner with empty contact info"
+    steps:
+      - step: "Create parent partner without any contact info"
+        action: "create"
+        model: "res.partner"
+        save_as: "parent"
+        values:
+          name: "Parent Contact Empty PC5"
+
+      - step: "Create CRM lead with partner having empty contact info"
+        action: "create"
+        model: "crm.lead"
+        save_as: "lead"
+        as_user: "base.user_admin"
+        values:
+          name: "Lead Parent Contact Empty Partner PC5"
+          partner_id: "REC: parent.id"
+
+      - step: "Assert lead was created successfully"
+        action: "assert"
+        target: "lead"
+        asserts:
+          id:
+            type: "value"
+            operator: "is_truthy"
+
+      - step: "Assert all parent_* fields are falsy"
+        action: "assert"
+        target: "lead"
+        asserts:
+          parent_street:
+            type: "value"
+            operator: "is_falsy"
+          parent_street2:
+            type: "value"
+            operator: "is_falsy"
+          parent_city:
+            type: "value"
+            operator: "is_falsy"
+          parent_state_id:
+            type: "value"
+            operator: "is_falsy"
+          parent_zip:
+            type: "value"
+            operator: "is_falsy"
+          parent_country_id:
+            type: "value"
+            operator: "is_falsy"
+          parent_mobile:
+            type: "value"
+            operator: "is_falsy"
+          parent_phone:
+            type: "value"
+            operator: "is_falsy"
+          parent_email:
+            type: "value"
+            operator: "is_falsy"

--- a/ssi_school_lead/views/crm_lead_views.xml
+++ b/ssi_school_lead/views/crm_lead_views.xml
@@ -18,6 +18,20 @@
             </xpath>
             <xpath expr="//group[@name='opportunity_partner']" position="after">
                 <group
+                        name="school_lead_parent_contact"
+                        string="Parent/Guardian Contact"
+                    >
+                    <field name="parent_street" />
+                    <field name="parent_street2" />
+                    <field name="parent_city" />
+                    <field name="parent_state_id" />
+                    <field name="parent_zip" />
+                    <field name="parent_country_id" />
+                    <field name="parent_phone" />
+                    <field name="parent_mobile" />
+                    <field name="parent_email" />
+                </group>
+                <group
                         name="school_lead_prospective_student"
                         string="Prospective Student"
                     >


### PR DESCRIPTION
## Ringkasan

Menambahkan sembilan field `parent_*` pada `crm.lead` (modul `ssi_school_lead`), seluruhnya
`related="partner_id.<field>"` dan `store=True`, agar data kontak orang tua/wali (alamat,
kota, provinsi, kode pos, negara, HP, telepon, email) selalu cermin data `res.partner` dan
dapat difilter/dikelompokkan/dilaporkan langsung dari lead.

- `parent_street`, `parent_street2`, `parent_city`, `parent_state_id`, `parent_zip`,
  `parent_country_id`, `parent_mobile`, `parent_phone`, `parent_email`
- Ditampilkan di form view `crm.lead` modul ini, dalam grup baru "Parent/Guardian Contact"
  sesudah grup `opportunity_partner`.
- Field kontak bawaan `crm.lead` (`street`, `phone`, `email_from`, dst.) tidak diubah.
- Tidak ada ACL/record rule baru, tidak ada dependensi `__manifest__.py` baru.
- Unit test `odoo-yaml-test` untuk 5 skenario: create lengkap, propagasi write pada
  partner (`auto_refresh: true`), propagasi ganti `partner_id`, negatif tanpa `partner_id`,
  negatif partner dengan kontak kosong.

Closes #165