### PR TITLE
[UPD] ssi_school_admission_lead: previous_school_id configurable via M2O Configurator

### DIFF
--- a/ssi_school_admission_lead/README.rst
+++ b/ssi_school_admission_lead/README.rst
@@ -22,6 +22,11 @@ It also carries the first layer of admission intake data on the lead itself:
   ``res.partner``, not duplicated on the lead.
 * ``grade_id``: the grade level the prospective student applies for, restricted
   by ``grade_type_id`` which is derived from the selected school.
+* ``previous_school_id``: the prospective student's previous school, a
+  ``res.partner`` reference restricted to ``allowed_previous_school_ids``.
+  The list of partners that can be selected is configurable per company
+  (``previous_school_selection_method``: manual/domain/code) from
+  **Settings > School > Admission > Settings**, without a code release.
 
 Credits
 =======

--- a/ssi_school_admission_lead/__manifest__.py
+++ b/ssi_school_admission_lead/__manifest__.py
@@ -15,10 +15,12 @@
     "depends": [
         "ssi_school_lead",
         "ssi_school_admission",
+        "ssi_m2o_configurator_mixin",
     ],
     "data": [
         "security/ir.model.access.csv",
         "views/crm_lead_create_admission_form.xml",
         "views/crm_lead.xml",
+        "views/res_config_settings_views.xml",
     ],
 }

--- a/ssi_school_admission_lead/models/__init__.py
+++ b/ssi_school_admission_lead/models/__init__.py
@@ -3,4 +3,6 @@
 # License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl).
 from . import (  # noqa: F401
     crm_lead,
+    res_company,
+    res_config_settings,
 )

--- a/ssi_school_admission_lead/models/crm_lead.py
+++ b/ssi_school_admission_lead/models/crm_lead.py
@@ -128,11 +128,54 @@ class CrmLead(models.Model):  # pylint: disable=too-few-public-methods
             "Indicates whether an admission form can still " "be created for this lead."
         ),
     )
+    previous_school_id = fields.Many2one(
+        string="Previous School",
+        comodel_name="res.partner",
+        tracking=True,
+        help=(
+            "The prospective student's previous school, restricted to the "
+            "partners allowed by the company's Previous School "
+            "configuration (see Allowed Previous Schools)."
+        ),
+    )
+    allowed_previous_school_ids = fields.Many2many(
+        string="Allowed Previous Schools",
+        comodel_name="res.partner",
+        compute="_compute_allowed_previous_school_ids",
+        store=False,
+        compute_sudo=True,
+        help=(
+            "Partners that can be selected on the Previous School field, "
+            "computed from the company's Previous School Selection "
+            "Method (manual/domain/code)."
+        ),
+    )
 
     @api.depends("admission_form_id")
     def _compute_create_admission_form_ok(self):
         for record in self:
             record.create_admission_form_ok = not record.admission_form_id
+
+    @api.depends(
+        "company_id.previous_school_selection_method",
+        "company_id.previous_school_ids",
+        "company_id.previous_school_domain",
+        "company_id.previous_school_python_code",
+    )
+    def _compute_allowed_previous_school_ids(self):
+        for record in self:
+            result = False
+            if record.company_id:
+                result = record.company_id._m2o_configurator_get_filter(
+                    object_name="res.partner",
+                    method_selection=(
+                        record.company_id.previous_school_selection_method
+                    ),
+                    manual_recordset=record.company_id.previous_school_ids,
+                    domain=record.company_id.previous_school_domain,
+                    python_code=record.company_id.previous_school_python_code,
+                )
+            record.allowed_previous_school_ids = result
 
     def action_create_admission_form(self):
         self.ensure_one()

