### PR TITLE
[UPD] ssi_school_lead: parent_* fields editable, address follows res.partner pattern

### DIFF
--- a/ssi_school_lead/models/crm_lead.py
+++ b/ssi_school_lead/models/crm_lead.py
@@ -61,12 +61,14 @@ class CrmLead(models.Model):
         string="Parent Street",
         related="partner_id.street",
         store=True,
+        readonly=False,
         help="Street address of the parent/guardian, mirrored from their contact record.",
     )
     parent_street2 = fields.Char(
         string="Parent Street2",
         related="partner_id.street2",
         store=True,
+        readonly=False,
         help="Additional street address of the parent/guardian, mirrored from their "
         "contact record.",
     )
@@ -74,6 +76,7 @@ class CrmLead(models.Model):
         string="Parent City",
         related="partner_id.city",
         store=True,
+        readonly=False,
         help="City of the parent/guardian, mirrored from their contact record.",
     )
     parent_state_id = fields.Many2one(
@@ -81,12 +84,14 @@ class CrmLead(models.Model):
         string="Parent State",
         related="partner_id.state_id",
         store=True,
+        readonly=False,
         help="State/province of the parent/guardian, mirrored from their contact record.",
     )
     parent_zip = fields.Char(
         string="Parent Zip",
         related="partner_id.zip",
         store=True,
+        readonly=False,
         help="Postal/zip code of the parent/guardian, mirrored from their contact record.",
     )
     parent_country_id = fields.Many2one(
@@ -94,24 +99,28 @@ class CrmLead(models.Model):
         string="Parent Country",
         related="partner_id.country_id",
         store=True,
+        readonly=False,
         help="Country of the parent/guardian, mirrored from their contact record.",
     )
     parent_mobile = fields.Char(
         string="Parent Mobile",
         related="partner_id.mobile",
         store=True,
+        readonly=False,
         help="Mobile number of the parent/guardian, mirrored from their contact record.",
     )
     parent_phone = fields.Char(
         string="Parent Phone",
         related="partner_id.phone",
         store=True,
+        readonly=False,
         help="Phone number of the parent/guardian, mirrored from their contact record.",
     )
     parent_email = fields.Char(
         string="Parent Email",
         related="partner_id.email",
         store=True,
+        readonly=False,
         help="Email address of the parent/guardian, mirrored from their contact record.",
     )
 

--- a/ssi_school_lead/tests/test_crm_lead_parent_contact.py
+++ b/ssi_school_lead/tests/test_crm_lead_parent_contact.py
@@ -11,3 +11,33 @@ from odoo.tests import tagged
 class TestCrmLeadParentContact(YamlTransactionCase):
     def test_crm_lead_parent_contact(self):
         self.run_yaml_scenario("test_data_crm_lead_parent_contact.yaml")
+
+    def test_parent_fields_are_not_readonly(self):
+        """Python murni — pemicu P1 (L-01: `fields_get()` mengembalikan dict,
+
+        YAML tidak bisa meng-assert nilai balik method).
+
+        Related field ``store=True`` bawaan Odoo di-set ``readonly=True``
+        secara default (``odoo/fields.py`` - ``Field._setup_attrs``); test
+        ini memverifikasi kesembilan field ``parent_*`` sudah diberi
+        ``readonly=False`` eksplisit sehingga dapat diedit dari form
+        ``crm.lead``.
+        """
+        fields_info = self.env["crm.lead"].fields_get(
+            [
+                "parent_street",
+                "parent_street2",
+                "parent_city",
+                "parent_state_id",
+                "parent_zip",
+                "parent_country_id",
+                "parent_phone",
+                "parent_mobile",
+                "parent_email",
+            ]
+        )
+        for field_name, field_info in fields_info.items():
+            self.assertFalse(
+                field_info["readonly"],
+                "Field %s should not be readonly" % field_name,
+            )

--- a/ssi_school_lead/tests/test_data_crm_lead_parent_contact.yaml
+++ b/ssi_school_lead/tests/test_data_crm_lead_parent_contact.yaml
@@ -175,6 +175,47 @@ scenarios:
             type: "value"
             expected: "parent.b.pc3@example.com"
 