--- a/ssi_school_admission_lead/models/res_company.py
+++ b/ssi_school_admission_lead/models/res_company.py
@@ -1,0 +1,66 @@
+# Copyright 2026 OpenSynergy Indonesia
+# Copyright 2026 PT. Simetri Sinergi Indonesia
+# License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl).
+
+from odoo import fields, models
+
+
+class ResCompany(models.Model):
+    """
+    Extends the company model with M2O Configurator fields used to
+    restrict which partners can be selected as the previous school of a
+    prospective student on a CRM lead, without requiring a code change.
+    """
+
+    _name = "res.company"
+    _inherit = [
+        "res.company",
+        "mixin.many2one_configurator",
+    ]
+
+    previous_school_selection_method = fields.Selection(
+        string="Previous School Selection Method",
+        selection=[
+            ("manual", "Manual"),
+            ("domain", "Domain"),
+            ("code", "Python Code"),
+        ],
+        default="domain",
+        required=True,
+        help=(
+            "Method used to filter the partners that can be selected as "
+            "the previous school of a prospective student on a CRM lead. "
+            "Manual: select from a fixed list. Domain: filter using an "
+            "Odoo domain expression. Python Code: compute the allowed "
+            "partners programmatically."
+        ),
+    )
+    previous_school_ids = fields.Many2many(
+        string="Previous Schools",
+        comodel_name="res.partner",
+        relation="rel_res_company_2_previous_school",
+        column1="company_id",
+        column2="partner_id",
+        help=(
+            "Partners allowed as the previous school of a prospective "
+            "student when the selection method is set to Manual."
+        ),
+    )
+    previous_school_domain = fields.Text(
+        string="Previous School Domain",
+        default="[('is_company', '=', True), ('parent_id', '=', False)]",
+        help=(
+            "Odoo domain expression used to filter the partners allowed "
+            "as the previous school of a prospective student when the "
+            "selection method is Domain."
+        ),
+    )
+    previous_school_python_code = fields.Text(
+        string="Previous School Python Code",
+        default="result = []",
+        help=(
+            "Python code that returns a recordset (or list of IDs) of "
+            "partners allowed as the previous school of a prospective "
+            "student when the selection method is Python Code."
+        ),
+    )

--- a/ssi_school_admission_lead/models/res_config_settings.py
+++ b/ssi_school_admission_lead/models/res_config_settings.py
@@ -1,0 +1,34 @@
+# Copyright 2026 OpenSynergy Indonesia
+# Copyright 2026 PT. Simetri Sinergi Indonesia
+# License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl).
+
+from odoo import fields, models
+
+
+class ResConfigSettings(models.TransientModel):
+    """
+    Exposes the company's Previous School M2O Configurator fields on the
+    Settings screen, so administrators can change the selection method
+    (manual/domain/code) without a code release.
+    """
+
+    _name = "res.config.settings"
+    _inherit = "res.config.settings"
+
+    previous_school_selection_method = fields.Selection(
+        related="company_id.previous_school_selection_method",
+        readonly=False,
+    )
+    previous_school_ids = fields.Many2many(
+        comodel_name="res.partner",
+        related="company_id.previous_school_ids",
+        readonly=False,
+    )
+    previous_school_domain = fields.Text(
+        related="company_id.previous_school_domain",
+        readonly=False,
+    )
+    previous_school_python_code = fields.Text(
+        related="company_id.previous_school_python_code",
+        readonly=False,
+    )

--- a/ssi_school_admission_lead/tests/__init__.py
+++ b/ssi_school_admission_lead/tests/__init__.py
@@ -3,5 +3,6 @@
 # License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl).
 
 from . import test_crm_lead_admission  # noqa: F401
+from . import test_crm_lead_previous_school  # noqa: F401
 from . import test_crm_lead_student_identity  # noqa: F401
 from . import test_crm_lead_view_architecture  # noqa: F401

--- a/ssi_school_admission_lead/tests/test_crm_lead_previous_school.py
+++ b/ssi_school_admission_lead/tests/test_crm_lead_previous_school.py
@@ -1,0 +1,13 @@
+# Copyright 2026 OpenSynergy Indonesia
+# Copyright 2026 PT. Simetri Sinergi Indonesia
+# License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl).
+
+from odoo_yaml_test import YamlTransactionCase
+
+from odoo.tests import tagged
+
+
+@tagged("post_install", "-at_install")
+class TestCrmLeadPreviousSchool(YamlTransactionCase):
+    def test_crm_lead_previous_school(self):
+        self.run_yaml_scenario("test_data_previous_school_configurator.yaml")

--- a/ssi_school_admission_lead/tests/test_crm_lead_view_architecture.py
+++ b/ssi_school_admission_lead/tests/test_crm_lead_view_architecture.py
@@ -40,9 +40,20 @@ class TestCrmLeadViewArchitecture(YamlTransactionCase):
                 "birth_city",
                 "religion_id",
                 "nationality_id",
+                "allowed_previous_school_ids",
+                "previous_school_id",
             ],
             "Prospective Student group should list student_id, student_birthdate, "
-            "student_gender, birth_city, religion_id, nationality_id in that order",
+            "student_gender, birth_city, religion_id, nationality_id, "
+            "allowed_previous_school_ids, previous_school_id in that order",
+        )
+        previous_school_id_field = group.xpath(".//field[@name='previous_school_id']")[
+            0
+        ]
+        self.assertEqual(
+            previous_school_id_field.get("domain"),
+            "[('id', 'in', allowed_previous_school_ids)]",
+            "previous_school_id should be restricted by allowed_previous_school_ids",
         )
 
     def test_admission_target_group_contains_expected_fields_in_order(self):

--- a/ssi_school_admission_lead/tests/test_data_previous_school_configurator.yaml
+++ b/ssi_school_admission_lead/tests/test_data_previous_school_configurator.yaml
@@ -1,0 +1,163 @@
+scenarios:
+  - name:
+      "Previous School Configurator - company defaults match the legacy hardcoded
+      criteria"
+    steps:
+      - step: "Assert company keeps the built-in Previous School configurator defaults"
+        action: "assert"
+        target: "company"
+        asserts:
+          previous_school_selection_method:
+            type: "value"
+            expected: "domain"
+          previous_school_domain:
+            type: "value"
+            expected: "[('is_company', '=', True), ('parent_id', '=', False)]"
+          previous_school_python_code:
+            type: "value"
+            expected: "result = []"
+
+  - name:
+      "Domain method - allowed_previous_school_ids restricted to partners matching
+      is_company/parent_id"
+    steps:
+      - step: "Create a partner matching the is_company/parent_id criteria"
+        action: "create"
+        model: "res.partner"
+        save_as: "school_match"
+        values:
+          name: "Previous School Domain Match"
+          is_company: true
+          parent_id: false
+
+      - step: "Create a partner NOT matching the is_company criteria"
+        action: "create"
+        model: "res.partner"
+        save_as: "school_nomatch"
+        values:
+          name: "Previous School Domain No Match"
+          is_company: false
+
+      - step: >-
+          Configure company with the domain method, keeping the same
+          is_company/parent_id criteria as the default but scoped to this scenario's two
+          candidate partners so the assertion below is not affected by unrelated
+          partners already present in the database (e.g. demo data companies)
+        action: "write"
+        target: "company"
+        values:
+          previous_school_selection_method: "domain"
+          previous_school_domain: >-
+            EVAL: "[('is_company', '=', True), ('parent_id', '=', False), ('id', 'in',
+            [%d, %d])]" % (registry['school_match'].id, registry['school_nomatch'].id)
+
+      - step: "Create CRM lead"
+        action: "create"
+        model: "crm.lead"
+        save_as: "lead"
+        values:
+          name: "Lead Previous School Domain"
+
+      - step: "Assert allowed_previous_school_ids contains exactly the matching partner"
+        action: "assert"
+        target: "lead"
+        asserts:
+          allowed_previous_school_ids:
+            type: "m2m"
+            check: "exact"
+            expected_records:
+              - "REC: school_match"
+
+  - name:
+      "Manual method - allowed_previous_school_ids restricted to the manually configured
+      partner list"
+    steps:
+      - step: "Create a partner outside the domain criteria"
+        action: "create"
+        model: "res.partner"
+        save_as: "school_manual"
+        values:
+          name: "Previous School Manual Override"
+          is_company: false
+
+      - step: "Configure company with the manual method"
+        action: "write"
+        target: "company"
+        values:
+          previous_school_selection_method: "manual"
+          previous_school_ids:
+            - - 6
+              - 0
+              - - "REC: school_manual.id"
+
+      - step: "Create CRM lead"
+        action: "create"
+        model: "crm.lead"
+        save_as: "lead"
+        values:
+          name: "Lead Previous School Manual"
+
+      - step:
+          "Assert allowed_previous_school_ids contains exactly the manually configured
+          partner"
+        action: "assert"
+        target: "lead"
+        asserts:
+          allowed_previous_school_ids:
+            type: "m2m"
+            check: "exact"
+            expected_records:
+              - "REC: school_manual"
+
+  - name: "Create lead with a valid previous_school_id - saved without error"
+    steps:
+      - step: "Create a partner to be the allowed previous school"
+        action: "create"
+        model: "res.partner"
+        save_as: "school_valid"
+        values:
+          name: "Previous School Valid"
+          is_company: false
+
+      - step: "Configure company to allow only that partner (manual method)"
+        action: "write"
+        target: "company"
+        values:
+          previous_school_selection_method: "manual"
+          previous_school_ids:
+            - - 6
+              - 0
+              - - "REC: school_valid.id"
+
+      - step: "Create CRM lead with previous_school_id set to the allowed partner"
+        action: "create"
+        model: "crm.lead"
+        save_as: "lead"
+        values:
+          name: "Lead With Previous School"
+          previous_school_id: "REC: school_valid.id"
+
+      - step: "Assert previous_school_id was saved"
+        action: "assert"
+        target: "lead"
+        asserts:
+          previous_school_id:
+            type: "m2o"
+            expected: "REC: school_valid"
+
+  - name: "Create lead without previous_school_id - falsy"
+    steps:
+      - step: "Create CRM lead without previous_school_id"
+        action: "create"
+        model: "crm.lead"
+        save_as: "lead"
+        values:
+          name: "Lead Without Previous School"
+
+      - step: "Assert previous_school_id is falsy"
+        action: "assert"
+        target: "lead"
+        asserts:
+          previous_school_id:
+            type: "value"
+            operator: "is_falsy"