+  - name: "CRM Lead Parent Contact - Write on lead writes through to partner"
+    steps:
+      - step: "Create parent partner with initial street"
+        action: "create"
+        model: "res.partner"
+        save_as: "parent"
+        values:
+          name: "Parent Contact Write-Through PC6"
+          street: "Jl. Lama No. 1"
+
+      - step: "Create CRM lead with partner_id"
+        action: "create"
+        model: "crm.lead"
+        save_as: "lead"
+        as_user: "base.user_admin"
+        values:
+          name: "Lead Parent Contact Write-Through PC6"
+          partner_id: "REC: parent.id"
+
+      - step: "Write new parent_street value on the lead"
+        action: "write"
+        target: "lead"
+        values:
+          parent_street: "Jl. Baru Write-Through No. 2"
+
+      - step: "Assert parent_street on lead is updated"
+        action: "assert"
+        target: "lead"
+        asserts:
+          parent_street:
+            type: "value"
+            expected: "Jl. Baru Write-Through No. 2"
+
+      - step: "Assert partner_id.street is updated by the related inverse"
+        action: "assert"
+        target: "parent"
+        asserts:
+          street:
+            type: "value"
+            expected: "Jl. Baru Write-Through No. 2"
+
   - name: "CRM Lead Parent Contact - Negative, no partner_id"
     steps:
       - step: "Create CRM lead without partner_id"
@@ -216,6 +257,20 @@ scenarios:
           parent_email:
             type: "value"
             operator: "is_falsy"
+
+      - step: "Write parent_zip on lead without partner_id"
+        action: "write"
+        target: "lead"
+        values:
+          parent_zip: "99999"
+
+      - step: "Assert write does not raise and parent_zip keeps the written value"
+        action: "assert"
+        target: "lead"
+        asserts:
+          parent_zip:
+            type: "value"
+            expected: "99999"
 
   - name: "CRM Lead Parent Contact - Negative, partner with empty contact info"
     steps:

--- a/ssi_school_lead/views/crm_lead_views.xml
+++ b/ssi_school_lead/views/crm_lead_views.xml
@@ -21,12 +21,41 @@
                         name="school_lead_parent_contact"
                         string="Parent/Guardian Contact"
                     >
-                    <field name="parent_street" />
-                    <field name="parent_street2" />
-                    <field name="parent_city" />
-                    <field name="parent_state_id" />
-                    <field name="parent_zip" />
-                    <field name="parent_country_id" />
+                    <div class="o_address_format">
+                        <field
+                                name="parent_street"
+                                placeholder="Street..."
+                                class="o_address_street"
+                            />
+                        <field
+                                name="parent_street2"
+                                placeholder="Street 2..."
+                                class="o_address_street"
+                            />
+                        <field
+                                name="parent_city"
+                                placeholder="City"
+                                class="o_address_city"
+                            />
+                        <field
+                                name="parent_state_id"
+                                placeholder="State"
+                                class="o_address_state"
+                                options="{'no_open': True, 'no_quick_create': True}"
+                                context="{'country_id': parent_country_id, 'default_country_id': parent_country_id, 'zip': parent_zip}"
+                            />
+                        <field
+                                name="parent_zip"
+                                placeholder="ZIP"
+                                class="o_address_zip"
+                            />
+                        <field
+                                name="parent_country_id"
+                                placeholder="Country"
+                                class="o_address_country"
+                                options='{"no_open": True, "no_create": True}'
+                            />
+                    </div>
                     <field name="parent_phone" />
                     <field name="parent_mobile" />
                     <field name="parent_email" />


### PR DESCRIPTION
## Ringkasan

- Menambahkan `readonly=False` eksplisit pada 9 field `parent_*` (related, `store=True`) di model `crm.lead`, agar dapat diedit dari form `crm.lead` dan menulis balik ke `partner_id` terkait lewat inverse otomatis related field.
- Menata ulang 6 field alamat (`parent_street` … `parent_country_id`) di group `school_lead_parent_contact` (`views/crm_lead_views.xml`) memakai pola `o_address_format` ala `res.partner` — dibungkus `<div class="o_address_format">`, kelas CSS `o_address_*`, placeholder, tanpa label per-field, `options`/`context` untuk `parent_state_id` dan `parent_country_id`.
- `parent_phone`/`parent_mobile`/`parent_email` tetap sebagai `<field>` biasa di group yang sama, di luar `<div class="o_address_format">`.

## Unit test

- `test_parent_fields_are_not_readonly` (Python murni, P1): `fields_get()` mengembalikan `readonly: False` untuk kesembilan field `parent_*`.
- Skenario YAML baru: write-through inverse (`parent_street` di lead menulis balik ke `partner_id.street`) dan negative path (write `parent_zip` tanpa `partner_id` tidak melempar error).
- Skenario YAML lama (create dengan partner terisi, propagasi saat partner diubah, propagasi saat `partner_id` diganti, negative path partner kosong) tetap sebagai regression-guard.

Closes #173