--- a/ssi_school_admission_lead/views/crm_lead.xml
+++ b/ssi_school_admission_lead/views/crm_lead.xml
@@ -19,6 +19,11 @@
                 <field name="birth_city" />
                 <field name="religion_id" />
                 <field name="nationality_id" />
+                <field name="allowed_previous_school_ids" invisible="1" />
+                <field
+                        name="previous_school_id"
+                        domain="[('id', 'in', allowed_previous_school_ids)]"
+                    />
             </xpath>
             <xpath
                     expr="//group[@name='school_lead_admission_target']//field[@name='school_id']"

--- a/ssi_school_admission_lead/views/res_config_settings_views.xml
+++ b/ssi_school_admission_lead/views/res_config_settings_views.xml
@@ -1,0 +1,98 @@
+<?xml version="1.0" encoding="utf-8" ?>
+<!-- Copyright 2026 OpenSynergy Indonesia
+     Copyright 2026 PT. Simetri Sinergi Indonesia
+     License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl). -->
+<odoo>
+
+<record id="res_config_settings_view_form" model="ir.ui.view">
+    <field name="name">res.config.settings form - ssi_school_admission_lead</field>
+    <field name="model">res.config.settings</field>
+    <field name="priority" eval="1" />
+    <field name="inherit_id" ref="base.res_config_settings_view_form" />
+    <field name="arch" type="xml">
+        <xpath expr="//div[hasclass('settings')]" position="inside">
+            <div
+                    class="app_settings_block"
+                    data-string="School Admission Lead"
+                    string="School Admission Lead"
+                    data-key="ssi_school_admission_lead"
+                >
+                <h2>Previous School Configuration</h2>
+                <div
+                        class="row mt16 o_settings_container"
+                        id="previous_school_configuration"
+                    >
+                    <div class="col-12 col-lg-6 o_setting_box">
+                        <div class="o_setting_right_pane">
+                            <div class="content-group">
+                                <div class="row mt16">
+                                    <label
+                                            for="previous_school_selection_method"
+                                            class="col-lg-4 o_light_label"
+                                        />
+                                    <field name="previous_school_selection_method" />
+                                </div>
+                                <div class="row">
+                                    <label
+                                            for="previous_school_ids"
+                                            class="col-lg-4 o_light_label"
+                                        />
+                                    <field
+                                            name="previous_school_ids"
+                                            widget="many2many_tags"
+                                            attrs="{'invisible': [('previous_school_selection_method', '!=', 'manual')]}"
+                                        />
+                                </div>
+                                <div class="row">
+                                    <label
+                                            for="previous_school_domain"
+                                            class="col-lg-4 o_light_label"
+                                        />
+                                    <field
+                                            name="previous_school_domain"
+                                            widget="domain"
+                                            options="{'model': 'res.partner', 'in_dialog': True}"
+                                            attrs="{'invisible': [('previous_school_selection_method', '!=', 'domain')]}"
+                                        />
+                                </div>
+                                <div class="row">
+                                    <label
+                                            for="previous_school_python_code"
+                                            class="col-lg-4 o_light_label"
+                                        />
+                                    <field
+                                            name="previous_school_python_code"
+                                            widget="ace"
+                                            attrs="{'invisible': [('previous_school_selection_method', '!=', 'code')]}"
+                                        />
+                                </div>
+                            </div>
+                        </div>
+                    </div>
+                </div>
+            </div>
+        </xpath>
+    </field>
+</record>
+
+<record id="res_config_settings_action" model="ir.actions.act_window">
+    <field name="name">Settings</field>
+    <field name="type">ir.actions.act_window</field>
+    <field name="res_model">res.config.settings</field>
+    <field name="view_mode">form</field>
+    <field name="target">inline</field>
+    <field
+            name="context"
+        >{'module' : 'ssi_school_admission_lead', 'bin_size': False}</field>
+</record>
+
+<menuitem
+        id="res_config_settings_menu"
+        name="Settings"
+        parent="ssi_school.menu_admission_configuration"
+        sequence="100"
+        action="res_config_settings_action"
+        groups="base.group_system"
+    />
+
+</odoo>


### PR DESCRIPTION
## Ringkasan

- Tambah `previous_school_id` (Many2one `res.partner`) pada `crm.lead` untuk menyimpan asal sekolah calon siswa.
- Tambah `allowed_previous_school_ids` (compute Many2many `res.partner`, non-stored) pada `crm.lead` yang membatasi partner yang bisa dipilih pada `previous_school_id`.
- `res.company` inherit `mixin.many2one_configurator` (`ssi_m2o_configurator_mixin`) dengan 4 field strategi konfigurasi (`manual`/`domain`/`code`); default `domain` mempertahankan kriteria lama (`is_company=True`, `parent_id` kosong).
- `res.config.settings` mengekspos ke-4 field itu (Settings > School > Admission > Settings) agar admin dapat mengubah kriteria asal sekolah tanpa rilis kode baru.
- Form view `crm.lead` menampilkan `previous_school_id` dengan domain dinamis `[('id', 'in', allowed_previous_school_ids)]`.

## Unit Test

Skenario `odoo-yaml-test` baru (`tests/test_data_previous_school_configurator.yaml`):
- Default company config (`domain`) menghasilkan kriteria yang sama seperti hardcoded semula.
- Metode `domain` membatasi `allowed_previous_school_ids` sesuai kriteria `is_company`/`parent_id`.
- Metode `manual` membatasi `allowed_previous_school_ids` sesuai daftar partner manual.
- Create lead dengan `previous_school_id` valid tersimpan tanpa error.
- Create lead tanpa `previous_school_id` menghasilkan nilai falsy.

Test `test_crm_lead_view_architecture.py` (arch `fields_view_get`) diperbarui untuk mencakup dua field baru di grup `school_lead_prospective_student`.

Closes #145