### PR TITLE
[UPD] Ganti invoice enrollment payment term ke customer_invoice

### DIFF
--- a/ssi_school/__manifest__.py
+++ b/ssi_school/__manifest__.py
@@ -22,6 +22,7 @@
         "ssi_m2o_configurator_mixin",
         "base_address_city",
         "ssi_financial_accounting",
+        "ssi_customer_invoice",
         "ssi_partner",
         "base_duration",
         "queue_job",

--- a/ssi_school/models/school_enrollment.py
+++ b/ssi_school/models/school_enrollment.py
@@ -335,6 +335,34 @@ class SchoolEnrollment(models.Model):
         },
         help="The receivable account used to record enrollment billing.",
     )
+    customer_invoice_type_id = fields.Many2one(
+        string="Customer Invoice Type",
+        comodel_name="customer_invoice_type",
+        readonly=True,
+        states={
+            "draft": [
+                ("readonly", False),
+            ],
+        },
+        help=(
+            "The customer invoice type used for every customer invoice "
+            "generated from the payment terms of this enrollment."
+        ),
+    )
+    auto_confirm_customer_invoice = fields.Boolean(
+        string="Auto Confirm Customer Invoice",
+        readonly=True,
+        states={
+            "draft": [
+                ("readonly", False),
+            ],
+        },
+        help=(
+            "If enabled, the customer invoice created from a payment "
+            "term of this enrollment is immediately confirmed instead "
+            "of being left in draft."
+        ),
+    )
     pass_ok = fields.Boolean(
         string="Pass",
         compute="_compute_policy",
@@ -504,6 +532,26 @@ class SchoolEnrollment(models.Model):
         self.receivable_account_id = False
         if self.payment_template_id:
             self.receivable_account_id = self.payment_template_id.receivable_account_id
+
+    @api.onchange(
+        "payment_template_id",
+    )
+    def onchange_customer_invoice_type_id(self):
+        self.customer_invoice_type_id = False
+        if self.payment_template_id:
+            self.customer_invoice_type_id = (
+                self.payment_template_id.customer_invoice_type_id
+            )
+
+    @api.onchange(
+        "payment_template_id",
+    )
+    def onchange_auto_confirm_customer_invoice(self):
+        self.auto_confirm_customer_invoice = False
+        if self.payment_template_id:
+            self.auto_confirm_customer_invoice = (
+                self.payment_template_id.auto_confirm_customer_invoice
+            )
 
     @api.constrains("academic_term_id", "academic_year_id")
     def _check_term_year_match(self):
@@ -859,7 +907,7 @@ Solution: Check create due invoice policy prerequisite
     @ssi_decorator.pre_cancel_action()
     def _10_check_payment_term_invoice(self):
         self.ensure_one()
-        invoiced_terms = self.payment_term_ids.filtered(lambda r: r.invoice_id)
+        invoiced_terms = self.payment_term_ids.filtered(lambda r: r.customer_invoice_id)
         if invoiced_terms:
             error_message = (
                 _(

--- a/ssi_school/models/school_enrollment_fee_analysis.py
+++ b/ssi_school/models/school_enrollment_fee_analysis.py
@@ -103,11 +103,11 @@ class SchoolEnrollmentFeeAnalysis(models.Model):
         readonly=True,
         help="The payment template used to auto-populate billing, if any.",
     )
-    invoice_id = fields.Many2one(
-        string="Invoice",
-        comodel_name="account.move",
+    customer_invoice_id = fields.Many2one(
+        string="Customer Invoice",
+        comodel_name="customer_invoice",
         readonly=True,
-        help="The invoice linked to the payment term, if already generated.",
+        help="The customer invoice linked to the payment term, if generated.",
     )
     term_name = fields.Char(
         string="Term",
@@ -127,8 +127,8 @@ class SchoolEnrollmentFeeAnalysis(models.Model):
         help=(
             "Billing status of the payment term: "
             "Draft = enrollment still in draft/confirm, "
-            "Uninvoiced = enrollment open/done but no invoice yet, "
-            "Invoiced = invoice created, "
+            "Uninvoiced = enrollment open/done but no customer invoice yet, "
+            "Invoiced = customer invoice created, "
             "Manually Controlled = managed manually, "
             "Cancelled = enrollment cancelled."
         ),
@@ -232,7 +232,7 @@ class SchoolEnrollmentFeeAnalysis(models.Model):
                 enr.grade_id AS grade_id,
                 enr.grade_class_id AS grade_class_id,
                 enr.payment_template_id AS payment_template_id,
-                term.invoice_id AS invoice_id,
+                term.customer_invoice_id AS customer_invoice_id,
                 term.name AS term_name,
                 term.state AS term_state,
                 enr.state AS enrollment_state,

--- a/ssi_school/models/school_enrollment_payment_template.py
+++ b/ssi_school/models/school_enrollment_payment_template.py
@@ -84,6 +84,26 @@ class SchoolEnrollmentPaymentTemplate(
             "when this template is selected."
         ),
     )
+    customer_invoice_type_id = fields.Many2one(
+        string="Customer Invoice Type",
+        comodel_name="customer_invoice_type",
+        required=True,
+        ondelete="restrict",
+        help=(
+            "Customer invoice type used for every customer invoice "
+            "generated from the payment terms of an enrollment that "
+            "uses this template."
+        ),
+    )
+    auto_confirm_customer_invoice = fields.Boolean(
+        string="Auto Confirm Customer Invoice",
+        default=False,
+        help=(
+            "If enabled, the customer invoice created from a payment "
+            "term is immediately confirmed instead of being left in "
+            "draft."
+        ),
+    )
     term_ids = fields.One2many(
         string="Payment Terms",
         comodel_name="school_enrollment_payment_template.term",

--- a/ssi_school/models/school_enrollment_payment_term.py
+++ b/ssi_school/models/school_enrollment_payment_term.py
@@ -5,17 +5,23 @@
 from odoo import _, api, fields, models
 from odoo.exceptions import UserError
 
-ADDENDUM_LOCK_ALLOWED_FIELDS = {"invoice_id", "manually_control", "locked", "sequence"}
+ADDENDUM_LOCK_ALLOWED_FIELDS = {
+    "customer_invoice_id",
+    "manually_control",
+    "locked",
+    "sequence",
+}
 
 
 class SchoolEnrollmentPaymentTerm(models.Model):
     """
     Represents an actual payment billing term on a specific enrollment.
     SchoolEnrollmentPaymentTerm is a realized instance of a template term applied
-    to a specific enrollment. Each term can generate one invoice (invoice_id) via
-    action_create_invoice. The state is automatically computed: draft (enrollment
-    in draft/confirm), uninvoiced (enrollment open/done, no invoice yet), invoiced
-    (invoice created), manual (manually controlled), cancelled (enrollment cancelled).
+    to a specific enrollment. Each term can generate one customer invoice
+    (customer_invoice_id) via action_create_invoice. The state is automatically
+    computed: draft (enrollment in draft/confirm), uninvoiced (enrollment
+    open/done, no customer invoice yet), invoiced (customer invoice created),
+    manual (manually controlled), cancelled (enrollment cancelled).
     Totals (amount_untaxed, amount_tax, amount_total) are computed from detail_ids.
     """
 
@@ -24,7 +30,7 @@ class SchoolEnrollmentPaymentTerm(models.Model):
     _order = "sequence, id"
 
     @api.depends(
-        "invoice_id",
+        "customer_invoice_id",
         "enrollment_id.state",
         "manually_control",
     )
@@ -33,7 +39,7 @@ class SchoolEnrollmentPaymentTerm(models.Model):
             if record.enrollment_id.state in ["draft", "confirm"]:
                 state = "draft"
             elif record.enrollment_id.state in ["open", "done"]:
-                if record.invoice_id:
+                if record.customer_invoice_id:
                     state = "invoiced"
                 elif record.manually_control:
                     state = "manual"
@@ -142,12 +148,12 @@ class SchoolEnrollmentPaymentTerm(models.Model):
             "automatically computed from the detail lines."
         ),
     )
-    invoice_id = fields.Many2one(
-        string="# Invoice",
-        comodel_name="account.move",
+    customer_invoice_id = fields.Many2one(
+        string="# Customer Invoice",
+        comodel_name="customer_invoice",
         readonly=True,
         ondelete="restrict",
-        help="The invoice linked to this payment period.",
+        help="The customer invoice linked to this payment period.",
     )
     date_invoice = fields.Date(
         string="Estimated Invoice Date",
@@ -171,8 +177,8 @@ class SchoolEnrollmentPaymentTerm(models.Model):
         help=(
             "Billing status: "
             "Draft = enrollment still in draft/confirm, "
-            "Uninvoiced = enrollment open/done but no invoice yet, "
-            "Invoiced = invoice created, "
+            "Uninvoiced = enrollment open/done but no customer invoice yet, "
+            "Invoiced = customer invoice created, "
             "Manually Controlled = managed manually, "
             "Cancelled = enrollment cancelled."
         ),
@@ -182,7 +188,7 @@ class SchoolEnrollmentPaymentTerm(models.Model):
         default=False,
         help=(
             "If enabled, this billing term is managed manually "
-            "and does not require an invoice."
+            "and does not require a customer invoice."
         ),
     )
     enrollment_state = fields.Selection(
@@ -295,50 +301,97 @@ Solution: Locked payment terms are permanent; create a new one via addendum inst
         self.write({"manually_control": False})
 
     def _create_invoice(self):
+        """Create the ``customer_invoice`` document for this term.
+
+        Creates the header first, then one ``customer_invoice.line`` per
+        detail line, writing the resulting line back onto the detail it
+        originates from, and finally links the document to this term.
+        Taxes are not computed here: ``customer_invoice`` recomputes them
+        itself on pre-confirm. When the enrollment has
+        ``auto_confirm_customer_invoice`` enabled, the new document is
+        confirmed right away.
+
+        :return: None
+        """
         self.ensure_one()
-        invoice = self.env["account.move"].create(self._prepare_invoice_data())
-        self.write({"invoice_id": invoice.id})
+        line_model = self.env["customer_invoice.line"]
+        invoice = self.env["customer_invoice"].create(self._prepare_invoice_data())
+        for detail in self.detail_ids:
+            # pylint: disable=protected-access
+            line_data = detail._prepare_invoice_line()
+            line_data["customer_invoice_id"] = invoice.id
+            line = line_model.create(line_data)
+            detail.write({"customer_invoice_line_id": line.id})
+        self.write({"customer_invoice_id": invoice.id})
+        if self.enrollment_id.auto_confirm_customer_invoice:
+            invoice.action_confirm()
 
     def _disconnect_invoice(self):
+        """Detach the customer invoice from this term without deleting it.
+
+        Only ``customer_invoice_id`` is cleared, so the term falls back to
+        the uninvoiced state while the ``customer_invoice`` document itself
+        is kept.
+
+        :return: None
+        """
         self.ensure_one()
-        self.write({"invoice_id": False})
+        self.write({"customer_invoice_id": False})
 
     def _prepare_invoice_data(self):
+        """Build the ``customer_invoice`` header values for this term.
+
+        Extension point: override in a glue module (Operating Unit, for
+        instance) to add extra header values without touching
+        ``_create_invoice``. Detail lines are deliberately excluded --
+        they are created one by one by ``_create_invoice`` so that each
+        line can be written back to its originating detail.
+
+        :return: dict of ``customer_invoice`` values
+        """
         self.ensure_one()
         enrollment = self.enrollment_id
-        partner = enrollment.student_id.contact_id
-        journal = enrollment.receivable_journal_id
-        lines = []
-        for detail in self.detail_ids:
-            lines += [
-                (
-                    0,
-                    0,
-                    detail._prepare_invoice_line(),  # pylint: disable=protected-access
-                )
-            ]
+        date = self.date_invoice or fields.Date.today()
         return {
-            "date": fields.Date.today(),
-            "ref": enrollment.name,
-            "move_type": "out_invoice",
-            "journal_id": journal.id,
-            "partner_id": partner.id,
+            "type_id": enrollment.customer_invoice_type_id.id,
+            "partner_id": enrollment.student_id.contact_id.id,
             "currency_id": enrollment.currency_id.id,
-            "invoice_user_id": False,
-            "invoice_date": self.date_invoice or fields.Date.today(),
-            "invoice_date_due": self.date_due
-            or self.date_invoice
-            or fields.Date.today(),
-            "invoice_origin": enrollment.name,
-            "invoice_payment_term_id": False,
-            "invoice_line_ids": lines,
+            "pricelist_id": enrollment.pricelist_id.id,
+            "journal_id": enrollment.receivable_journal_id.id,
+            "receivable_account_id": enrollment.receivable_account_id.id,
+            "date": date,
+            "date_due": self.date_due or date,
+            "customer_document_number": enrollment.name,
         }
 
     def _delete_invoice(self):
+        """Delete the customer invoice document created from this term.
+
+        Only a document still in ``draft`` may be deleted. Every detail
+        line is unlinked from its ``customer_invoice.line`` first, then the
+        term is detached, and finally the document is deleted (its lines
+        are removed by cascade).
+
+        :raises UserError: when the customer invoice is no longer draft
+        :return: None
+        """
         self.ensure_one()
-        invoice = self.invoice_id
-        self.detail_ids.write({"invoice_line_id": False})
-        self.write({"invoice_id": False})
+        invoice = self.customer_invoice_id
+        if invoice.state != "draft":
+            error_message = (
+                _(
+                    """
+Context: Delete customer invoice of payment term
+Database ID: %s
+Problem: Customer invoice '%s' is not draft anymore and cannot be deleted
+Solution: Use Disconnect Invoice to detach it from the payment term instead
+"""
+                )
+                % (self.id, invoice.display_name)
+            )
+            raise UserError(error_message)
+        self.detail_ids.write({"customer_invoice_line_id": False})
+        self.write({"customer_invoice_id": False})
         invoice.unlink()
 
     @api.model

--- a/ssi_school/models/school_enrollment_payment_term_detail.py
+++ b/ssi_school/models/school_enrollment_payment_term_detail.py
@@ -5,7 +5,7 @@
 from odoo import _, api, fields, models
 from odoo.exceptions import UserError
 
-ADDENDUM_LOCK_ALLOWED_FIELDS = {"invoice_line_id", "locked", "sequence"}
+ADDENDUM_LOCK_ALLOWED_FIELDS = {"customer_invoice_line_id", "locked", "sequence"}
 
 
 class SchoolEnrollmentPaymentTermDetail(
@@ -15,9 +15,9 @@ class SchoolEnrollmentPaymentTermDetail(
     Represents a product/fee line detail on an actual enrollment payment term.
     Inherits mixin.product_line_account which provides standard product line fields
     such as name, account_id, uom_id, uom_quantity, price_unit, tax_ids,
-    price_subtotal, price_tax, and price_total. If the term is linked to an invoice,
-    each detail line will reference the corresponding invoice line (invoice_line_id)
-    created when the invoice is generated.
+    price_subtotal, price_tax, and price_total. If the term is linked to a customer
+    invoice, each detail line will reference the corresponding customer invoice line
+    (customer_invoice_line_id) created when the customer invoice is generated.
     """
 
     _name = "school_enrollment_payment_term_detail"
@@ -50,14 +50,14 @@ class SchoolEnrollmentPaymentTermDetail(
         store=True,
         help="The pricelist used, automatically taken from the enrollment.",
     )
-    invoice_line_id = fields.Many2one(
-        string="Invoice Line",
-        comodel_name="account.move.line",
+    customer_invoice_line_id = fields.Many2one(
+        string="Customer Invoice Line",
+        comodel_name="customer_invoice.line",
         readonly=True,
         ondelete="restrict",
         help=(
-            "The invoice line linked to this detail, "
-            "automatically populated when the invoice is generated."
+            "The customer invoice line linked to this detail, "
+            "automatically populated when the customer invoice is generated."
         ),
     )
     allowed_product_ids = fields.Many2many(
@@ -143,6 +143,16 @@ Solution: Locked detail lines are permanent; create a new one via the addendum m
             record.allowed_product_ids = result
 
     def _prepare_invoice_line(self):
+        """Build the ``customer_invoice.line`` values for this fee line.
+
+        Extension point: override in a glue module to add extra line
+        values. The link to the parent document
+        (``customer_invoice_id``) is intentionally left out -- it is
+        added by ``school_enrollment_payment_term._create_invoice``,
+        which owns the newly created header.
+
+        :return: dict of ``customer_invoice.line`` values
+        """
         self.ensure_one()
         aa = (  # pylint: disable=invalid-name,consider-using-ternary
             self.analytic_account_id and self.analytic_account_id.id or False
@@ -151,8 +161,8 @@ Solution: Locked detail lines are permanent; create a new one via the addendum m
             "product_id": self.product_id.id,
             "name": self.name,
             "account_id": self.account_id.id,
-            "quantity": self.uom_quantity,
-            "product_uom_id": self.uom_id.id,
+            "uom_id": self.uom_id.id,
+            "uom_quantity": self.uom_quantity,
             "price_unit": self.price_unit,
             "tax_ids": [(6, 0, self.tax_ids.ids)],
             "analytic_account_id": aa or False,

--- a/ssi_school/policy_template/school_enrollment.xml
+++ b/ssi_school/policy_template/school_enrollment.xml
@@ -218,7 +218,7 @@ if document.last_term:
             <field name="restrict_additional" eval="1" />
             <field name="additional_python_code">result = True
 for term in document.payment_term_ids:
-    if term.invoice_id:
+    if term.customer_invoice_id:
         result = False
         break</field>
 </record>

--- a/ssi_school/tests/__init__.py
+++ b/ssi_school/tests/__init__.py
@@ -27,6 +27,7 @@ from . import (  # noqa: F401
     test_school_enrollment_payment_term_duplicate,
     test_school_enrollment_copy_payment_term,
     test_school_enrollment_create_due_invoice,
+    test_school_enrollment_customer_invoice,
     test_school_enrollment_product_summary,
     test_school_enrollment_fee_analysis,
     test_school_enrollment_payment_date_pattern,

--- a/ssi_school/tests/test_data_enrollment.yaml
+++ b/ssi_school/tests/test_data_enrollment.yaml
@@ -3,6 +3,38 @@ options:
 scenarios:
   - name: "Enrollment Full Workflow Create Confirm Approve Invoice Done"
     steps:
+      - step: "Setup - get customer invoice journal"
+        action: "search"
+        model: "account.journal"
+        domain: [["type", "=", "sale"]]
+        save_as: "ci_journal"
+        limit: 1
+
+      - step: "Setup - get receivable account type"
+        action: "ref"
+        xml_id: "account.data_account_type_receivable"
+        save_as: "ci_account_type"
+
+      - step: "Setup - create customer invoice receivable account"
+        action: "create"
+        model: "account.account"
+        save_as: "ci_account"
+        values:
+          name: "Customer Invoice Receivable ENRCI01"
+          code: "ENRCI01"
+          user_type_id: "REC: ci_account_type.id"
+          reconcile: true
+
+      - step: "Setup - create customer invoice type"
+        action: "create"
+        model: "customer_invoice_type"
+        save_as: "ci_type"
+        values:
+          name: "Customer Invoice Type ENRCI01"
+          code: "ENRCI01"
+          journal_id: "REC: ci_journal.id"
+          receivable_account_id: "REC: ci_account.id"
+
       - step: "Setup - get receivable journal"
         action: "search"
         model: "account.journal"
@@ -137,6 +169,7 @@ scenarios:
         model: "school_enrollment_payment_template"
         save_as: "payment_template"
         values:
+          customer_invoice_type_id: "REC: ci_type.id"
           name: "Enrollment Payment Template Test"
           code: "ENRPMT001"
           school_id: "EVAL: registry['school'].id"
@@ -175,6 +208,8 @@ scenarios:
         model: "school_enrollment"
         save_as: "enrollment"
         values:
+          customer_invoice_type_id: "REC: ci_type.id"
+          receivable_account_id: "REC: ci_account.id"
           date: "2024-07-01"
           academic_year_id: "EVAL: registry['academic_year'].id"
           academic_term_id: "EVAL: registry['academic_term'].id"
@@ -260,6 +295,38 @@ scenarios:
 
   - name: "Enrollment Workflow One Manual Term Done"
     steps:
+      - step: "Setup - get customer invoice journal"
+        action: "search"
+        model: "account.journal"
+        domain: [["type", "=", "sale"]]
+        save_as: "ci_journal"
+        limit: 1
+
+      - step: "Setup - get receivable account type"
+        action: "ref"
+        xml_id: "account.data_account_type_receivable"
+        save_as: "ci_account_type"
+
+      - step: "Setup - create customer invoice receivable account"
+        action: "create"
+        model: "account.account"
+        save_as: "ci_account"
+        values:
+          name: "Customer Invoice Receivable ENRCI02"
+          code: "ENRCI02"
+          user_type_id: "REC: ci_account_type.id"
+          reconcile: true
+
+      - step: "Setup - create customer invoice type"
+        action: "create"
+        model: "customer_invoice_type"
+        save_as: "ci_type"
+        values:
+          name: "Customer Invoice Type ENRCI02"
+          code: "ENRCI02"
+          journal_id: "REC: ci_journal.id"
+          receivable_account_id: "REC: ci_account.id"
+
       - step: "Setup - get receivable journal"
         action: "search"
         model: "account.journal"
@@ -394,6 +461,7 @@ scenarios:
         model: "school_enrollment_payment_template"
         save_as: "payment_template"
         values:
+          customer_invoice_type_id: "REC: ci_type.id"
           name: "Enrollment Payment Template Test 2"
           code: "ENRPMT002"
           school_id: "EVAL: registry['school'].id"
@@ -432,6 +500,8 @@ scenarios:
         model: "school_enrollment"
         save_as: "enrollment"
         values:
+          customer_invoice_type_id: "REC: ci_type.id"
+          receivable_account_id: "REC: ci_account.id"
           date: "2024-07-01"
           academic_year_id: "EVAL: registry['academic_year'].id"
           academic_term_id: "EVAL: registry['academic_term'].id"
@@ -511,7 +581,7 @@ scenarios:
         action: "assert"
         target: "term_2"
         asserts:
-          invoice_id:
+          customer_invoice_id:
             type: "value"
             operator: "is_truthy"
 
@@ -519,7 +589,7 @@ scenarios:
         action: "assert"
         target: "term_1"
         asserts:
-          invoice_id:
+          customer_invoice_id:
             type: "value"
             operator: "is_falsy"
 

--- a/ssi_school/tests/test_data_enrollment_addendum.yaml
+++ b/ssi_school/tests/test_data_enrollment_addendum.yaml
@@ -3,6 +3,38 @@ options:
 scenarios:
   - name: "Addendum - Existing Payment Term Is Locked After Enrollment Opens"
     steps:
+      - step: "Setup - get customer invoice journal"
+        action: "search"
+        model: "account.journal"
+        domain: [["type", "=", "sale"]]
+        save_as: "ci_journal"
+        limit: 1
+
+      - step: "Setup - get receivable account type"
+        action: "ref"
+        xml_id: "account.data_account_type_receivable"
+        save_as: "ci_account_type"
+
+      - step: "Setup - create customer invoice receivable account"
+        action: "create"
+        model: "account.account"
+        save_as: "ci_account"
+        values:
+          name: "Customer Invoice Receivable ADDCI01"
+          code: "ADDCI01"
+          user_type_id: "REC: ci_account_type.id"
+          reconcile: true
+
+      - step: "Setup - create customer invoice type"
+        action: "create"
+        model: "customer_invoice_type"
+        save_as: "ci_type"
+        values:
+          name: "Customer Invoice Type ADDCI01"
+          code: "ADDCI01"
+          journal_id: "REC: ci_journal.id"
+          receivable_account_id: "REC: ci_account.id"
+
       - step: "Setup - get receivable journal"
         action: "search"
         model: "account.journal"
@@ -123,6 +155,7 @@ scenarios:
         model: "school_enrollment_payment_template"
         save_as: "payment_template"
         values:
+          customer_invoice_type_id: "REC: ci_type.id"
           name: "Payment Template ADDEN1"
           code: "PMTADDEN1"
           school_id: "EVAL: registry['school'].id"
@@ -149,6 +182,8 @@ scenarios:
         save_as: "enrollment"
         as_user: "base.user_admin"
         values:
+          customer_invoice_type_id: "REC: ci_type.id"
+          receivable_account_id: "REC: ci_account.id"
           date: "2024-07-01"
           academic_year_id: "EVAL: registry['academic_year'].id"
           academic_term_id: "EVAL: registry['academic_term'].id"

--- a/ssi_school/tests/test_data_enrollment_copy_payment_term.yaml
+++ b/ssi_school/tests/test_data_enrollment_copy_payment_term.yaml
@@ -218,7 +218,7 @@ scenarios:
           sequence:
             type: "value"
             expected: 10
-          invoice_id:
+          customer_invoice_id:
             type: "value"
             operator: "is_falsy"
           detail_ids:
@@ -244,7 +244,7 @@ scenarios:
           price_unit:
             type: "value"
             expected: 500000.0
-          invoice_line_id:
+          customer_invoice_line_id:
             type: "value"
             operator: "is_falsy"
 

--- a/ssi_school/tests/test_data_enrollment_create_due_invoice.yaml
+++ b/ssi_school/tests/test_data_enrollment_create_due_invoice.yaml
@@ -3,6 +3,38 @@ options:
 scenarios:
   - name: "Create Due Invoice - No Range Invoices Only Due Terms"
     steps:
+      - step: "Setup - get customer invoice journal"
+        action: "search"
+        model: "account.journal"
+        domain: [["type", "=", "sale"]]
+        save_as: "ci_journal"
+        limit: 1
+
+      - step: "Setup - get receivable account type"
+        action: "ref"
+        xml_id: "account.data_account_type_receivable"
+        save_as: "ci_account_type"
+
+      - step: "Setup - create customer invoice receivable account"
+        action: "create"
+        model: "account.account"
+        save_as: "ci_account"
+        values:
+          name: "Customer Invoice Receivable CDICI01"
+          code: "CDICI01"
+          user_type_id: "REC: ci_account_type.id"
+          reconcile: true
+
+      - step: "Setup - create customer invoice type"
+        action: "create"
+        model: "customer_invoice_type"
+        save_as: "ci_type"
+        values:
+          name: "Customer Invoice Type CDICI01"
+          code: "CDICI01"
+          journal_id: "REC: ci_journal.id"
+          receivable_account_id: "REC: ci_account.id"
+
       - step: "Setup - get account type ref"
         action: "ref"
         xml_id: "account.data_account_type_revenue"
@@ -115,6 +147,9 @@ scenarios:
         model: "school_enrollment"
         save_as: "enrollment"
         values:
+          customer_invoice_type_id: "REC: ci_type.id"
+          receivable_account_id: "REC: ci_account.id"
+          pricelist_id: "REF: product.list0"
           date: "2024-07-01"
           academic_year_id: "REC: academic_year.id"
           academic_term_id: "REC: academic_term.id"
@@ -253,7 +288,7 @@ scenarios:
           state:
             type: "value"
             expected: "invoiced"
-          invoice_id:
+          customer_invoice_id:
             type: "value"
             operator: "is_truthy"
 
@@ -264,7 +299,7 @@ scenarios:
           state:
             type: "value"
             expected: "invoiced"
-          invoice_id:
+          customer_invoice_id:
             type: "value"
             operator: "is_truthy"
 
@@ -275,7 +310,7 @@ scenarios:
           state:
             type: "value"
             expected: "uninvoiced"
-          invoice_id:
+          customer_invoice_id:
             type: "value"
             operator: "is_falsy"
 
@@ -286,7 +321,7 @@ scenarios:
           state:
             type: "value"
             expected: "manual"
-          invoice_id:
+          customer_invoice_id:
             type: "value"
             operator: "is_falsy"
 
@@ -297,12 +332,44 @@ scenarios:
           state:
             type: "value"
             expected: "uninvoiced"
-          invoice_id:
+          customer_invoice_id:
             type: "value"
             operator: "is_falsy"
 
   - name: "Create Due Invoice - Future Date End Includes Term C"
     steps:
+      - step: "Setup - get customer invoice journal"
+        action: "search"
+        model: "account.journal"
+        domain: [["type", "=", "sale"]]
+        save_as: "ci_journal"
+        limit: 1
+
+      - step: "Setup - get receivable account type"
+        action: "ref"
+        xml_id: "account.data_account_type_receivable"
+        save_as: "ci_account_type"
+
+      - step: "Setup - create customer invoice receivable account"
+        action: "create"
+        model: "account.account"
+        save_as: "ci_account"
+        values:
+          name: "Customer Invoice Receivable CDICI02"
+          code: "CDICI02"
+          user_type_id: "REC: ci_account_type.id"
+          reconcile: true
+
+      - step: "Setup - create customer invoice type"
+        action: "create"
+        model: "customer_invoice_type"
+        save_as: "ci_type"
+        values:
+          name: "Customer Invoice Type CDICI02"
+          code: "CDICI02"
+          journal_id: "REC: ci_journal.id"
+          receivable_account_id: "REC: ci_account.id"
+
       - step: "Setup - get account type ref"
         action: "ref"
         xml_id: "account.data_account_type_revenue"
@@ -415,6 +482,9 @@ scenarios:
         model: "school_enrollment"
         save_as: "enrollment"
         values:
+          customer_invoice_type_id: "REC: ci_type.id"
+          receivable_account_id: "REC: ci_account.id"
+          pricelist_id: "REF: product.list0"
           date: "2024-07-01"
           academic_year_id: "REC: academic_year.id"
           academic_term_id: "REC: academic_term.id"
@@ -562,7 +632,7 @@ scenarios:
           state:
             type: "value"
             expected: "invoiced"
-          invoice_id:
+          customer_invoice_id:
             type: "value"
             operator: "is_truthy"
 
@@ -584,6 +654,38 @@ scenarios:
 
   - name: "Create Due Invoice - Date Start Only Excludes Past And Future Terms"
     steps:
+      - step: "Setup - get customer invoice journal"
+        action: "search"
+        model: "account.journal"
+        domain: [["type", "=", "sale"]]
+        save_as: "ci_journal"
+        limit: 1
+
+      - step: "Setup - get receivable account type"
+        action: "ref"
+        xml_id: "account.data_account_type_receivable"
+        save_as: "ci_account_type"
+
+      - step: "Setup - create customer invoice receivable account"
+        action: "create"
+        model: "account.account"
+        save_as: "ci_account"
+        values:
+          name: "Customer Invoice Receivable CDICI03"
+          code: "CDICI03"
+          user_type_id: "REC: ci_account_type.id"
+          reconcile: true
+
+      - step: "Setup - create customer invoice type"
+        action: "create"
+        model: "customer_invoice_type"
+        save_as: "ci_type"
+        values:
+          name: "Customer Invoice Type CDICI03"
+          code: "CDICI03"
+          journal_id: "REC: ci_journal.id"
+          receivable_account_id: "REC: ci_account.id"
+
       - step: "Setup - get account type ref"
         action: "ref"
         xml_id: "account.data_account_type_revenue"
@@ -696,6 +798,9 @@ scenarios:
         model: "school_enrollment"
         save_as: "enrollment"
         values:
+          customer_invoice_type_id: "REC: ci_type.id"
+          receivable_account_id: "REC: ci_account.id"
+          pricelist_id: "REF: product.list0"
           date: "2024-07-01"
           academic_year_id: "REC: academic_year.id"
           academic_term_id: "REC: academic_term.id"
@@ -835,7 +940,7 @@ scenarios:
           state:
             type: "value"
             expected: "invoiced"
-          invoice_id:
+          customer_invoice_id:
             type: "value"
             operator: "is_truthy"
 
@@ -865,6 +970,38 @@ scenarios:
 
   - name: "Create Due Invoice - Both Dates Set Narrows To Term A Only"
     steps:
+      - step: "Setup - get customer invoice journal"
+        action: "search"
+        model: "account.journal"
+        domain: [["type", "=", "sale"]]
+        save_as: "ci_journal"
+        limit: 1
+
+      - step: "Setup - get receivable account type"
+        action: "ref"
+        xml_id: "account.data_account_type_receivable"
+        save_as: "ci_account_type"
+
+      - step: "Setup - create customer invoice receivable account"
+        action: "create"
+        model: "account.account"
+        save_as: "ci_account"
+        values:
+          name: "Customer Invoice Receivable CDICI04"
+          code: "CDICI04"
+          user_type_id: "REC: ci_account_type.id"
+          reconcile: true
+
+      - step: "Setup - create customer invoice type"
+        action: "create"
+        model: "customer_invoice_type"
+        save_as: "ci_type"
+        values:
+          name: "Customer Invoice Type CDICI04"
+          code: "CDICI04"
+          journal_id: "REC: ci_journal.id"
+          receivable_account_id: "REC: ci_account.id"
+
       - step: "Setup - get account type ref"
         action: "ref"
         xml_id: "account.data_account_type_revenue"
@@ -977,6 +1114,9 @@ scenarios:
         model: "school_enrollment"
         save_as: "enrollment"
         values:
+          customer_invoice_type_id: "REC: ci_type.id"
+          receivable_account_id: "REC: ci_account.id"
+          pricelist_id: "REF: product.list0"
           date: "2024-07-01"
           academic_year_id: "REC: academic_year.id"
           academic_term_id: "REC: academic_term.id"
@@ -1109,7 +1249,7 @@ scenarios:
           state:
             type: "value"
             expected: "invoiced"
-          invoice_id:
+          customer_invoice_id:
             type: "value"
             operator: "is_truthy"
 
@@ -1147,6 +1287,38 @@ scenarios:
 
   - name: "Create Due Invoice - Idempotent On Repeated Run"
     steps:
+      - step: "Setup - get customer invoice journal"
+        action: "search"
+        model: "account.journal"
+        domain: [["type", "=", "sale"]]
+        save_as: "ci_journal"
+        limit: 1
+
+      - step: "Setup - get receivable account type"
+        action: "ref"
+        xml_id: "account.data_account_type_receivable"
+        save_as: "ci_account_type"
+
+      - step: "Setup - create customer invoice receivable account"
+        action: "create"
+        model: "account.account"
+        save_as: "ci_account"
+        values:
+          name: "Customer Invoice Receivable CDICI05"
+          code: "CDICI05"
+          user_type_id: "REC: ci_account_type.id"
+          reconcile: true
+
+      - step: "Setup - create customer invoice type"
+        action: "create"
+        model: "customer_invoice_type"
+        save_as: "ci_type"
+        values:
+          name: "Customer Invoice Type CDICI05"
+          code: "CDICI05"
+          journal_id: "REC: ci_journal.id"
+          receivable_account_id: "REC: ci_account.id"
+
       - step: "Setup - get account type ref"
         action: "ref"
         xml_id: "account.data_account_type_revenue"
@@ -1259,6 +1431,9 @@ scenarios:
         model: "school_enrollment"
         save_as: "enrollment"
         values:
+          customer_invoice_type_id: "REC: ci_type.id"
+          receivable_account_id: "REC: ci_account.id"
+          pricelist_id: "REF: product.list0"
           date: "2024-07-01"
           academic_year_id: "REC: academic_year.id"
           academic_term_id: "REC: academic_term.id"
@@ -1345,8 +1520,8 @@ scenarios:
 
       - step: "Assert two invoices exist after the first run"
         action: "search"
-        model: "account.move"
-        domain: [["invoice_origin", "=", "REC: enrollment.name"]]
+        model: "customer_invoice"
+        domain: [["customer_document_number", "=", "REC: enrollment.name"]]
         save_as: "invoices_after_run1"
         expect_count: 2
 
@@ -1357,8 +1532,8 @@ scenarios:
 
       - step: "Assert invoice count is unchanged after the second run"
         action: "search"
-        model: "account.move"
-        domain: [["invoice_origin", "=", "REC: enrollment.name"]]
+        model: "customer_invoice"
+        domain: [["customer_document_number", "=", "REC: enrollment.name"]]
         save_as: "invoices_after_run2"
         expect_count: 2
 
@@ -1369,7 +1544,7 @@ scenarios:
           state:
             type: "value"
             expected: "invoiced"
-          invoice_id:
+          customer_invoice_id:
             type: "value"
             operator: "is_truthy"
 
@@ -1380,12 +1555,44 @@ scenarios:
           state:
             type: "value"
             expected: "invoiced"
-          invoice_id:
+          customer_invoice_id:
             type: "value"
             operator: "is_truthy"
 
   - name: "Create Due Invoice - Blocked When Selection Includes A Non-Open Enrollment"
     steps:
+      - step: "Setup - get customer invoice journal"
+        action: "search"
+        model: "account.journal"
+        domain: [["type", "=", "sale"]]
+        save_as: "ci_journal"
+        limit: 1
+
+      - step: "Setup - get receivable account type"
+        action: "ref"
+        xml_id: "account.data_account_type_receivable"
+        save_as: "ci_account_type"
+
+      - step: "Setup - create customer invoice receivable account"
+        action: "create"
+        model: "account.account"
+        save_as: "ci_account"
+        values:
+          name: "Customer Invoice Receivable CDICI06"
+          code: "CDICI06"
+          user_type_id: "REC: ci_account_type.id"
+          reconcile: true
+
+      - step: "Setup - create customer invoice type"
+        action: "create"
+        model: "customer_invoice_type"
+        save_as: "ci_type"
+        values:
+          name: "Customer Invoice Type CDICI06"
+          code: "CDICI06"
+          journal_id: "REC: ci_journal.id"
+          receivable_account_id: "REC: ci_account.id"
+
       - step: "Setup - get account type ref"
         action: "ref"
         xml_id: "account.data_account_type_revenue"
@@ -1498,6 +1705,9 @@ scenarios:
         model: "school_enrollment"
         save_as: "enrollment"
         values:
+          customer_invoice_type_id: "REC: ci_type.id"
+          receivable_account_id: "REC: ci_account.id"
+          pricelist_id: "REF: product.list0"
           date: "2024-07-01"
           academic_year_id: "REC: academic_year.id"
           academic_term_id: "REC: academic_term.id"
@@ -1570,6 +1780,9 @@ scenarios:
         model: "school_enrollment"
         save_as: "enrollment_draft"
         values:
+          customer_invoice_type_id: "REC: ci_type.id"
+          receivable_account_id: "REC: ci_account.id"
+          pricelist_id: "REF: product.list0"
           date: "2024-07-01"
           academic_year_id: "REC: academic_year.id"
           academic_term_id: "REC: academic_term.id"
@@ -1612,19 +1825,51 @@ scenarios:
           state:
             type: "value"
             expected: "uninvoiced"
-          invoice_id:
+          customer_invoice_id:
             type: "value"
             operator: "is_falsy"
 
       - step: "Assert no invoice was created for the valid enrollment either"
         action: "search"
-        model: "account.move"
-        domain: [["invoice_origin", "=", "REC: enrollment.name"]]
+        model: "customer_invoice"
+        domain: [["customer_document_number", "=", "REC: enrollment.name"]]
         save_as: "invoices_after_failed_run"
         expect_count: 0
 
   - name: "Create Due Invoice - Blocked When Date Start Is Later Than Date End"
     steps:
+      - step: "Setup - get customer invoice journal"
+        action: "search"
+        model: "account.journal"
+        domain: [["type", "=", "sale"]]
+        save_as: "ci_journal"
+        limit: 1
+
+      - step: "Setup - get receivable account type"
+        action: "ref"
+        xml_id: "account.data_account_type_receivable"
+        save_as: "ci_account_type"
+
+      - step: "Setup - create customer invoice receivable account"
+        action: "create"
+        model: "account.account"
+        save_as: "ci_account"
+        values:
+          name: "Customer Invoice Receivable CDICI07"
+          code: "CDICI07"
+          user_type_id: "REC: ci_account_type.id"
+          reconcile: true
+
+      - step: "Setup - create customer invoice type"
+        action: "create"
+        model: "customer_invoice_type"
+        save_as: "ci_type"
+        values:
+          name: "Customer Invoice Type CDICI07"
+          code: "CDICI07"
+          journal_id: "REC: ci_journal.id"
+          receivable_account_id: "REC: ci_account.id"
+
       - step: "Setup - get account type ref"
         action: "ref"
         xml_id: "account.data_account_type_revenue"
@@ -1737,6 +1982,9 @@ scenarios:
         model: "school_enrollment"
         save_as: "enrollment"
         values:
+          customer_invoice_type_id: "REC: ci_type.id"
+          receivable_account_id: "REC: ci_account.id"
+          pricelist_id: "REF: product.list0"
           date: "2024-07-01"
           academic_year_id: "REC: academic_year.id"
           academic_term_id: "REC: academic_term.id"
@@ -1814,13 +2062,13 @@ scenarios:
           state:
             type: "value"
             expected: "uninvoiced"
-          invoice_id:
+          customer_invoice_id:
             type: "value"
             operator: "is_falsy"
 
       - step: "Assert no invoice was created"
         action: "search"
-        model: "account.move"
-        domain: [["invoice_origin", "=", "REC: enrollment.name"]]
+        model: "customer_invoice"
+        domain: [["customer_document_number", "=", "REC: enrollment.name"]]
         save_as: "invoices_after_failed_range"
         expect_count: 0

--- a/ssi_school/tests/test_data_enrollment_customer_invoice.yaml
+++ b/ssi_school/tests/test_data_enrollment_customer_invoice.yaml
@@ -1,0 +1,1815 @@
+options:
+  auto_refresh: true
+scenarios:
+  - name: "Create Customer Invoice From Payment Term"
+    steps:
+      - step: "Setup - get sale journal"
+        action: "search"
+        model: "account.journal"
+        domain: [["type", "=", "sale"]]
+        save_as: "journal"
+        limit: 1
+
+      - step: "Setup - get revenue account type"
+        action: "ref"
+        xml_id: "account.data_account_type_revenue"
+        save_as: "revenue_type"
+
+      - step: "Setup - get receivable account type"
+        action: "ref"
+        xml_id: "account.data_account_type_receivable"
+        save_as: "receivable_type"
+
+      - step: "Setup - create income account"
+        action: "create"
+        model: "account.account"
+        save_as: "income_account"
+        values:
+          name: "School Fee Income SCI1"
+          code: "SCI14200"
+          user_type_id: "REC: revenue_type.id"
+
+      - step: "Setup - create receivable account"
+        action: "create"
+        model: "account.account"
+        save_as: "receivable_account"
+        values:
+          name: "School Receivable SCI1"
+          code: "SCI11100"
+          user_type_id: "REC: receivable_type.id"
+          reconcile: true
+
+      - step: "Setup - create customer invoice type"
+        action: "create"
+        model: "customer_invoice_type"
+        save_as: "ci_type"
+        values:
+          name: "Customer Invoice Type SCI1"
+          code: "CITSCI1"
+          journal_id: "REC: journal.id"
+          receivable_account_id: "REC: receivable_account.id"
+
+      - step: "Setup - create product"
+        action: "create"
+        model: "product.product"
+        save_as: "product"
+        values:
+          name: "School Fee SCI1"
+          type: "service"
+          list_price: 1000000.0
+
+      - step: "Setup - create pricelist"
+        action: "create"
+        model: "product.pricelist"
+        save_as: "pricelist"
+        values:
+          name: "School Pricelist SCI1"
+          currency_id: "REC: company.currency_id.id"
+
+      - step: "Setup - create grade type"
+        action: "create"
+        model: "school_grade_type"
+        save_as: "grade_type"
+        values:
+          name: "Grade Type SCI1"
+          code: "GTSCI1"
+          sequence: 10
+
+      - step: "Setup - create academic year"
+        action: "create"
+        model: "school_academic_year"
+        save_as: "academic_year"
+        values:
+          name: "2024/2025 SCI1"
+          code: "AYSCI1"
+          date_start: "2024-07-01"
+          date_end: "2025-06-30"
+
+      - step: "Setup - create academic term"
+        action: "create"
+        model: "school_academic_term"
+        save_as: "academic_term"
+        values:
+          name: "Semester SCI1"
+          code: "SMSCI1"
+          date_start: "2024-07-01"
+          date_end: "2025-06-30"
+          year_id: "REC: academic_year.id"
+          enrollment_state: "open"
+
+      - step: "Setup - create school"
+        action: "create"
+        model: "school"
+        save_as: "school"
+        values:
+          name: "School SCI1"
+          code: "SCHSCI1"
+          grade_type_id: "REC: grade_type.id"
+
+      - step: "Setup - create grade"
+        action: "create"
+        model: "school_grade"
+        save_as: "grade"
+        values:
+          name: "Grade SCI1"
+          code: "GSCI1"
+          sequence: 10
+          type_id: "REC: grade_type.id"
+
+      - step: "Setup - create grade class"
+        action: "create"
+        model: "school_grade_class"
+        save_as: "grade_class"
+        values:
+          name: "Class SCI1"
+          code: "CLASCI1"
+          school_id: "REC: school.id"
+          grade_id: "REC: grade.id"
+
+      - step: "Setup - create student contact"
+        action: "create"
+        model: "res.partner"
+        save_as: "contact"
+        values:
+          name: "Student Contact SCI1"
+
+      - step: "Setup - create student"
+        action: "create"
+        model: "school_student"
+        save_as: "student"
+        values:
+          name: "Student SCI1"
+          code: "STUSCI1"
+          contact_id: "REC: contact.id"
+          school_id: "REC: school.id"
+
+      - step: "Setup - create payment template"
+        action: "create"
+        model: "school_enrollment_payment_template"
+        save_as: "payment_template"
+        values:
+          name: "Payment Template SCI1"
+          code: "PMTSCI1"
+          school_id: "REC: school.id"
+          grade_id: "REC: grade.id"
+          academic_term_id: "REC: academic_term.id"
+          journal_id: "REC: journal.id"
+          receivable_account_id: "REC: receivable_account.id"
+          customer_invoice_type_id: "REC: ci_type.id"
+          auto_confirm_customer_invoice: false
+
+      - step: "Create enrollment"
+        action: "create"
+        model: "school_enrollment"
+        save_as: "enrollment"
+        values:
+          date: "2024-07-01"
+          academic_year_id: "REC: academic_year.id"
+          academic_term_id: "REC: academic_term.id"
+          school_id: "REC: school.id"
+          grade_id: "REC: grade.id"
+          grade_class_id: "REC: grade_class.id"
+          student_id: "REC: student.id"
+          currency_id: "REC: company.currency_id.id"
+          pricelist_id: "REC: pricelist.id"
+          receivable_journal_id: "REC: journal.id"
+          receivable_account_id: "REC: receivable_account.id"
+          customer_invoice_type_id: "REC: payment_template.customer_invoice_type_id.id"
+          auto_confirm_customer_invoice:
+            "REC: payment_template.auto_confirm_customer_invoice"
+
+      - step: "Create payment term"
+        action: "create"
+        model: "school_enrollment_payment_term"
+        save_as: "term"
+        values:
+          enrollment_id: "REC: enrollment.id"
+          name: "Term SCI1"
+          sequence: 10
+          date_invoice: "2024-07-05"
+          date_due: "2024-07-20"
+
+      - step: "Create first payment term detail"
+        action: "create"
+        model: "school_enrollment_payment_term_detail"
+        save_as: "detail_1"
+        values:
+          term_id: "REC: term.id"
+          product_id: "REC: product.id"
+          name: "Registration Fee SCI1"
+          account_id: "REC: income_account.id"
+          uom_quantity: 1.0
+          uom_id: "REF: uom.product_uom_unit"
+          price_unit: 1000000.0
+
+      - step: "Create second payment term detail"
+        action: "create"
+        model: "school_enrollment_payment_term_detail"
+        save_as: "detail_2"
+        values:
+          term_id: "REC: term.id"
+          product_id: "REC: product.id"
+          name: "Monthly Tuition SCI1"
+          account_id: "REC: income_account.id"
+          uom_quantity: 1.0
+          uom_id: "REF: uom.product_uom_unit"
+          price_unit: 500000.0
+
+      - step: "Confirm enrollment"
+        action: "call"
+        target: "enrollment"
+        method: "action_confirm"
+        as_user: "base.user_admin"
+
+      - step: "Invalidate enrollment cache before approve"
+        action: "call"
+        target: "enrollment"
+        method: "invalidate_cache"
+
+      - step: "Approve enrollment"
+        action: "call"
+        target: "enrollment"
+        method: "action_approve_approval"
+        as_user: "base.user_admin"
+        asserts:
+          state:
+            type: "value"
+            expected: "open"
+
+      - step: "Create customer invoice from the payment term"
+        action: "call"
+        target: "term"
+        method: "action_create_invoice"
+        as_user: "base.user_admin"
+
+      - step: "Assert term is invoiced and linked to a customer invoice"
+        action: "assert"
+        target: "term"
+        asserts:
+          state:
+            type: "value"
+            expected: "invoiced"
+          customer_invoice_id:
+            type: "value"
+            operator: "is_truthy"
+          customer_invoice_id.state:
+            type: "value"
+            expected: "draft"
+          customer_invoice_id.type_id.id:
+            type: "value"
+            expected: "REC: ci_type.id"
+          customer_invoice_id.partner_id.id:
+            type: "value"
+            expected: "REC: contact.id"
+          customer_invoice_id.customer_document_number:
+            type: "value"
+            expected: "REC: enrollment.name"
+          customer_invoice_id.amount_untaxed:
+            type: "value"
+            expected: 1500000.0
+
+      - step: "Assert first detail is linked to its own customer invoice line"
+        action: "assert"
+        target: "detail_1"
+        asserts:
+          customer_invoice_line_id:
+            type: "value"
+            operator: "is_truthy"
+          customer_invoice_line_id.name:
+            type: "value"
+            expected: "Registration Fee SCI1"
+          customer_invoice_line_id.price_unit:
+            type: "value"
+            expected: 1000000.0
+          customer_invoice_line_id.customer_invoice_id.id:
+            type: "value"
+            expected: "REC: term.customer_invoice_id.id"
+
+      - step: "Assert second detail is linked to its own customer invoice line"
+        action: "assert"
+        target: "detail_2"
+        asserts:
+          customer_invoice_line_id:
+            type: "value"
+            operator: "is_truthy"
+          customer_invoice_line_id.name:
+            type: "value"
+            expected: "Monthly Tuition SCI1"
+          customer_invoice_line_id.price_unit:
+            type: "value"
+            expected: 500000.0
+          customer_invoice_line_id.customer_invoice_id.id:
+            type: "value"
+            expected: "REC: term.customer_invoice_id.id"
+
+  - name: "Auto Confirm Customer Invoice From Payment Template"
+    steps:
+      - step: "Setup - get sale journal"
+        action: "search"
+        model: "account.journal"
+        domain: [["type", "=", "sale"]]
+        save_as: "journal"
+        limit: 1
+
+      - step: "Setup - get revenue account type"
+        action: "ref"
+        xml_id: "account.data_account_type_revenue"
+        save_as: "revenue_type"
+
+      - step: "Setup - get receivable account type"
+        action: "ref"
+        xml_id: "account.data_account_type_receivable"
+        save_as: "receivable_type"
+
+      - step: "Setup - create income account"
+        action: "create"
+        model: "account.account"
+        save_as: "income_account"
+        values:
+          name: "School Fee Income SCI2"
+          code: "SCI24200"
+          user_type_id: "REC: revenue_type.id"
+
+      - step: "Setup - create receivable account"
+        action: "create"
+        model: "account.account"
+        save_as: "receivable_account"
+        values:
+          name: "School Receivable SCI2"
+          code: "SCI21100"
+          user_type_id: "REC: receivable_type.id"
+          reconcile: true
+
+      - step: "Setup - create customer invoice type"
+        action: "create"
+        model: "customer_invoice_type"
+        save_as: "ci_type"
+        values:
+          name: "Customer Invoice Type SCI2"
+          code: "CITSCI2"
+          journal_id: "REC: journal.id"
+          receivable_account_id: "REC: receivable_account.id"
+
+      - step: "Setup - create product"
+        action: "create"
+        model: "product.product"
+        save_as: "product"
+        values:
+          name: "School Fee SCI2"
+          type: "service"
+          list_price: 1000000.0
+
+      - step: "Setup - create pricelist"
+        action: "create"
+        model: "product.pricelist"
+        save_as: "pricelist"
+        values:
+          name: "School Pricelist SCI2"
+          currency_id: "REC: company.currency_id.id"
+
+      - step: "Setup - create grade type"
+        action: "create"
+        model: "school_grade_type"
+        save_as: "grade_type"
+        values:
+          name: "Grade Type SCI2"
+          code: "GTSCI2"
+          sequence: 10
+
+      - step: "Setup - create academic year"
+        action: "create"
+        model: "school_academic_year"
+        save_as: "academic_year"
+        values:
+          name: "2024/2025 SCI2"
+          code: "AYSCI2"
+          date_start: "2024-07-01"
+          date_end: "2025-06-30"
+
+      - step: "Setup - create academic term"
+        action: "create"
+        model: "school_academic_term"
+        save_as: "academic_term"
+        values:
+          name: "Semester SCI2"
+          code: "SMSCI2"
+          date_start: "2024-07-01"
+          date_end: "2025-06-30"
+          year_id: "REC: academic_year.id"
+          enrollment_state: "open"
+
+      - step: "Setup - create school"
+        action: "create"
+        model: "school"
+        save_as: "school"
+        values:
+          name: "School SCI2"
+          code: "SCHSCI2"
+          grade_type_id: "REC: grade_type.id"
+
+      - step: "Setup - create grade"
+        action: "create"
+        model: "school_grade"
+        save_as: "grade"
+        values:
+          name: "Grade SCI2"
+          code: "GSCI2"
+          sequence: 10
+          type_id: "REC: grade_type.id"
+
+      - step: "Setup - create grade class"
+        action: "create"
+        model: "school_grade_class"
+        save_as: "grade_class"
+        values:
+          name: "Class SCI2"
+          code: "CLASCI2"
+          school_id: "REC: school.id"
+          grade_id: "REC: grade.id"
+
+      - step: "Setup - create student contact"
+        action: "create"
+        model: "res.partner"
+        save_as: "contact"
+        values:
+          name: "Student Contact SCI2"
+
+      - step: "Setup - create student"
+        action: "create"
+        model: "school_student"
+        save_as: "student"
+        values:
+          name: "Student SCI2"
+          code: "STUSCI2"
+          contact_id: "REC: contact.id"
+          school_id: "REC: school.id"
+
+      - step: "Setup - create payment template"
+        action: "create"
+        model: "school_enrollment_payment_template"
+        save_as: "payment_template"
+        values:
+          name: "Payment Template SCI2"
+          code: "PMTSCI2"
+          school_id: "REC: school.id"
+          grade_id: "REC: grade.id"
+          academic_term_id: "REC: academic_term.id"
+          journal_id: "REC: journal.id"
+          receivable_account_id: "REC: receivable_account.id"
+          customer_invoice_type_id: "REC: ci_type.id"
+          auto_confirm_customer_invoice: true
+
+      - step: "Create enrollment"
+        action: "create"
+        model: "school_enrollment"
+        save_as: "enrollment"
+        values:
+          date: "2024-07-01"
+          academic_year_id: "REC: academic_year.id"
+          academic_term_id: "REC: academic_term.id"
+          school_id: "REC: school.id"
+          grade_id: "REC: grade.id"
+          grade_class_id: "REC: grade_class.id"
+          student_id: "REC: student.id"
+          currency_id: "REC: company.currency_id.id"
+          pricelist_id: "REC: pricelist.id"
+          receivable_journal_id: "REC: journal.id"
+          receivable_account_id: "REC: receivable_account.id"
+          customer_invoice_type_id: "REC: payment_template.customer_invoice_type_id.id"
+          auto_confirm_customer_invoice:
+            "REC: payment_template.auto_confirm_customer_invoice"
+
+      - step: "Create payment term"
+        action: "create"
+        model: "school_enrollment_payment_term"
+        save_as: "term"
+        values:
+          enrollment_id: "REC: enrollment.id"
+          name: "Term SCI2"
+          sequence: 10
+          date_invoice: "2024-07-05"
+          date_due: "2024-07-20"
+
+      - step: "Create first payment term detail"
+        action: "create"
+        model: "school_enrollment_payment_term_detail"
+        save_as: "detail_1"
+        values:
+          term_id: "REC: term.id"
+          product_id: "REC: product.id"
+          name: "Registration Fee SCI2"
+          account_id: "REC: income_account.id"
+          uom_quantity: 1.0
+          uom_id: "REF: uom.product_uom_unit"
+          price_unit: 1000000.0
+
+      - step: "Create second payment term detail"
+        action: "create"
+        model: "school_enrollment_payment_term_detail"
+        save_as: "detail_2"
+        values:
+          term_id: "REC: term.id"
+          product_id: "REC: product.id"
+          name: "Monthly Tuition SCI2"
+          account_id: "REC: income_account.id"
+          uom_quantity: 1.0
+          uom_id: "REF: uom.product_uom_unit"
+          price_unit: 500000.0
+
+      - step: "Confirm enrollment"
+        action: "call"
+        target: "enrollment"
+        method: "action_confirm"
+        as_user: "base.user_admin"
+
+      - step: "Invalidate enrollment cache before approve"
+        action: "call"
+        target: "enrollment"
+        method: "invalidate_cache"
+
+      - step: "Approve enrollment"
+        action: "call"
+        target: "enrollment"
+        method: "action_approve_approval"
+        as_user: "base.user_admin"
+        asserts:
+          state:
+            type: "value"
+            expected: "open"
+
+      - step: "Create customer invoice from the payment term"
+        action: "call"
+        target: "term"
+        method: "action_create_invoice"
+        as_user: "base.user_admin"
+
+      - step: "Assert the customer invoice was confirmed automatically"
+        action: "assert"
+        target: "enrollment"
+        asserts:
+          auto_confirm_customer_invoice:
+            type: "value"
+            expected: true
+
+      - step: "Assert customer invoice state is confirm"
+        action: "assert"
+        target: "term"
+        asserts:
+          state:
+            type: "value"
+            expected: "invoiced"
+          customer_invoice_id.state:
+            type: "value"
+            expected: "confirm"
+
+  - name: "Disconnect Customer Invoice From Payment Term"
+    steps:
+      - step: "Setup - get sale journal"
+        action: "search"
+        model: "account.journal"
+        domain: [["type", "=", "sale"]]
+        save_as: "journal"
+        limit: 1
+
+      - step: "Setup - get revenue account type"
+        action: "ref"
+        xml_id: "account.data_account_type_revenue"
+        save_as: "revenue_type"
+
+      - step: "Setup - get receivable account type"
+        action: "ref"
+        xml_id: "account.data_account_type_receivable"
+        save_as: "receivable_type"
+
+      - step: "Setup - create income account"
+        action: "create"
+        model: "account.account"
+        save_as: "income_account"
+        values:
+          name: "School Fee Income SCI3"
+          code: "SCI34200"
+          user_type_id: "REC: revenue_type.id"
+
+      - step: "Setup - create receivable account"
+        action: "create"
+        model: "account.account"
+        save_as: "receivable_account"
+        values:
+          name: "School Receivable SCI3"
+          code: "SCI31100"
+          user_type_id: "REC: receivable_type.id"
+          reconcile: true
+
+      - step: "Setup - create customer invoice type"
+        action: "create"
+        model: "customer_invoice_type"
+        save_as: "ci_type"
+        values:
+          name: "Customer Invoice Type SCI3"
+          code: "CITSCI3"
+          journal_id: "REC: journal.id"
+          receivable_account_id: "REC: receivable_account.id"
+
+      - step: "Setup - create product"
+        action: "create"
+        model: "product.product"
+        save_as: "product"
+        values:
+          name: "School Fee SCI3"
+          type: "service"
+          list_price: 1000000.0
+
+      - step: "Setup - create pricelist"
+        action: "create"
+        model: "product.pricelist"
+        save_as: "pricelist"
+        values:
+          name: "School Pricelist SCI3"
+          currency_id: "REC: company.currency_id.id"
+
+      - step: "Setup - create grade type"
+        action: "create"
+        model: "school_grade_type"
+        save_as: "grade_type"
+        values:
+          name: "Grade Type SCI3"
+          code: "GTSCI3"
+          sequence: 10
+
+      - step: "Setup - create academic year"
+        action: "create"
+        model: "school_academic_year"
+        save_as: "academic_year"
+        values:
+          name: "2024/2025 SCI3"
+          code: "AYSCI3"
+          date_start: "2024-07-01"
+          date_end: "2025-06-30"
+
+      - step: "Setup - create academic term"
+        action: "create"
+        model: "school_academic_term"
+        save_as: "academic_term"
+        values:
+          name: "Semester SCI3"
+          code: "SMSCI3"
+          date_start: "2024-07-01"
+          date_end: "2025-06-30"
+          year_id: "REC: academic_year.id"
+          enrollment_state: "open"
+
+      - step: "Setup - create school"
+        action: "create"
+        model: "school"
+        save_as: "school"
+        values:
+          name: "School SCI3"
+          code: "SCHSCI3"
+          grade_type_id: "REC: grade_type.id"
+
+      - step: "Setup - create grade"
+        action: "create"
+        model: "school_grade"
+        save_as: "grade"
+        values:
+          name: "Grade SCI3"
+          code: "GSCI3"
+          sequence: 10
+          type_id: "REC: grade_type.id"
+
+      - step: "Setup - create grade class"
+        action: "create"
+        model: "school_grade_class"
+        save_as: "grade_class"
+        values:
+          name: "Class SCI3"
+          code: "CLASCI3"
+          school_id: "REC: school.id"
+          grade_id: "REC: grade.id"
+
+      - step: "Setup - create student contact"
+        action: "create"
+        model: "res.partner"
+        save_as: "contact"
+        values:
+          name: "Student Contact SCI3"
+
+      - step: "Setup - create student"
+        action: "create"
+        model: "school_student"
+        save_as: "student"
+        values:
+          name: "Student SCI3"
+          code: "STUSCI3"
+          contact_id: "REC: contact.id"
+          school_id: "REC: school.id"
+
+      - step: "Setup - create payment template"
+        action: "create"
+        model: "school_enrollment_payment_template"
+        save_as: "payment_template"
+        values:
+          name: "Payment Template SCI3"
+          code: "PMTSCI3"
+          school_id: "REC: school.id"
+          grade_id: "REC: grade.id"
+          academic_term_id: "REC: academic_term.id"
+          journal_id: "REC: journal.id"
+          receivable_account_id: "REC: receivable_account.id"
+          customer_invoice_type_id: "REC: ci_type.id"
+          auto_confirm_customer_invoice: false
+
+      - step: "Create enrollment"
+        action: "create"
+        model: "school_enrollment"
+        save_as: "enrollment"
+        values:
+          date: "2024-07-01"
+          academic_year_id: "REC: academic_year.id"
+          academic_term_id: "REC: academic_term.id"
+          school_id: "REC: school.id"
+          grade_id: "REC: grade.id"
+          grade_class_id: "REC: grade_class.id"
+          student_id: "REC: student.id"
+          currency_id: "REC: company.currency_id.id"
+          pricelist_id: "REC: pricelist.id"
+          receivable_journal_id: "REC: journal.id"
+          receivable_account_id: "REC: receivable_account.id"
+          customer_invoice_type_id: "REC: payment_template.customer_invoice_type_id.id"
+          auto_confirm_customer_invoice:
+            "REC: payment_template.auto_confirm_customer_invoice"
+
+      - step: "Create payment term"
+        action: "create"
+        model: "school_enrollment_payment_term"
+        save_as: "term"
+        values:
+          enrollment_id: "REC: enrollment.id"
+          name: "Term SCI3"
+          sequence: 10
+          date_invoice: "2024-07-05"
+          date_due: "2024-07-20"
+
+      - step: "Create first payment term detail"
+        action: "create"
+        model: "school_enrollment_payment_term_detail"
+        save_as: "detail_1"
+        values:
+          term_id: "REC: term.id"
+          product_id: "REC: product.id"
+          name: "Registration Fee SCI3"
+          account_id: "REC: income_account.id"
+          uom_quantity: 1.0
+          uom_id: "REF: uom.product_uom_unit"
+          price_unit: 1000000.0
+
+      - step: "Create second payment term detail"
+        action: "create"
+        model: "school_enrollment_payment_term_detail"
+        save_as: "detail_2"
+        values:
+          term_id: "REC: term.id"
+          product_id: "REC: product.id"
+          name: "Monthly Tuition SCI3"
+          account_id: "REC: income_account.id"
+          uom_quantity: 1.0
+          uom_id: "REF: uom.product_uom_unit"
+          price_unit: 500000.0
+
+      - step: "Confirm enrollment"
+        action: "call"
+        target: "enrollment"
+        method: "action_confirm"
+        as_user: "base.user_admin"
+
+      - step: "Invalidate enrollment cache before approve"
+        action: "call"
+        target: "enrollment"
+        method: "invalidate_cache"
+
+      - step: "Approve enrollment"
+        action: "call"
+        target: "enrollment"
+        method: "action_approve_approval"
+        as_user: "base.user_admin"
+        asserts:
+          state:
+            type: "value"
+            expected: "open"
+
+      - step: "Create customer invoice from the payment term"
+        action: "call"
+        target: "term"
+        method: "action_create_invoice"
+        as_user: "base.user_admin"
+
+      - step: "Disconnect the customer invoice from the payment term"
+        action: "call"
+        target: "term"
+        method: "action_disconnect_invoice"
+        as_user: "base.user_admin"
+
+      - step: "Assert the term is uninvoiced again"
+        action: "assert"
+        target: "term"
+        asserts:
+          customer_invoice_id:
+            type: "value"
+            operator: "is_falsy"
+          state:
+            type: "value"
+            expected: "uninvoiced"
+
+      - step: "Assert the customer invoice document still exists"
+        action: "search"
+        model: "customer_invoice"
+        domain: [["customer_document_number", "=", "REC: enrollment.name"]]
+        save_as: "kept_invoices"
+        expect_count: 1
+
+  - name: "Delete Draft Customer Invoice Of Payment Term"
+    steps:
+      - step: "Setup - get sale journal"
+        action: "search"
+        model: "account.journal"
+        domain: [["type", "=", "sale"]]
+        save_as: "journal"
+        limit: 1
+
+      - step: "Setup - get revenue account type"
+        action: "ref"
+        xml_id: "account.data_account_type_revenue"
+        save_as: "revenue_type"
+
+      - step: "Setup - get receivable account type"
+        action: "ref"
+        xml_id: "account.data_account_type_receivable"
+        save_as: "receivable_type"
+
+      - step: "Setup - create income account"
+        action: "create"
+        model: "account.account"
+        save_as: "income_account"
+        values:
+          name: "School Fee Income SCI4"
+          code: "SCI44200"
+          user_type_id: "REC: revenue_type.id"
+
+      - step: "Setup - create receivable account"
+        action: "create"
+        model: "account.account"
+        save_as: "receivable_account"
+        values:
+          name: "School Receivable SCI4"
+          code: "SCI41100"
+          user_type_id: "REC: receivable_type.id"
+          reconcile: true
+
+      - step: "Setup - create customer invoice type"
+        action: "create"
+        model: "customer_invoice_type"
+        save_as: "ci_type"
+        values:
+          name: "Customer Invoice Type SCI4"
+          code: "CITSCI4"
+          journal_id: "REC: journal.id"
+          receivable_account_id: "REC: receivable_account.id"
+
+      - step: "Setup - create product"
+        action: "create"
+        model: "product.product"
+        save_as: "product"
+        values:
+          name: "School Fee SCI4"
+          type: "service"
+          list_price: 1000000.0
+
+      - step: "Setup - create pricelist"
+        action: "create"
+        model: "product.pricelist"
+        save_as: "pricelist"
+        values:
+          name: "School Pricelist SCI4"
+          currency_id: "REC: company.currency_id.id"
+
+      - step: "Setup - create grade type"
+        action: "create"
+        model: "school_grade_type"
+        save_as: "grade_type"
+        values:
+          name: "Grade Type SCI4"
+          code: "GTSCI4"
+          sequence: 10
+
+      - step: "Setup - create academic year"
+        action: "create"
+        model: "school_academic_year"
+        save_as: "academic_year"
+        values:
+          name: "2024/2025 SCI4"
+          code: "AYSCI4"
+          date_start: "2024-07-01"
+          date_end: "2025-06-30"
+
+      - step: "Setup - create academic term"
+        action: "create"
+        model: "school_academic_term"
+        save_as: "academic_term"
+        values:
+          name: "Semester SCI4"
+          code: "SMSCI4"
+          date_start: "2024-07-01"
+          date_end: "2025-06-30"
+          year_id: "REC: academic_year.id"
+          enrollment_state: "open"
+
+      - step: "Setup - create school"
+        action: "create"
+        model: "school"
+        save_as: "school"
+        values:
+          name: "School SCI4"
+          code: "SCHSCI4"
+          grade_type_id: "REC: grade_type.id"
+
+      - step: "Setup - create grade"
+        action: "create"
+        model: "school_grade"
+        save_as: "grade"
+        values:
+          name: "Grade SCI4"
+          code: "GSCI4"
+          sequence: 10
+          type_id: "REC: grade_type.id"
+
+      - step: "Setup - create grade class"
+        action: "create"
+        model: "school_grade_class"
+        save_as: "grade_class"
+        values:
+          name: "Class SCI4"
+          code: "CLASCI4"
+          school_id: "REC: school.id"
+          grade_id: "REC: grade.id"
+
+      - step: "Setup - create student contact"
+        action: "create"
+        model: "res.partner"
+        save_as: "contact"
+        values:
+          name: "Student Contact SCI4"
+
+      - step: "Setup - create student"
+        action: "create"
+        model: "school_student"
+        save_as: "student"
+        values:
+          name: "Student SCI4"
+          code: "STUSCI4"
+          contact_id: "REC: contact.id"
+          school_id: "REC: school.id"
+
+      - step: "Setup - create payment template"
+        action: "create"
+        model: "school_enrollment_payment_template"
+        save_as: "payment_template"
+        values:
+          name: "Payment Template SCI4"
+          code: "PMTSCI4"
+          school_id: "REC: school.id"
+          grade_id: "REC: grade.id"
+          academic_term_id: "REC: academic_term.id"
+          journal_id: "REC: journal.id"
+          receivable_account_id: "REC: receivable_account.id"
+          customer_invoice_type_id: "REC: ci_type.id"
+          auto_confirm_customer_invoice: false
+
+      - step: "Create enrollment"
+        action: "create"
+        model: "school_enrollment"
+        save_as: "enrollment"
+        values:
+          date: "2024-07-01"
+          academic_year_id: "REC: academic_year.id"
+          academic_term_id: "REC: academic_term.id"
+          school_id: "REC: school.id"
+          grade_id: "REC: grade.id"
+          grade_class_id: "REC: grade_class.id"
+          student_id: "REC: student.id"
+          currency_id: "REC: company.currency_id.id"
+          pricelist_id: "REC: pricelist.id"
+          receivable_journal_id: "REC: journal.id"
+          receivable_account_id: "REC: receivable_account.id"
+          customer_invoice_type_id: "REC: payment_template.customer_invoice_type_id.id"
+          auto_confirm_customer_invoice:
+            "REC: payment_template.auto_confirm_customer_invoice"
+
+      - step: "Create payment term"
+        action: "create"
+        model: "school_enrollment_payment_term"
+        save_as: "term"
+        values:
+          enrollment_id: "REC: enrollment.id"
+          name: "Term SCI4"
+          sequence: 10
+          date_invoice: "2024-07-05"
+          date_due: "2024-07-20"
+
+      - step: "Create first payment term detail"
+        action: "create"
+        model: "school_enrollment_payment_term_detail"
+        save_as: "detail_1"
+        values:
+          term_id: "REC: term.id"
+          product_id: "REC: product.id"
+          name: "Registration Fee SCI4"
+          account_id: "REC: income_account.id"
+          uom_quantity: 1.0
+          uom_id: "REF: uom.product_uom_unit"
+          price_unit: 1000000.0
+
+      - step: "Create second payment term detail"
+        action: "create"
+        model: "school_enrollment_payment_term_detail"
+        save_as: "detail_2"
+        values:
+          term_id: "REC: term.id"
+          product_id: "REC: product.id"
+          name: "Monthly Tuition SCI4"
+          account_id: "REC: income_account.id"
+          uom_quantity: 1.0
+          uom_id: "REF: uom.product_uom_unit"
+          price_unit: 500000.0
+
+      - step: "Confirm enrollment"
+        action: "call"
+        target: "enrollment"
+        method: "action_confirm"
+        as_user: "base.user_admin"
+
+      - step: "Invalidate enrollment cache before approve"
+        action: "call"
+        target: "enrollment"
+        method: "invalidate_cache"
+
+      - step: "Approve enrollment"
+        action: "call"
+        target: "enrollment"
+        method: "action_approve_approval"
+        as_user: "base.user_admin"
+        asserts:
+          state:
+            type: "value"
+            expected: "open"
+
+      - step: "Create customer invoice from the payment term"
+        action: "call"
+        target: "term"
+        method: "action_create_invoice"
+        as_user: "base.user_admin"
+
+      - step: "Delete the draft customer invoice"
+        action: "call"
+        target: "term"
+        method: "action_delete_invoice"
+        as_user: "base.user_admin"
+
+      - step: "Assert the term is uninvoiced again"
+        action: "assert"
+        target: "term"
+        asserts:
+          customer_invoice_id:
+            type: "value"
+            operator: "is_falsy"
+          state:
+            type: "value"
+            expected: "uninvoiced"
+
+      - step: "Assert first detail is no longer linked to a line"
+        action: "assert"
+        target: "detail_1"
+        asserts:
+          customer_invoice_line_id:
+            type: "value"
+            operator: "is_falsy"
+
+      - step: "Assert second detail is no longer linked to a line"
+        action: "assert"
+        target: "detail_2"
+        asserts:
+          customer_invoice_line_id:
+            type: "value"
+            operator: "is_falsy"
+
+      - step: "Assert the customer invoice document is gone"
+        action: "search"
+        model: "customer_invoice"
+        domain: [["customer_document_number", "=", "REC: enrollment.name"]]
+        save_as: "remaining_invoices"
+        expect_count: 0
+
+  - name: "Delete Non Draft Customer Invoice Is Rejected"
+    steps:
+      - step: "Setup - get sale journal"
+        action: "search"
+        model: "account.journal"
+        domain: [["type", "=", "sale"]]
+        save_as: "journal"
+        limit: 1
+
+      - step: "Setup - get revenue account type"
+        action: "ref"
+        xml_id: "account.data_account_type_revenue"
+        save_as: "revenue_type"
+
+      - step: "Setup - get receivable account type"
+        action: "ref"
+        xml_id: "account.data_account_type_receivable"
+        save_as: "receivable_type"
+
+      - step: "Setup - create income account"
+        action: "create"
+        model: "account.account"
+        save_as: "income_account"
+        values:
+          name: "School Fee Income SCI5"
+          code: "SCI54200"
+          user_type_id: "REC: revenue_type.id"
+
+      - step: "Setup - create receivable account"
+        action: "create"
+        model: "account.account"
+        save_as: "receivable_account"
+        values:
+          name: "School Receivable SCI5"
+          code: "SCI51100"
+          user_type_id: "REC: receivable_type.id"
+          reconcile: true
+
+      - step: "Setup - create customer invoice type"
+        action: "create"
+        model: "customer_invoice_type"
+        save_as: "ci_type"
+        values:
+          name: "Customer Invoice Type SCI5"
+          code: "CITSCI5"
+          journal_id: "REC: journal.id"
+          receivable_account_id: "REC: receivable_account.id"
+
+      - step: "Setup - create product"
+        action: "create"
+        model: "product.product"
+        save_as: "product"
+        values:
+          name: "School Fee SCI5"
+          type: "service"
+          list_price: 1000000.0
+
+      - step: "Setup - create pricelist"
+        action: "create"
+        model: "product.pricelist"
+        save_as: "pricelist"
+        values:
+          name: "School Pricelist SCI5"
+          currency_id: "REC: company.currency_id.id"
+
+      - step: "Setup - create grade type"
+        action: "create"
+        model: "school_grade_type"
+        save_as: "grade_type"
+        values:
+          name: "Grade Type SCI5"
+          code: "GTSCI5"
+          sequence: 10
+
+      - step: "Setup - create academic year"
+        action: "create"
+        model: "school_academic_year"
+        save_as: "academic_year"
+        values:
+          name: "2024/2025 SCI5"
+          code: "AYSCI5"
+          date_start: "2024-07-01"
+          date_end: "2025-06-30"
+
+      - step: "Setup - create academic term"
+        action: "create"
+        model: "school_academic_term"
+        save_as: "academic_term"
+        values:
+          name: "Semester SCI5"
+          code: "SMSCI5"
+          date_start: "2024-07-01"
+          date_end: "2025-06-30"
+          year_id: "REC: academic_year.id"
+          enrollment_state: "open"
+
+      - step: "Setup - create school"
+        action: "create"
+        model: "school"
+        save_as: "school"
+        values:
+          name: "School SCI5"
+          code: "SCHSCI5"
+          grade_type_id: "REC: grade_type.id"
+
+      - step: "Setup - create grade"
+        action: "create"
+        model: "school_grade"
+        save_as: "grade"
+        values:
+          name: "Grade SCI5"
+          code: "GSCI5"
+          sequence: 10
+          type_id: "REC: grade_type.id"
+
+      - step: "Setup - create grade class"
+        action: "create"
+        model: "school_grade_class"
+        save_as: "grade_class"
+        values:
+          name: "Class SCI5"
+          code: "CLASCI5"
+          school_id: "REC: school.id"
+          grade_id: "REC: grade.id"
+
+      - step: "Setup - create student contact"
+        action: "create"
+        model: "res.partner"
+        save_as: "contact"
+        values:
+          name: "Student Contact SCI5"
+
+      - step: "Setup - create student"
+        action: "create"
+        model: "school_student"
+        save_as: "student"
+        values:
+          name: "Student SCI5"
+          code: "STUSCI5"
+          contact_id: "REC: contact.id"
+          school_id: "REC: school.id"
+
+      - step: "Setup - create payment template"
+        action: "create"
+        model: "school_enrollment_payment_template"
+        save_as: "payment_template"
+        values:
+          name: "Payment Template SCI5"
+          code: "PMTSCI5"
+          school_id: "REC: school.id"
+          grade_id: "REC: grade.id"
+          academic_term_id: "REC: academic_term.id"
+          journal_id: "REC: journal.id"
+          receivable_account_id: "REC: receivable_account.id"
+          customer_invoice_type_id: "REC: ci_type.id"
+          auto_confirm_customer_invoice: false
+
+      - step: "Create enrollment"
+        action: "create"
+        model: "school_enrollment"
+        save_as: "enrollment"
+        values:
+          date: "2024-07-01"
+          academic_year_id: "REC: academic_year.id"
+          academic_term_id: "REC: academic_term.id"
+          school_id: "REC: school.id"
+          grade_id: "REC: grade.id"
+          grade_class_id: "REC: grade_class.id"
+          student_id: "REC: student.id"
+          currency_id: "REC: company.currency_id.id"
+          pricelist_id: "REC: pricelist.id"
+          receivable_journal_id: "REC: journal.id"
+          receivable_account_id: "REC: receivable_account.id"
+          customer_invoice_type_id: "REC: payment_template.customer_invoice_type_id.id"
+          auto_confirm_customer_invoice:
+            "REC: payment_template.auto_confirm_customer_invoice"
+
+      - step: "Create payment term"
+        action: "create"
+        model: "school_enrollment_payment_term"
+        save_as: "term"
+        values:
+          enrollment_id: "REC: enrollment.id"
+          name: "Term SCI5"
+          sequence: 10
+          date_invoice: "2024-07-05"
+          date_due: "2024-07-20"
+
+      - step: "Create first payment term detail"
+        action: "create"
+        model: "school_enrollment_payment_term_detail"
+        save_as: "detail_1"
+        values:
+          term_id: "REC: term.id"
+          product_id: "REC: product.id"
+          name: "Registration Fee SCI5"
+          account_id: "REC: income_account.id"
+          uom_quantity: 1.0
+          uom_id: "REF: uom.product_uom_unit"
+          price_unit: 1000000.0
+
+      - step: "Create second payment term detail"
+        action: "create"
+        model: "school_enrollment_payment_term_detail"
+        save_as: "detail_2"
+        values:
+          term_id: "REC: term.id"
+          product_id: "REC: product.id"
+          name: "Monthly Tuition SCI5"
+          account_id: "REC: income_account.id"
+          uom_quantity: 1.0
+          uom_id: "REF: uom.product_uom_unit"
+          price_unit: 500000.0
+
+      - step: "Confirm enrollment"
+        action: "call"
+        target: "enrollment"
+        method: "action_confirm"
+        as_user: "base.user_admin"
+
+      - step: "Invalidate enrollment cache before approve"
+        action: "call"
+        target: "enrollment"
+        method: "invalidate_cache"
+
+      - step: "Approve enrollment"
+        action: "call"
+        target: "enrollment"
+        method: "action_approve_approval"
+        as_user: "base.user_admin"
+        asserts:
+          state:
+            type: "value"
+            expected: "open"
+
+      - step: "Create customer invoice from the payment term"
+        action: "call"
+        target: "term"
+        method: "action_create_invoice"
+        as_user: "base.user_admin"
+
+      - step: "Get the generated customer invoice"
+        action: "search"
+        model: "customer_invoice"
+        domain: [["customer_document_number", "=", "REC: enrollment.name"]]
+        save_as: "invoice"
+        expect_count: 1
+
+      - step: "Confirm the customer invoice"
+        action: "call"
+        target: "invoice"
+        method: "action_confirm"
+        as_user: "base.user_admin"
+        asserts:
+          state:
+            type: "value"
+            expected: "confirm"
+
+      - step: "Deleting a non-draft customer invoice must be rejected"
+        action: "call"
+        target: "term"
+        method: "action_delete_invoice"
+        as_user: "base.user_admin"
+        expect_error:
+          type: "UserError"
+          message_contains: "not draft anymore"
+
+      - step: "Assert the term is still linked to the customer invoice"
+        action: "assert"
+        target: "term"
+        asserts:
+          customer_invoice_id:
+            type: "value"
+            operator: "is_truthy"
+          state:
+            type: "value"
+            expected: "invoiced"
+
+  - name: "Cancel Enrollment With Invoiced Payment Term Is Rejected"
+    steps:
+      - step: "Setup - get sale journal"
+        action: "search"
+        model: "account.journal"
+        domain: [["type", "=", "sale"]]
+        save_as: "journal"
+        limit: 1
+
+      - step: "Setup - get revenue account type"
+        action: "ref"
+        xml_id: "account.data_account_type_revenue"
+        save_as: "revenue_type"
+
+      - step: "Setup - get receivable account type"
+        action: "ref"
+        xml_id: "account.data_account_type_receivable"
+        save_as: "receivable_type"
+
+      - step: "Setup - create income account"
+        action: "create"
+        model: "account.account"
+        save_as: "income_account"
+        values:
+          name: "School Fee Income SCI6"
+          code: "SCI64200"
+          user_type_id: "REC: revenue_type.id"
+
+      - step: "Setup - create receivable account"
+        action: "create"
+        model: "account.account"
+        save_as: "receivable_account"
+        values:
+          name: "School Receivable SCI6"
+          code: "SCI61100"
+          user_type_id: "REC: receivable_type.id"
+          reconcile: true
+
+      - step: "Setup - create customer invoice type"
+        action: "create"
+        model: "customer_invoice_type"
+        save_as: "ci_type"
+        values:
+          name: "Customer Invoice Type SCI6"
+          code: "CITSCI6"
+          journal_id: "REC: journal.id"
+          receivable_account_id: "REC: receivable_account.id"
+
+      - step: "Setup - create product"
+        action: "create"
+        model: "product.product"
+        save_as: "product"
+        values:
+          name: "School Fee SCI6"
+          type: "service"
+          list_price: 1000000.0
+
+      - step: "Setup - create pricelist"
+        action: "create"
+        model: "product.pricelist"
+        save_as: "pricelist"
+        values:
+          name: "School Pricelist SCI6"
+          currency_id: "REC: company.currency_id.id"
+
+      - step: "Setup - create grade type"
+        action: "create"
+        model: "school_grade_type"
+        save_as: "grade_type"
+        values:
+          name: "Grade Type SCI6"
+          code: "GTSCI6"
+          sequence: 10
+
+      - step: "Setup - create academic year"
+        action: "create"
+        model: "school_academic_year"
+        save_as: "academic_year"
+        values:
+          name: "2024/2025 SCI6"
+          code: "AYSCI6"
+          date_start: "2024-07-01"
+          date_end: "2025-06-30"
+
+      - step: "Setup - create academic term"
+        action: "create"
+        model: "school_academic_term"
+        save_as: "academic_term"
+        values:
+          name: "Semester SCI6"
+          code: "SMSCI6"
+          date_start: "2024-07-01"
+          date_end: "2025-06-30"
+          year_id: "REC: academic_year.id"
+          enrollment_state: "open"
+
+      - step: "Setup - create school"
+        action: "create"
+        model: "school"
+        save_as: "school"
+        values:
+          name: "School SCI6"
+          code: "SCHSCI6"
+          grade_type_id: "REC: grade_type.id"
+
+      - step: "Setup - create grade"
+        action: "create"
+        model: "school_grade"
+        save_as: "grade"
+        values:
+          name: "Grade SCI6"
+          code: "GSCI6"
+          sequence: 10
+          type_id: "REC: grade_type.id"
+
+      - step: "Setup - create grade class"
+        action: "create"
+        model: "school_grade_class"
+        save_as: "grade_class"
+        values:
+          name: "Class SCI6"
+          code: "CLASCI6"
+          school_id: "REC: school.id"
+          grade_id: "REC: grade.id"
+
+      - step: "Setup - create student contact"
+        action: "create"
+        model: "res.partner"
+        save_as: "contact"
+        values:
+          name: "Student Contact SCI6"
+
+      - step: "Setup - create student"
+        action: "create"
+        model: "school_student"
+        save_as: "student"
+        values:
+          name: "Student SCI6"
+          code: "STUSCI6"
+          contact_id: "REC: contact.id"
+          school_id: "REC: school.id"
+
+      - step: "Setup - create payment template"
+        action: "create"
+        model: "school_enrollment_payment_template"
+        save_as: "payment_template"
+        values:
+          name: "Payment Template SCI6"
+          code: "PMTSCI6"
+          school_id: "REC: school.id"
+          grade_id: "REC: grade.id"
+          academic_term_id: "REC: academic_term.id"
+          journal_id: "REC: journal.id"
+          receivable_account_id: "REC: receivable_account.id"
+          customer_invoice_type_id: "REC: ci_type.id"
+          auto_confirm_customer_invoice: false
+
+      - step: "Create enrollment"
+        action: "create"
+        model: "school_enrollment"
+        save_as: "enrollment"
+        values:
+          date: "2024-07-01"
+          academic_year_id: "REC: academic_year.id"
+          academic_term_id: "REC: academic_term.id"
+          school_id: "REC: school.id"
+          grade_id: "REC: grade.id"
+          grade_class_id: "REC: grade_class.id"
+          student_id: "REC: student.id"
+          currency_id: "REC: company.currency_id.id"
+          pricelist_id: "REC: pricelist.id"
+          receivable_journal_id: "REC: journal.id"
+          receivable_account_id: "REC: receivable_account.id"
+          customer_invoice_type_id: "REC: payment_template.customer_invoice_type_id.id"
+          auto_confirm_customer_invoice:
+            "REC: payment_template.auto_confirm_customer_invoice"
+
+      - step: "Create payment term"
+        action: "create"
+        model: "school_enrollment_payment_term"
+        save_as: "term"
+        values:
+          enrollment_id: "REC: enrollment.id"
+          name: "Term SCI6"
+          sequence: 10
+          date_invoice: "2024-07-05"
+          date_due: "2024-07-20"
+
+      - step: "Create first payment term detail"
+        action: "create"
+        model: "school_enrollment_payment_term_detail"
+        save_as: "detail_1"
+        values:
+          term_id: "REC: term.id"
+          product_id: "REC: product.id"
+          name: "Registration Fee SCI6"
+          account_id: "REC: income_account.id"
+          uom_quantity: 1.0
+          uom_id: "REF: uom.product_uom_unit"
+          price_unit: 1000000.0
+
+      - step: "Create second payment term detail"
+        action: "create"
+        model: "school_enrollment_payment_term_detail"
+        save_as: "detail_2"
+        values:
+          term_id: "REC: term.id"
+          product_id: "REC: product.id"
+          name: "Monthly Tuition SCI6"
+          account_id: "REC: income_account.id"
+          uom_quantity: 1.0
+          uom_id: "REF: uom.product_uom_unit"
+          price_unit: 500000.0
+
+      - step: "Confirm enrollment"
+        action: "call"
+        target: "enrollment"
+        method: "action_confirm"
+        as_user: "base.user_admin"
+
+      - step: "Invalidate enrollment cache before approve"
+        action: "call"
+        target: "enrollment"
+        method: "invalidate_cache"
+
+      - step: "Approve enrollment"
+        action: "call"
+        target: "enrollment"
+        method: "action_approve_approval"
+        as_user: "base.user_admin"
+        asserts:
+          state:
+            type: "value"
+            expected: "open"
+
+      - step: "Create customer invoice from the payment term"
+        action: "call"
+        target: "term"
+        method: "action_create_invoice"
+        as_user: "base.user_admin"
+
+      - step: "Cancelling the enrollment must be rejected"
+        action: "call"
+        target: "enrollment"
+        method: "action_cancel"
+        as_user: "base.user_admin"
+        expect_error:
+          type: "UserError"
+
+      - step: "Assert the enrollment is still open"
+        action: "assert"
+        target: "enrollment"
+        asserts:
+          state:
+            type: "value"
+            expected: "open"
+
+  - name: "Payment Template Onchange Fills Customer Invoice Fields"
+    steps:
+      - step: "Setup - get sale journal"
+        action: "search"
+        model: "account.journal"
+        domain: [["type", "=", "sale"]]
+        save_as: "journal"
+        limit: 1
+
+      - step: "Setup - get revenue account type"
+        action: "ref"
+        xml_id: "account.data_account_type_revenue"
+        save_as: "revenue_type"
+
+      - step: "Setup - get receivable account type"
+        action: "ref"
+        xml_id: "account.data_account_type_receivable"
+        save_as: "receivable_type"
+
+      - step: "Setup - create income account"
+        action: "create"
+        model: "account.account"
+        save_as: "income_account"
+        values:
+          name: "School Fee Income SCI7"
+          code: "SCI74200"
+          user_type_id: "REC: revenue_type.id"
+
+      - step: "Setup - create receivable account"
+        action: "create"
+        model: "account.account"
+        save_as: "receivable_account"
+        values:
+          name: "School Receivable SCI7"
+          code: "SCI71100"
+          user_type_id: "REC: receivable_type.id"
+          reconcile: true
+
+      - step: "Setup - create customer invoice type"
+        action: "create"
+        model: "customer_invoice_type"
+        save_as: "ci_type"
+        values:
+          name: "Customer Invoice Type SCI7"
+          code: "CITSCI7"
+          journal_id: "REC: journal.id"
+          receivable_account_id: "REC: receivable_account.id"
+
+      - step: "Setup - create product"
+        action: "create"
+        model: "product.product"
+        save_as: "product"
+        values:
+          name: "School Fee SCI7"
+          type: "service"
+          list_price: 1000000.0
+
+      - step: "Setup - create pricelist"
+        action: "create"
+        model: "product.pricelist"
+        save_as: "pricelist"
+        values:
+          name: "School Pricelist SCI7"
+          currency_id: "REC: company.currency_id.id"
+
+      - step: "Setup - create grade type"
+        action: "create"
+        model: "school_grade_type"
+        save_as: "grade_type"
+        values:
+          name: "Grade Type SCI7"
+          code: "GTSCI7"
+          sequence: 10
+
+      - step: "Setup - create academic year"
+        action: "create"
+        model: "school_academic_year"
+        save_as: "academic_year"
+        values:
+          name: "2024/2025 SCI7"
+          code: "AYSCI7"
+          date_start: "2024-07-01"
+          date_end: "2025-06-30"
+
+      - step: "Setup - create academic term"
+        action: "create"
+        model: "school_academic_term"
+        save_as: "academic_term"
+        values:
+          name: "Semester SCI7"
+          code: "SMSCI7"
+          date_start: "2024-07-01"
+          date_end: "2025-06-30"
+          year_id: "REC: academic_year.id"
+          enrollment_state: "open"
+
+      - step: "Setup - create school"
+        action: "create"
+        model: "school"
+        save_as: "school"
+        values:
+          name: "School SCI7"
+          code: "SCHSCI7"
+          grade_type_id: "REC: grade_type.id"
+
+      - step: "Setup - create grade"
+        action: "create"
+        model: "school_grade"
+        save_as: "grade"
+        values:
+          name: "Grade SCI7"
+          code: "GSCI7"
+          sequence: 10
+          type_id: "REC: grade_type.id"
+
+      - step: "Setup - create grade class"
+        action: "create"
+        model: "school_grade_class"
+        save_as: "grade_class"
+        values:
+          name: "Class SCI7"
+          code: "CLASCI7"
+          school_id: "REC: school.id"
+          grade_id: "REC: grade.id"
+
+      - step: "Setup - create student contact"
+        action: "create"
+        model: "res.partner"
+        save_as: "contact"
+        values:
+          name: "Student Contact SCI7"
+
+      - step: "Setup - create student"
+        action: "create"
+        model: "school_student"
+        save_as: "student"
+        values:
+          name: "Student SCI7"
+          code: "STUSCI7"
+          contact_id: "REC: contact.id"
+          school_id: "REC: school.id"
+
+      - step: "Setup - create payment template"
+        action: "create"
+        model: "school_enrollment_payment_template"
+        save_as: "payment_template"
+        values:
+          name: "Payment Template SCI7"
+          code: "PMTSCI7"
+          school_id: "REC: school.id"
+          grade_id: "REC: grade.id"
+          academic_term_id: "REC: academic_term.id"
+          journal_id: "REC: journal.id"
+          receivable_account_id: "REC: receivable_account.id"
+          customer_invoice_type_id: "REC: ci_type.id"
+          auto_confirm_customer_invoice: true
+
+      - step: "Selecting the payment template fills the customer invoice fields"
+        action: "form"
+        model: "school_enrollment"
+        save: false
+        values:
+          payment_template_id: "REC: payment_template"
+        asserts:
+          customer_invoice_type_id.id:
+            type: "value"
+            expected: "REC: ci_type.id"
+          auto_confirm_customer_invoice:
+            type: "value"
+            expected: true

--- a/ssi_school/tests/test_data_enrollment_payment_date_pattern.yaml
+++ b/ssi_school/tests/test_data_enrollment_payment_date_pattern.yaml
@@ -3,6 +3,38 @@ options:
 scenarios:
   - name: "Compute Payment - Estimated Invoice and Due Date from Duration"
     steps:
+      - step: "Setup - get customer invoice journal"
+        action: "search"
+        model: "account.journal"
+        domain: [["type", "=", "sale"]]
+        save_as: "ci_journal"
+        limit: 1
+
+      - step: "Setup - get receivable account type"
+        action: "ref"
+        xml_id: "account.data_account_type_receivable"
+        save_as: "ci_account_type"
+
+      - step: "Setup - create customer invoice receivable account"
+        action: "create"
+        model: "account.account"
+        save_as: "ci_account"
+        values:
+          name: "Customer Invoice Receivable PDPCI01"
+          code: "PDPCI01"
+          user_type_id: "REC: ci_account_type.id"
+          reconcile: true
+
+      - step: "Setup - create customer invoice type"
+        action: "create"
+        model: "customer_invoice_type"
+        save_as: "ci_type"
+        values:
+          name: "Customer Invoice Type PDPCI01"
+          code: "PDPCI01"
+          journal_id: "REC: ci_journal.id"
+          receivable_account_id: "REC: ci_account.id"
+
       - step: "Setup - get sale journal"
         action: "search"
         model: "account.journal"
@@ -149,6 +181,7 @@ scenarios:
         model: "school_enrollment_payment_template"
         save_as: "payment_template"
         values:
+          customer_invoice_type_id: "REC: ci_type.id"
           name: "Enrollment Payment Template ENPTDUR"
           code: "ENPTDUR001"
           school_id: "EVAL: registry['school'].id"
@@ -261,6 +294,38 @@ scenarios:
 
   - name: "Compute Payment - Term without Duration leaves dates empty"
     steps:
+      - step: "Setup - get customer invoice journal"
+        action: "search"
+        model: "account.journal"
+        domain: [["type", "=", "sale"]]
+        save_as: "ci_journal"
+        limit: 1
+
+      - step: "Setup - get receivable account type"
+        action: "ref"
+        xml_id: "account.data_account_type_receivable"
+        save_as: "ci_account_type"
+
+      - step: "Setup - create customer invoice receivable account"
+        action: "create"
+        model: "account.account"
+        save_as: "ci_account"
+        values:
+          name: "Customer Invoice Receivable PDPCI02"
+          code: "PDPCI02"
+          user_type_id: "REC: ci_account_type.id"
+          reconcile: true
+
+      - step: "Setup - create customer invoice type"
+        action: "create"
+        model: "customer_invoice_type"
+        save_as: "ci_type"
+        values:
+          name: "Customer Invoice Type PDPCI02"
+          code: "PDPCI02"
+          journal_id: "REC: ci_journal.id"
+          receivable_account_id: "REC: ci_account.id"
+
       - step: "Setup - get sale journal"
         action: "search"
         model: "account.journal"
@@ -381,6 +446,7 @@ scenarios:
         model: "school_enrollment_payment_template"
         save_as: "payment_template"
         values:
+          customer_invoice_type_id: "REC: ci_type.id"
           name: "Enrollment Payment Template ENPTNODUR"
           code: "ENPTNODUR001"
           school_id: "EVAL: registry['school'].id"

--- a/ssi_school/tests/test_data_enrollment_payment_product_configurator.yaml
+++ b/ssi_school/tests/test_data_enrollment_payment_product_configurator.yaml
@@ -3,6 +3,38 @@ options:
 scenarios:
   - name: "Allowed Products - Template Detail - Manual Strategy"
     steps:
+      - step: "Setup - get customer invoice journal"
+        action: "search"
+        model: "account.journal"
+        domain: [["type", "=", "sale"]]
+        save_as: "ci_journal"
+        limit: 1
+
+      - step: "Setup - get receivable account type"
+        action: "ref"
+        xml_id: "account.data_account_type_receivable"
+        save_as: "ci_account_type"
+
+      - step: "Setup - create customer invoice receivable account"
+        action: "create"
+        model: "account.account"
+        save_as: "ci_account"
+        values:
+          name: "Customer Invoice Receivable PPCCI01"
+          code: "PPCCI01"
+          user_type_id: "REC: ci_account_type.id"
+          reconcile: true
+
+      - step: "Setup - create customer invoice type"
+        action: "create"
+        model: "customer_invoice_type"
+        save_as: "ci_type"
+        values:
+          name: "Customer Invoice Type PPCCI01"
+          code: "PPCCI01"
+          journal_id: "REC: ci_journal.id"
+          receivable_account_id: "REC: ci_account.id"
+
       - step: "Get account type ref"
         action: "ref"
         xml_id: "account.data_account_type_revenue"
@@ -41,6 +73,7 @@ scenarios:
         model: "school_enrollment_payment_template"
         save_as: "template"
         values:
+          customer_invoice_type_id: "REC: ci_type.id"
           name: "Template CFG Manual"
           code: "TPLCFGMAN"
           product_selection_method: "manual"
@@ -80,6 +113,38 @@ scenarios:
 
   - name: "Allowed Products - Template Detail - Manual Strategy Empty"
     steps:
+      - step: "Setup - get customer invoice journal"
+        action: "search"
+        model: "account.journal"
+        domain: [["type", "=", "sale"]]
+        save_as: "ci_journal"
+        limit: 1
+
+      - step: "Setup - get receivable account type"
+        action: "ref"
+        xml_id: "account.data_account_type_receivable"
+        save_as: "ci_account_type"
+
+      - step: "Setup - create customer invoice receivable account"
+        action: "create"
+        model: "account.account"
+        save_as: "ci_account"
+        values:
+          name: "Customer Invoice Receivable PPCCI02"
+          code: "PPCCI02"
+          user_type_id: "REC: ci_account_type.id"
+          reconcile: true
+
+      - step: "Setup - create customer invoice type"
+        action: "create"
+        model: "customer_invoice_type"
+        save_as: "ci_type"
+        values:
+          name: "Customer Invoice Type PPCCI02"
+          code: "PPCCI02"
+          journal_id: "REC: ci_journal.id"
+          receivable_account_id: "REC: ci_account.id"
+
       - step: "Get account type ref"
         action: "ref"
         xml_id: "account.data_account_type_revenue"
@@ -104,6 +169,7 @@ scenarios:
         model: "school_enrollment_payment_template"
         save_as: "template"
         values:
+          customer_invoice_type_id: "REC: ci_type.id"
           name: "Template CFG Empty"
           code: "TPLCFGEMP"
           product_selection_method: "manual"
@@ -138,6 +204,38 @@ scenarios:
 
   - name: "Allowed Products - Template Detail - Domain Strategy"
     steps:
+      - step: "Setup - get customer invoice journal"
+        action: "search"
+        model: "account.journal"
+        domain: [["type", "=", "sale"]]
+        save_as: "ci_journal"
+        limit: 1
+
+      - step: "Setup - get receivable account type"
+        action: "ref"
+        xml_id: "account.data_account_type_receivable"
+        save_as: "ci_account_type"
+
+      - step: "Setup - create customer invoice receivable account"
+        action: "create"
+        model: "account.account"
+        save_as: "ci_account"
+        values:
+          name: "Customer Invoice Receivable PPCCI03"
+          code: "PPCCI03"
+          user_type_id: "REC: ci_account_type.id"
+          reconcile: true
+
+      - step: "Setup - create customer invoice type"
+        action: "create"
+        model: "customer_invoice_type"
+        save_as: "ci_type"
+        values:
+          name: "Customer Invoice Type PPCCI03"
+          code: "PPCCI03"
+          journal_id: "REC: ci_journal.id"
+          receivable_account_id: "REC: ci_account.id"
+
       - step: "Get account type ref"
         action: "ref"
         xml_id: "account.data_account_type_revenue"
@@ -171,6 +269,7 @@ scenarios:
         model: "school_enrollment_payment_template"
         save_as: "template"
         values:
+          customer_invoice_type_id: "REC: ci_type.id"
           name: "Template CFG Domain"
           code: "TPLCFGDOM"
           product_selection_method: "domain"
@@ -206,6 +305,38 @@ scenarios:
 
   - name: "Allowed Products - Template Detail - Python Code Strategy"
     steps:
+      - step: "Setup - get customer invoice journal"
+        action: "search"
+        model: "account.journal"
+        domain: [["type", "=", "sale"]]
+        save_as: "ci_journal"
+        limit: 1
+
+      - step: "Setup - get receivable account type"
+        action: "ref"
+        xml_id: "account.data_account_type_receivable"
+        save_as: "ci_account_type"
+
+      - step: "Setup - create customer invoice receivable account"
+        action: "create"
+        model: "account.account"
+        save_as: "ci_account"
+        values:
+          name: "Customer Invoice Receivable PPCCI04"
+          code: "PPCCI04"
+          user_type_id: "REC: ci_account_type.id"
+          reconcile: true
+
+      - step: "Setup - create customer invoice type"
+        action: "create"
+        model: "customer_invoice_type"
+        save_as: "ci_type"
+        values:
+          name: "Customer Invoice Type PPCCI04"
+          code: "PPCCI04"
+          journal_id: "REC: ci_journal.id"
+          receivable_account_id: "REC: ci_account.id"
+
       - step: "Get account type ref"
         action: "ref"
         xml_id: "account.data_account_type_revenue"
@@ -239,6 +370,7 @@ scenarios:
         model: "school_enrollment_payment_template"
         save_as: "template"
         values:
+          customer_invoice_type_id: "REC: ci_type.id"
           name: "Template CFG Code"
           code: "TPLCFGCOD"
           product_selection_method: "code"
@@ -276,6 +408,38 @@ scenarios:
 
   - name: "Allowed Products - Enrollment Detail - Manual Strategy"
     steps:
+      - step: "Setup - get customer invoice journal"
+        action: "search"
+        model: "account.journal"
+        domain: [["type", "=", "sale"]]
+        save_as: "ci_journal"
+        limit: 1
+
+      - step: "Setup - get receivable account type"
+        action: "ref"
+        xml_id: "account.data_account_type_receivable"
+        save_as: "ci_account_type"
+
+      - step: "Setup - create customer invoice receivable account"
+        action: "create"
+        model: "account.account"
+        save_as: "ci_account"
+        values:
+          name: "Customer Invoice Receivable PPCCI05"
+          code: "PPCCI05"
+          user_type_id: "REC: ci_account_type.id"
+          reconcile: true
+
+      - step: "Setup - create customer invoice type"
+        action: "create"
+        model: "customer_invoice_type"
+        save_as: "ci_type"
+        values:
+          name: "Customer Invoice Type PPCCI05"
+          code: "PPCCI05"
+          journal_id: "REC: ci_journal.id"
+          receivable_account_id: "REC: ci_account.id"
+
       - step: "Setup - get receivable journal"
         action: "search"
         model: "account.journal"
@@ -389,6 +553,7 @@ scenarios:
         model: "school_enrollment_payment_template"
         save_as: "payment_template"
         values:
+          customer_invoice_type_id: "REC: ci_type.id"
           name: "Template CFG Enr Manual"
           code: "TPLCFGENRMAN"
           school_id: "EVAL: registry['school'].id"
@@ -456,6 +621,38 @@ scenarios:
 
   - name: "Allowed Products - Enrollment Detail - No Template"
     steps:
+      - step: "Setup - get customer invoice journal"
+        action: "search"
+        model: "account.journal"
+        domain: [["type", "=", "sale"]]
+        save_as: "ci_journal"
+        limit: 1
+
+      - step: "Setup - get receivable account type"
+        action: "ref"
+        xml_id: "account.data_account_type_receivable"
+        save_as: "ci_account_type"
+
+      - step: "Setup - create customer invoice receivable account"
+        action: "create"
+        model: "account.account"
+        save_as: "ci_account"
+        values:
+          name: "Customer Invoice Receivable PPCCI06"
+          code: "PPCCI06"
+          user_type_id: "REC: ci_account_type.id"
+          reconcile: true
+
+      - step: "Setup - create customer invoice type"
+        action: "create"
+        model: "customer_invoice_type"
+        save_as: "ci_type"
+        values:
+          name: "Customer Invoice Type PPCCI06"
+          code: "PPCCI06"
+          journal_id: "REC: ci_journal.id"
+          receivable_account_id: "REC: ci_account.id"
+
       - step: "Setup - get receivable journal"
         action: "search"
         model: "account.journal"
@@ -603,6 +800,38 @@ scenarios:
 
   - name: "Allowed Products - Enrollment Detail - Domain Strategy"
     steps:
+      - step: "Setup - get customer invoice journal"
+        action: "search"
+        model: "account.journal"
+        domain: [["type", "=", "sale"]]
+        save_as: "ci_journal"
+        limit: 1
+
+      - step: "Setup - get receivable account type"
+        action: "ref"
+        xml_id: "account.data_account_type_receivable"
+        save_as: "ci_account_type"
+
+      - step: "Setup - create customer invoice receivable account"
+        action: "create"
+        model: "account.account"
+        save_as: "ci_account"
+        values:
+          name: "Customer Invoice Receivable PPCCI07"
+          code: "PPCCI07"
+          user_type_id: "REC: ci_account_type.id"
+          reconcile: true
+
+      - step: "Setup - create customer invoice type"
+        action: "create"
+        model: "customer_invoice_type"
+        save_as: "ci_type"
+        values:
+          name: "Customer Invoice Type PPCCI07"
+          code: "PPCCI07"
+          journal_id: "REC: ci_journal.id"
+          receivable_account_id: "REC: ci_account.id"
+
       - step: "Setup - get receivable journal"
         action: "search"
         model: "account.journal"
@@ -718,6 +947,7 @@ scenarios:
         model: "school_enrollment_payment_template"
         save_as: "payment_template"
         values:
+          customer_invoice_type_id: "REC: ci_type.id"
           name: "Template CFG Enr Domain"
           code: "TPLCFGENRDOM"
           school_id: "EVAL: registry['school'].id"
@@ -781,6 +1011,38 @@ scenarios:
 
   - name: "Allowed Products - Enrollment Detail - Python Code Strategy"
     steps:
+      - step: "Setup - get customer invoice journal"
+        action: "search"
+        model: "account.journal"
+        domain: [["type", "=", "sale"]]
+        save_as: "ci_journal"
+        limit: 1
+
+      - step: "Setup - get receivable account type"
+        action: "ref"
+        xml_id: "account.data_account_type_receivable"
+        save_as: "ci_account_type"
+
+      - step: "Setup - create customer invoice receivable account"
+        action: "create"
+        model: "account.account"
+        save_as: "ci_account"
+        values:
+          name: "Customer Invoice Receivable PPCCI08"
+          code: "PPCCI08"
+          user_type_id: "REC: ci_account_type.id"
+          reconcile: true
+
+      - step: "Setup - create customer invoice type"
+        action: "create"
+        model: "customer_invoice_type"
+        save_as: "ci_type"
+        values:
+          name: "Customer Invoice Type PPCCI08"
+          code: "PPCCI08"
+          journal_id: "REC: ci_journal.id"
+          receivable_account_id: "REC: ci_account.id"
+
       - step: "Setup - get receivable journal"
         action: "search"
         model: "account.journal"
@@ -896,6 +1158,7 @@ scenarios:
         model: "school_enrollment_payment_template"
         save_as: "payment_template"
         values:
+          customer_invoice_type_id: "REC: ci_type.id"
           name: "Template CFG Enr Code"
           code: "TPLCFGENRCOD"
           school_id: "EVAL: registry['school'].id"

--- a/ssi_school/tests/test_data_enrollment_payment_template.yaml
+++ b/ssi_school/tests/test_data_enrollment_payment_template.yaml
@@ -3,6 +3,38 @@ options:
 scenarios:
   - name: "Create Payment Template"
     steps:
+      - step: "Setup - get customer invoice journal"
+        action: "search"
+        model: "account.journal"
+        domain: [["type", "=", "sale"]]
+        save_as: "ci_journal"
+        limit: 1
+
+      - step: "Setup - get receivable account type"
+        action: "ref"
+        xml_id: "account.data_account_type_receivable"
+        save_as: "ci_account_type"
+
+      - step: "Setup - create customer invoice receivable account"
+        action: "create"
+        model: "account.account"
+        save_as: "ci_account"
+        values:
+          name: "Customer Invoice Receivable PTPCI01"
+          code: "PTPCI01"
+          user_type_id: "REC: ci_account_type.id"
+          reconcile: true
+
+      - step: "Setup - create customer invoice type"
+        action: "create"
+        model: "customer_invoice_type"
+        save_as: "ci_type"
+        values:
+          name: "Customer Invoice Type PTPCI01"
+          code: "PTPCI01"
+          journal_id: "REC: ci_journal.id"
+          receivable_account_id: "REC: ci_account.id"
+
       - step: "Create grade type"
         action: "create"
         model: "school_grade_type"
@@ -33,6 +65,7 @@ scenarios:
         model: "school_enrollment_payment_template"
         save_as: "template"
         values:
+          customer_invoice_type_id: "REC: ci_type.id"
           name: "New Payment Template"
           code: "PMT002"
           school_id: "EVAL: registry['school'].id"
@@ -56,11 +89,44 @@ scenarios:
 
   - name: "Create Payment Template Without School And Grade"
     steps:
+      - step: "Setup - get customer invoice journal"
+        action: "search"
+        model: "account.journal"
+        domain: [["type", "=", "sale"]]
+        save_as: "ci_journal"
+        limit: 1
+
+      - step: "Setup - get receivable account type"
+        action: "ref"
+        xml_id: "account.data_account_type_receivable"
+        save_as: "ci_account_type"
+
+      - step: "Setup - create customer invoice receivable account"
+        action: "create"
+        model: "account.account"
+        save_as: "ci_account"
+        values:
+          name: "Customer Invoice Receivable PTPCI02"
+          code: "PTPCI02"
+          user_type_id: "REC: ci_account_type.id"
+          reconcile: true
+
+      - step: "Setup - create customer invoice type"
+        action: "create"
+        model: "customer_invoice_type"
+        save_as: "ci_type"
+        values:
+          name: "Customer Invoice Type PTPCI02"
+          code: "PTPCI02"
+          journal_id: "REC: ci_journal.id"
+          receivable_account_id: "REC: ci_account.id"
+
       - step: "Create payment template without school and grade"
         action: "create"
         model: "school_enrollment_payment_template"
         save_as: "template"
         values:
+          customer_invoice_type_id: "REC: ci_type.id"
           name: "Generic Payment Template"
           code: "PMT003"
       - step: "Assert created with falsy school and grade"
@@ -79,6 +145,38 @@ scenarios:
 
   - name: "Create Payment Template With Term Lines"
     steps:
+      - step: "Setup - get customer invoice journal"
+        action: "search"
+        model: "account.journal"
+        domain: [["type", "=", "sale"]]
+        save_as: "ci_journal"
+        limit: 1
+
+      - step: "Setup - get receivable account type"
+        action: "ref"
+        xml_id: "account.data_account_type_receivable"
+        save_as: "ci_account_type"
+
+      - step: "Setup - create customer invoice receivable account"
+        action: "create"
+        model: "account.account"
+        save_as: "ci_account"
+        values:
+          name: "Customer Invoice Receivable PTPCI03"
+          code: "PTPCI03"
+          user_type_id: "REC: ci_account_type.id"
+          reconcile: true
+
+      - step: "Setup - create customer invoice type"
+        action: "create"
+        model: "customer_invoice_type"
+        save_as: "ci_type"
+        values:
+          name: "Customer Invoice Type PTPCI03"
+          code: "PTPCI03"
+          journal_id: "REC: ci_journal.id"
+          receivable_account_id: "REC: ci_account.id"
+
       - step: "Create grade type"
         action: "create"
         model: "school_grade_type"
@@ -100,6 +198,7 @@ scenarios:
         model: "school_enrollment_payment_template"
         save_as: "template"
         values:
+          customer_invoice_type_id: "REC: ci_type.id"
           name: "Template With Terms"
           code: "PMTWT"
           school_id: "EVAL: registry['school'].id"
@@ -116,6 +215,38 @@ scenarios:
 
   - name: "Create Payment Template With Receivable Journal And Account"
     steps:
+      - step: "Setup - get customer invoice journal"
+        action: "search"
+        model: "account.journal"
+        domain: [["type", "=", "sale"]]
+        save_as: "ci_journal"
+        limit: 1
+
+      - step: "Setup - get receivable account type"
+        action: "ref"
+        xml_id: "account.data_account_type_receivable"
+        save_as: "ci_account_type"
+
+      - step: "Setup - create customer invoice receivable account"
+        action: "create"
+        model: "account.account"
+        save_as: "ci_account"
+        values:
+          name: "Customer Invoice Receivable PTPCI04"
+          code: "PTPCI04"
+          user_type_id: "REC: ci_account_type.id"
+          reconcile: true
+
+      - step: "Setup - create customer invoice type"
+        action: "create"
+        model: "customer_invoice_type"
+        save_as: "ci_type"
+        values:
+          name: "Customer Invoice Type PTPCI04"
+          code: "PTPCI04"
+          journal_id: "REC: ci_journal.id"
+          receivable_account_id: "REC: ci_account.id"
+
       - step: "Get sale journal"
         action: "search"
         model: "account.journal"
@@ -139,6 +270,7 @@ scenarios:
         model: "school_enrollment_payment_template"
         save_as: "template"
         values:
+          customer_invoice_type_id: "REC: ci_type.id"
           name: "Template Receivable Fields"
           code: "PMTRECV"
           journal_id: "EVAL: registry['journal'].id"
@@ -156,6 +288,38 @@ scenarios:
 
   - name: "Edit Payment Template Receivable Journal"
     steps:
+      - step: "Setup - get customer invoice journal"
+        action: "search"
+        model: "account.journal"
+        domain: [["type", "=", "sale"]]
+        save_as: "ci_journal"
+        limit: 1
+
+      - step: "Setup - get receivable account type"
+        action: "ref"
+        xml_id: "account.data_account_type_receivable"
+        save_as: "ci_account_type"
+
+      - step: "Setup - create customer invoice receivable account"
+        action: "create"
+        model: "account.account"
+        save_as: "ci_account"
+        values:
+          name: "Customer Invoice Receivable PTPCI05"
+          code: "PTPCI05"
+          user_type_id: "REC: ci_account_type.id"
+          reconcile: true
+
+      - step: "Setup - create customer invoice type"
+        action: "create"
+        model: "customer_invoice_type"
+        save_as: "ci_type"
+        values:
+          name: "Customer Invoice Type PTPCI05"
+          code: "PTPCI05"
+          journal_id: "REC: ci_journal.id"
+          receivable_account_id: "REC: ci_account.id"
+
       - step: "Get sale journal"
         action: "search"
         model: "account.journal"
@@ -167,6 +331,7 @@ scenarios:
         model: "school_enrollment_payment_template"
         save_as: "template"
         values:
+          customer_invoice_type_id: "REC: ci_type.id"
           name: "Template Journal Edit"
           code: "PMTJED"
       - step: "Set receivable journal"
@@ -184,6 +349,38 @@ scenarios:
 
   - name: "Edit Payment Template Receivable Account"
     steps:
+      - step: "Setup - get customer invoice journal"
+        action: "search"
+        model: "account.journal"
+        domain: [["type", "=", "sale"]]
+        save_as: "ci_journal"
+        limit: 1
+
+      - step: "Setup - get receivable account type"
+        action: "ref"
+        xml_id: "account.data_account_type_receivable"
+        save_as: "ci_account_type"
+
+      - step: "Setup - create customer invoice receivable account"
+        action: "create"
+        model: "account.account"
+        save_as: "ci_account"
+        values:
+          name: "Customer Invoice Receivable PTPCI06"
+          code: "PTPCI06"
+          user_type_id: "REC: ci_account_type.id"
+          reconcile: true
+
+      - step: "Setup - create customer invoice type"
+        action: "create"
+        model: "customer_invoice_type"
+        save_as: "ci_type"
+        values:
+          name: "Customer Invoice Type PTPCI06"
+          code: "PTPCI06"
+          journal_id: "REC: ci_journal.id"
+          receivable_account_id: "REC: ci_account.id"
+
       - step: "Get account type ref"
         action: "ref"
         xml_id: "account.data_account_type_revenue"
@@ -201,6 +398,7 @@ scenarios:
         model: "school_enrollment_payment_template"
         save_as: "template"
         values:
+          customer_invoice_type_id: "REC: ci_type.id"
           name: "Template Account Edit"
           code: "PMTAED"
       - step: "Set receivable account"
@@ -218,11 +416,44 @@ scenarios:
 
   - name: "Edit Payment Template Name"
     steps:
+      - step: "Setup - get customer invoice journal"
+        action: "search"
+        model: "account.journal"
+        domain: [["type", "=", "sale"]]
+        save_as: "ci_journal"
+        limit: 1
+
+      - step: "Setup - get receivable account type"
+        action: "ref"
+        xml_id: "account.data_account_type_receivable"
+        save_as: "ci_account_type"
+
+      - step: "Setup - create customer invoice receivable account"
+        action: "create"
+        model: "account.account"
+        save_as: "ci_account"
+        values:
+          name: "Customer Invoice Receivable PTPCI07"
+          code: "PTPCI07"
+          user_type_id: "REC: ci_account_type.id"
+          reconcile: true
+
+      - step: "Setup - create customer invoice type"
+        action: "create"
+        model: "customer_invoice_type"
+        save_as: "ci_type"
+        values:
+          name: "Customer Invoice Type PTPCI07"
+          code: "PTPCI07"
+          journal_id: "REC: ci_journal.id"
+          receivable_account_id: "REC: ci_account.id"
+
       - step: "Create payment template"
         action: "create"
         model: "school_enrollment_payment_template"
         save_as: "template"
         values:
+          customer_invoice_type_id: "REC: ci_type.id"
           name: "Payment Template Test Edit"
           code: "PMTED"
       - step: "Write new name"
@@ -240,6 +471,38 @@ scenarios:
 
   - name: "Edit Payment Template Academic Term"
     steps:
+      - step: "Setup - get customer invoice journal"
+        action: "search"
+        model: "account.journal"
+        domain: [["type", "=", "sale"]]
+        save_as: "ci_journal"
+        limit: 1
+
+      - step: "Setup - get receivable account type"
+        action: "ref"
+        xml_id: "account.data_account_type_receivable"
+        save_as: "ci_account_type"
+
+      - step: "Setup - create customer invoice receivable account"
+        action: "create"
+        model: "account.account"
+        save_as: "ci_account"
+        values:
+          name: "Customer Invoice Receivable PTPCI08"
+          code: "PTPCI08"
+          user_type_id: "REC: ci_account_type.id"
+          reconcile: true
+
+      - step: "Setup - create customer invoice type"
+        action: "create"
+        model: "customer_invoice_type"
+        save_as: "ci_type"
+        values:
+          name: "Customer Invoice Type PTPCI08"
+          code: "PTPCI08"
+          journal_id: "REC: ci_journal.id"
+          receivable_account_id: "REC: ci_account.id"
+
       - step: "Create academic year"
         action: "create"
         model: "school_academic_year"
@@ -274,6 +537,7 @@ scenarios:
         model: "school_enrollment_payment_template"
         save_as: "template"
         values:
+          customer_invoice_type_id: "REC: ci_type.id"
           name: "Template Term Edit"
           code: "PMTTE"
           academic_term_id: "EVAL: registry['term'].id"
@@ -295,11 +559,44 @@ scenarios:
 
   - name: "Edit Payment Template Add Term Line"
     steps:
+      - step: "Setup - get customer invoice journal"
+        action: "search"
+        model: "account.journal"
+        domain: [["type", "=", "sale"]]
+        save_as: "ci_journal"
+        limit: 1
+
+      - step: "Setup - get receivable account type"
+        action: "ref"
+        xml_id: "account.data_account_type_receivable"
+        save_as: "ci_account_type"
+
+      - step: "Setup - create customer invoice receivable account"
+        action: "create"
+        model: "account.account"
+        save_as: "ci_account"
+        values:
+          name: "Customer Invoice Receivable PTPCI09"
+          code: "PTPCI09"
+          user_type_id: "REC: ci_account_type.id"
+          reconcile: true
+
+      - step: "Setup - create customer invoice type"
+        action: "create"
+        model: "customer_invoice_type"
+        save_as: "ci_type"
+        values:
+          name: "Customer Invoice Type PTPCI09"
+          code: "PTPCI09"
+          journal_id: "REC: ci_journal.id"
+          receivable_account_id: "REC: ci_account.id"
+
       - step: "Create payment template"
         action: "create"
         model: "school_enrollment_payment_template"
         save_as: "template"
         values:
+          customer_invoice_type_id: "REC: ci_type.id"
           name: "Template Add Term"
           code: "PMTAT"
       - step: "Add a term line"
@@ -319,11 +616,44 @@ scenarios:
 
   - name: "Delete Payment Template"
     steps:
+      - step: "Setup - get customer invoice journal"
+        action: "search"
+        model: "account.journal"
+        domain: [["type", "=", "sale"]]
+        save_as: "ci_journal"
+        limit: 1
+
+      - step: "Setup - get receivable account type"
+        action: "ref"
+        xml_id: "account.data_account_type_receivable"
+        save_as: "ci_account_type"
+
+      - step: "Setup - create customer invoice receivable account"
+        action: "create"
+        model: "account.account"
+        save_as: "ci_account"
+        values:
+          name: "Customer Invoice Receivable PTPCI10"
+          code: "PTPCI10"
+          user_type_id: "REC: ci_account_type.id"
+          reconcile: true
+
+      - step: "Setup - create customer invoice type"
+        action: "create"
+        model: "customer_invoice_type"
+        save_as: "ci_type"
+        values:
+          name: "Customer Invoice Type PTPCI10"
+          code: "PTPCI10"
+          journal_id: "REC: ci_journal.id"
+          receivable_account_id: "REC: ci_account.id"
+
       - step: "Create payment template"
         action: "create"
         model: "school_enrollment_payment_template"
         save_as: "template"
         values:
+          customer_invoice_type_id: "REC: ci_type.id"
           name: "Template To Delete"
           code: "PMTDEL"
       - step: "Delete template"
@@ -339,11 +669,44 @@ scenarios:
 
   - name: "Delete Payment Template Cascades Terms"
     steps:
+      - step: "Setup - get customer invoice journal"
+        action: "search"
+        model: "account.journal"
+        domain: [["type", "=", "sale"]]
+        save_as: "ci_journal"
+        limit: 1
+
+      - step: "Setup - get receivable account type"
+        action: "ref"
+        xml_id: "account.data_account_type_receivable"
+        save_as: "ci_account_type"
+
+      - step: "Setup - create customer invoice receivable account"
+        action: "create"
+        model: "account.account"
+        save_as: "ci_account"
+        values:
+          name: "Customer Invoice Receivable PTPCI11"
+          code: "PTPCI11"
+          user_type_id: "REC: ci_account_type.id"
+          reconcile: true
+
+      - step: "Setup - create customer invoice type"
+        action: "create"
+        model: "customer_invoice_type"
+        save_as: "ci_type"
+        values:
+          name: "Customer Invoice Type PTPCI11"
+          code: "PTPCI11"
+          journal_id: "REC: ci_journal.id"
+          receivable_account_id: "REC: ci_account.id"
+
       - step: "Create payment template with terms"
         action: "create"
         model: "school_enrollment_payment_template"
         save_as: "template"
         values:
+          customer_invoice_type_id: "REC: ci_type.id"
           name: "Template Cascade Delete"
           code: "PMTCSC"
           term_ids:
@@ -361,6 +724,38 @@ scenarios:
 
   - name: "Compute Grade Type From School"
     steps:
+      - step: "Setup - get customer invoice journal"
+        action: "search"
+        model: "account.journal"
+        domain: [["type", "=", "sale"]]
+        save_as: "ci_journal"
+        limit: 1
+
+      - step: "Setup - get receivable account type"
+        action: "ref"
+        xml_id: "account.data_account_type_receivable"
+        save_as: "ci_account_type"
+
+      - step: "Setup - create customer invoice receivable account"
+        action: "create"
+        model: "account.account"
+        save_as: "ci_account"
+        values:
+          name: "Customer Invoice Receivable PTPCI12"
+          code: "PTPCI12"
+          user_type_id: "REC: ci_account_type.id"
+          reconcile: true
+
+      - step: "Setup - create customer invoice type"
+        action: "create"
+        model: "customer_invoice_type"
+        save_as: "ci_type"
+        values:
+          name: "Customer Invoice Type PTPCI12"
+          code: "PTPCI12"
+          journal_id: "REC: ci_journal.id"
+          receivable_account_id: "REC: ci_account.id"
+
       - step: "Create grade type"
         action: "create"
         model: "school_grade_type"
@@ -382,6 +777,7 @@ scenarios:
         model: "school_enrollment_payment_template"
         save_as: "template"
         values:
+          customer_invoice_type_id: "REC: ci_type.id"
           name: "Template Grade Type Compute"
           code: "PMTGTC"
           school_id: "EVAL: registry['school'].id"
@@ -395,11 +791,44 @@ scenarios:
 
   - name: "Compute Grade Type Empty When No School"
     steps:
+      - step: "Setup - get customer invoice journal"
+        action: "search"
+        model: "account.journal"
+        domain: [["type", "=", "sale"]]
+        save_as: "ci_journal"
+        limit: 1
+
+      - step: "Setup - get receivable account type"
+        action: "ref"
+        xml_id: "account.data_account_type_receivable"
+        save_as: "ci_account_type"
+
+      - step: "Setup - create customer invoice receivable account"
+        action: "create"
+        model: "account.account"
+        save_as: "ci_account"
+        values:
+          name: "Customer Invoice Receivable PTPCI13"
+          code: "PTPCI13"
+          user_type_id: "REC: ci_account_type.id"
+          reconcile: true
+
+      - step: "Setup - create customer invoice type"
+        action: "create"
+        model: "customer_invoice_type"
+        save_as: "ci_type"
+        values:
+          name: "Customer Invoice Type PTPCI13"
+          code: "PTPCI13"
+          journal_id: "REC: ci_journal.id"
+          receivable_account_id: "REC: ci_account.id"
+
       - step: "Create payment template without school"
         action: "create"
         model: "school_enrollment_payment_template"
         save_as: "template"
         values:
+          customer_invoice_type_id: "REC: ci_type.id"
           name: "Template No School"
           code: "PMTNS"
       - step: "Assert grade_type_id is falsy"
@@ -412,11 +841,44 @@ scenarios:
 
   - name: "Create Term"
     steps:
+      - step: "Setup - get customer invoice journal"
+        action: "search"
+        model: "account.journal"
+        domain: [["type", "=", "sale"]]
+        save_as: "ci_journal"
+        limit: 1
+
+      - step: "Setup - get receivable account type"
+        action: "ref"
+        xml_id: "account.data_account_type_receivable"
+        save_as: "ci_account_type"
+
+      - step: "Setup - create customer invoice receivable account"
+        action: "create"
+        model: "account.account"
+        save_as: "ci_account"
+        values:
+          name: "Customer Invoice Receivable PTPCI14"
+          code: "PTPCI14"
+          user_type_id: "REC: ci_account_type.id"
+          reconcile: true
+
+      - step: "Setup - create customer invoice type"
+        action: "create"
+        model: "customer_invoice_type"
+        save_as: "ci_type"
+        values:
+          name: "Customer Invoice Type PTPCI14"
+          code: "PTPCI14"
+          journal_id: "REC: ci_journal.id"
+          receivable_account_id: "REC: ci_account.id"
+
       - step: "Create payment template"
         action: "create"
         model: "school_enrollment_payment_template"
         save_as: "template"
         values:
+          customer_invoice_type_id: "REC: ci_type.id"
           name: "Template for Term Test"
           code: "PMTTRM"
       - step: "Create term"
@@ -443,11 +905,44 @@ scenarios:
 
   - name: "Edit Term Name"
     steps:
+      - step: "Setup - get customer invoice journal"
+        action: "search"
+        model: "account.journal"
+        domain: [["type", "=", "sale"]]
+        save_as: "ci_journal"
+        limit: 1
+
+      - step: "Setup - get receivable account type"
+        action: "ref"
+        xml_id: "account.data_account_type_receivable"
+        save_as: "ci_account_type"
+
+      - step: "Setup - create customer invoice receivable account"
+        action: "create"
+        model: "account.account"
+        save_as: "ci_account"
+        values:
+          name: "Customer Invoice Receivable PTPCI15"
+          code: "PTPCI15"
+          user_type_id: "REC: ci_account_type.id"
+          reconcile: true
+
+      - step: "Setup - create customer invoice type"
+        action: "create"
+        model: "customer_invoice_type"
+        save_as: "ci_type"
+        values:
+          name: "Customer Invoice Type PTPCI15"
+          code: "PTPCI15"
+          journal_id: "REC: ci_journal.id"
+          receivable_account_id: "REC: ci_account.id"
+
       - step: "Create payment template"
         action: "create"
         model: "school_enrollment_payment_template"
         save_as: "template"
         values:
+          customer_invoice_type_id: "REC: ci_type.id"
           name: "Template Term Edit Name"
           code: "PMTTEN"
       - step: "Create term"
@@ -473,11 +968,44 @@ scenarios:
 
   - name: "Edit Term Sequence"
     steps:
+      - step: "Setup - get customer invoice journal"
+        action: "search"
+        model: "account.journal"
+        domain: [["type", "=", "sale"]]
+        save_as: "ci_journal"
+        limit: 1
+
+      - step: "Setup - get receivable account type"
+        action: "ref"
+        xml_id: "account.data_account_type_receivable"
+        save_as: "ci_account_type"
+
+      - step: "Setup - create customer invoice receivable account"
+        action: "create"
+        model: "account.account"
+        save_as: "ci_account"
+        values:
+          name: "Customer Invoice Receivable PTPCI16"
+          code: "PTPCI16"
+          user_type_id: "REC: ci_account_type.id"
+          reconcile: true
+
+      - step: "Setup - create customer invoice type"
+        action: "create"
+        model: "customer_invoice_type"
+        save_as: "ci_type"
+        values:
+          name: "Customer Invoice Type PTPCI16"
+          code: "PTPCI16"
+          journal_id: "REC: ci_journal.id"
+          receivable_account_id: "REC: ci_account.id"
+
       - step: "Create payment template"
         action: "create"
         model: "school_enrollment_payment_template"
         save_as: "template"
         values:
+          customer_invoice_type_id: "REC: ci_type.id"
           name: "Template Term Edit Seq"
           code: "PMTTESEQ"
       - step: "Create term"
@@ -503,11 +1031,44 @@ scenarios:
 
   - name: "Delete Term"
     steps:
+      - step: "Setup - get customer invoice journal"
+        action: "search"
+        model: "account.journal"
+        domain: [["type", "=", "sale"]]
+        save_as: "ci_journal"
+        limit: 1
+
+      - step: "Setup - get receivable account type"
+        action: "ref"
+        xml_id: "account.data_account_type_receivable"
+        save_as: "ci_account_type"
+
+      - step: "Setup - create customer invoice receivable account"
+        action: "create"
+        model: "account.account"
+        save_as: "ci_account"
+        values:
+          name: "Customer Invoice Receivable PTPCI17"
+          code: "PTPCI17"
+          user_type_id: "REC: ci_account_type.id"
+          reconcile: true
+
+      - step: "Setup - create customer invoice type"
+        action: "create"
+        model: "customer_invoice_type"
+        save_as: "ci_type"
+        values:
+          name: "Customer Invoice Type PTPCI17"
+          code: "PTPCI17"
+          journal_id: "REC: ci_journal.id"
+          receivable_account_id: "REC: ci_account.id"
+
       - step: "Create payment template"
         action: "create"
         model: "school_enrollment_payment_template"
         save_as: "template"
         values:
+          customer_invoice_type_id: "REC: ci_type.id"
           name: "Template Term Delete"
           code: "PMTTDEL"
       - step: "Create term"
@@ -533,6 +1094,38 @@ scenarios:
 
   - name: "Create Term Detail"
     steps:
+      - step: "Setup - get customer invoice journal"
+        action: "search"
+        model: "account.journal"
+        domain: [["type", "=", "sale"]]
+        save_as: "ci_journal"
+        limit: 1
+
+      - step: "Setup - get receivable account type"
+        action: "ref"
+        xml_id: "account.data_account_type_receivable"
+        save_as: "ci_account_type"
+
+      - step: "Setup - create customer invoice receivable account"
+        action: "create"
+        model: "account.account"
+        save_as: "ci_account"
+        values:
+          name: "Customer Invoice Receivable PTPCI18"
+          code: "PTPCI18"
+          user_type_id: "REC: ci_account_type.id"
+          reconcile: true
+
+      - step: "Setup - create customer invoice type"
+        action: "create"
+        model: "customer_invoice_type"
+        save_as: "ci_type"
+        values:
+          name: "Customer Invoice Type PTPCI18"
+          code: "PTPCI18"
+          journal_id: "REC: ci_journal.id"
+          receivable_account_id: "REC: ci_account.id"
+
       - step: "Create account type ref"
         action: "ref"
         xml_id: "account.data_account_type_revenue"
@@ -558,6 +1151,7 @@ scenarios:
         model: "school_enrollment_payment_template"
         save_as: "template"
         values:
+          customer_invoice_type_id: "REC: ci_type.id"
           name: "Template for Detail Create"
           code: "PMTDETCR"
       - step: "Create term"
@@ -596,6 +1190,38 @@ scenarios:
 
   - name: "Edit Term Detail Name"
     steps:
+      - step: "Setup - get customer invoice journal"
+        action: "search"
+        model: "account.journal"
+        domain: [["type", "=", "sale"]]
+        save_as: "ci_journal"
+        limit: 1
+
+      - step: "Setup - get receivable account type"
+        action: "ref"
+        xml_id: "account.data_account_type_receivable"
+        save_as: "ci_account_type"
+
+      - step: "Setup - create customer invoice receivable account"
+        action: "create"
+        model: "account.account"
+        save_as: "ci_account"
+        values:
+          name: "Customer Invoice Receivable PTPCI19"
+          code: "PTPCI19"
+          user_type_id: "REC: ci_account_type.id"
+          reconcile: true
+
+      - step: "Setup - create customer invoice type"
+        action: "create"
+        model: "customer_invoice_type"
+        save_as: "ci_type"
+        values:
+          name: "Customer Invoice Type PTPCI19"
+          code: "PTPCI19"
+          journal_id: "REC: ci_journal.id"
+          receivable_account_id: "REC: ci_account.id"
+
       - step: "Create account type ref"
         action: "ref"
         xml_id: "account.data_account_type_revenue"
@@ -620,6 +1246,7 @@ scenarios:
         model: "school_enrollment_payment_template"
         save_as: "template"
         values:
+          customer_invoice_type_id: "REC: ci_type.id"
           name: "Template Detail Edit Name"
           code: "PMTDETEN"
       - step: "Create term"
@@ -657,6 +1284,38 @@ scenarios:
 
   - name: "Edit Term Detail Price"
     steps:
+      - step: "Setup - get customer invoice journal"
+        action: "search"
+        model: "account.journal"
+        domain: [["type", "=", "sale"]]
+        save_as: "ci_journal"
+        limit: 1
+
+      - step: "Setup - get receivable account type"
+        action: "ref"
+        xml_id: "account.data_account_type_receivable"
+        save_as: "ci_account_type"
+
+      - step: "Setup - create customer invoice receivable account"
+        action: "create"
+        model: "account.account"
+        save_as: "ci_account"
+        values:
+          name: "Customer Invoice Receivable PTPCI20"
+          code: "PTPCI20"
+          user_type_id: "REC: ci_account_type.id"
+          reconcile: true
+
+      - step: "Setup - create customer invoice type"
+        action: "create"
+        model: "customer_invoice_type"
+        save_as: "ci_type"
+        values:
+          name: "Customer Invoice Type PTPCI20"
+          code: "PTPCI20"
+          journal_id: "REC: ci_journal.id"
+          receivable_account_id: "REC: ci_account.id"
+
       - step: "Create account type ref"
         action: "ref"
         xml_id: "account.data_account_type_revenue"
@@ -681,6 +1340,7 @@ scenarios:
         model: "school_enrollment_payment_template"
         save_as: "template"
         values:
+          customer_invoice_type_id: "REC: ci_type.id"
           name: "Template Detail Price Edit"
           code: "PMTDETPE"
       - step: "Create term"
@@ -718,6 +1378,38 @@ scenarios:
 
   - name: "Delete Term Detail"
     steps:
+      - step: "Setup - get customer invoice journal"
+        action: "search"
+        model: "account.journal"
+        domain: [["type", "=", "sale"]]
+        save_as: "ci_journal"
+        limit: 1
+
+      - step: "Setup - get receivable account type"
+        action: "ref"
+        xml_id: "account.data_account_type_receivable"
+        save_as: "ci_account_type"
+
+      - step: "Setup - create customer invoice receivable account"
+        action: "create"
+        model: "account.account"
+        save_as: "ci_account"
+        values:
+          name: "Customer Invoice Receivable PTPCI21"
+          code: "PTPCI21"
+          user_type_id: "REC: ci_account_type.id"
+          reconcile: true
+
+      - step: "Setup - create customer invoice type"
+        action: "create"
+        model: "customer_invoice_type"
+        save_as: "ci_type"
+        values:
+          name: "Customer Invoice Type PTPCI21"
+          code: "PTPCI21"
+          journal_id: "REC: ci_journal.id"
+          receivable_account_id: "REC: ci_account.id"
+
       - step: "Create account type ref"
         action: "ref"
         xml_id: "account.data_account_type_revenue"
@@ -742,6 +1434,7 @@ scenarios:
         model: "school_enrollment_payment_template"
         save_as: "template"
         values:
+          customer_invoice_type_id: "REC: ci_type.id"
           name: "Template Detail Delete"
           code: "PMTDETDEL"
       - step: "Create term"

--- a/ssi_school/tests/test_data_enrollment_payment_term_duplicate.yaml
+++ b/ssi_school/tests/test_data_enrollment_payment_term_duplicate.yaml
@@ -3,6 +3,38 @@ options:
 scenarios:
   - name: "Enrollment Payment Term - Duplicate via Wizard"
     steps:
+      - step: "Setup - get customer invoice journal"
+        action: "search"
+        model: "account.journal"
+        domain: [["type", "=", "sale"]]
+        save_as: "ci_journal"
+        limit: 1
+
+      - step: "Setup - get receivable account type"
+        action: "ref"
+        xml_id: "account.data_account_type_receivable"
+        save_as: "ci_account_type"
+
+      - step: "Setup - create customer invoice receivable account"
+        action: "create"
+        model: "account.account"
+        save_as: "ci_account"
+        values:
+          name: "Customer Invoice Receivable PTDCI01"
+          code: "PTDCI01"
+          user_type_id: "REC: ci_account_type.id"
+          reconcile: true
+
+      - step: "Setup - create customer invoice type"
+        action: "create"
+        model: "customer_invoice_type"
+        save_as: "ci_type"
+        values:
+          name: "Customer Invoice Type PTDCI01"
+          code: "PTDCI01"
+          journal_id: "REC: ci_journal.id"
+          receivable_account_id: "REC: ci_account.id"
+
       - step: "Setup - get receivable journal"
         action: "search"
         model: "account.journal"
@@ -132,6 +164,8 @@ scenarios:
         model: "school_enrollment"
         save_as: "enrollment"
         values:
+          customer_invoice_type_id: "REC: ci_type.id"
+          receivable_account_id: "REC: ci_account.id"
           date: "2024-07-01"
           academic_year_id: "EVAL: registry['academic_year'].id"
           academic_term_id: "EVAL: registry['academic_term'].id"
@@ -185,7 +219,7 @@ scenarios:
         action: "assert"
         target: "term"
         asserts:
-          invoice_id:
+          customer_invoice_id:
             type: "value"
             operator: "is_truthy"
 
@@ -230,7 +264,7 @@ scenarios:
           date_due:
             type: "value"
             expected: 2024-09-15
-          invoice_id:
+          customer_invoice_id:
             type: "value"
             operator: "is_falsy"
           detail_ids:
@@ -260,7 +294,7 @@ scenarios:
           uom_quantity:
             type: "value"
             expected: 1.0
-          invoice_line_id:
+          customer_invoice_line_id:
             type: "value"
             operator: "is_falsy"
 
@@ -286,7 +320,7 @@ scenarios:
           uom_quantity:
             type: "value"
             expected: 1.0
-          invoice_line_id:
+          customer_invoice_line_id:
             type: "value"
             operator: "is_falsy"
 

--- a/ssi_school/tests/test_data_enrollment_payment_term_management.yaml
+++ b/ssi_school/tests/test_data_enrollment_payment_term_management.yaml
@@ -3,6 +3,38 @@ options:
 scenarios:
   - name: "Enrollment Payment Term - Delete Invoice"
     steps:
+      - step: "Setup - get customer invoice journal"
+        action: "search"
+        model: "account.journal"
+        domain: [["type", "=", "sale"]]
+        save_as: "ci_journal"
+        limit: 1
+
+      - step: "Setup - get receivable account type"
+        action: "ref"
+        xml_id: "account.data_account_type_receivable"
+        save_as: "ci_account_type"
+
+      - step: "Setup - create customer invoice receivable account"
+        action: "create"
+        model: "account.account"
+        save_as: "ci_account"
+        values:
+          name: "Customer Invoice Receivable PTMCI01"
+          code: "PTMCI01"
+          user_type_id: "REC: ci_account_type.id"
+          reconcile: true
+
+      - step: "Setup - create customer invoice type"
+        action: "create"
+        model: "customer_invoice_type"
+        save_as: "ci_type"
+        values:
+          name: "Customer Invoice Type PTMCI01"
+          code: "PTMCI01"
+          journal_id: "REC: ci_journal.id"
+          receivable_account_id: "REC: ci_account.id"
+
       - step: "Setup - get receivable journal"
         action: "search"
         model: "account.journal"
@@ -123,6 +155,7 @@ scenarios:
         model: "school_enrollment_payment_template"
         save_as: "payment_template"
         values:
+          customer_invoice_type_id: "REC: ci_type.id"
           name: "Payment Template PTDEL"
           code: "PMTPTDEL"
           school_id: "EVAL: registry['school'].id"
@@ -148,6 +181,8 @@ scenarios:
         model: "school_enrollment"
         save_as: "enrollment"
         values:
+          customer_invoice_type_id: "REC: ci_type.id"
+          receivable_account_id: "REC: ci_account.id"
           date: "2024-07-01"
           academic_year_id: "EVAL: registry['academic_year'].id"
           academic_term_id: "EVAL: registry['academic_term'].id"
@@ -203,7 +238,7 @@ scenarios:
         action: "assert"
         target: "term"
         asserts:
-          invoice_id:
+          customer_invoice_id:
             type: "value"
             operator: "is_truthy"
           state:
@@ -219,7 +254,7 @@ scenarios:
         action: "assert"
         target: "term"
         asserts:
-          invoice_id:
+          customer_invoice_id:
             type: "value"
             operator: "is_falsy"
           state:
@@ -228,6 +263,38 @@ scenarios:
 
   - name: "Enrollment Payment Term - Disconnect Invoice"
     steps:
+      - step: "Setup - get customer invoice journal"
+        action: "search"
+        model: "account.journal"
+        domain: [["type", "=", "sale"]]
+        save_as: "ci_journal"
+        limit: 1
+
+      - step: "Setup - get receivable account type"
+        action: "ref"
+        xml_id: "account.data_account_type_receivable"
+        save_as: "ci_account_type"
+
+      - step: "Setup - create customer invoice receivable account"
+        action: "create"
+        model: "account.account"
+        save_as: "ci_account"
+        values:
+          name: "Customer Invoice Receivable PTMCI02"
+          code: "PTMCI02"
+          user_type_id: "REC: ci_account_type.id"
+          reconcile: true
+
+      - step: "Setup - create customer invoice type"
+        action: "create"
+        model: "customer_invoice_type"
+        save_as: "ci_type"
+        values:
+          name: "Customer Invoice Type PTMCI02"
+          code: "PTMCI02"
+          journal_id: "REC: ci_journal.id"
+          receivable_account_id: "REC: ci_account.id"
+
       - step: "Setup - get receivable journal"
         action: "search"
         model: "account.journal"
@@ -348,6 +415,7 @@ scenarios:
         model: "school_enrollment_payment_template"
         save_as: "payment_template"
         values:
+          customer_invoice_type_id: "REC: ci_type.id"
           name: "Payment Template PTDISC"
           code: "PMTPTDISC"
           school_id: "EVAL: registry['school'].id"
@@ -373,6 +441,8 @@ scenarios:
         model: "school_enrollment"
         save_as: "enrollment"
         values:
+          customer_invoice_type_id: "REC: ci_type.id"
+          receivable_account_id: "REC: ci_account.id"
           date: "2024-07-01"
           academic_year_id: "EVAL: registry['academic_year'].id"
           academic_term_id: "EVAL: registry['academic_term'].id"
@@ -424,7 +494,7 @@ scenarios:
         action: "assert"
         target: "term"
         asserts:
-          invoice_id:
+          customer_invoice_id:
             type: "value"
             operator: "is_truthy"
 
@@ -437,7 +507,7 @@ scenarios:
         action: "assert"
         target: "term"
         asserts:
-          invoice_id:
+          customer_invoice_id:
             type: "value"
             operator: "is_falsy"
           state:
@@ -446,6 +516,38 @@ scenarios:
 
   - name: "Enrollment Payment Term - Unmark As Manual"
     steps:
+      - step: "Setup - get customer invoice journal"
+        action: "search"
+        model: "account.journal"
+        domain: [["type", "=", "sale"]]
+        save_as: "ci_journal"
+        limit: 1
+
+      - step: "Setup - get receivable account type"
+        action: "ref"
+        xml_id: "account.data_account_type_receivable"
+        save_as: "ci_account_type"
+
+      - step: "Setup - create customer invoice receivable account"
+        action: "create"
+        model: "account.account"
+        save_as: "ci_account"
+        values:
+          name: "Customer Invoice Receivable PTMCI03"
+          code: "PTMCI03"
+          user_type_id: "REC: ci_account_type.id"
+          reconcile: true
+
+      - step: "Setup - create customer invoice type"
+        action: "create"
+        model: "customer_invoice_type"
+        save_as: "ci_type"
+        values:
+          name: "Customer Invoice Type PTMCI03"
+          code: "PTMCI03"
+          journal_id: "REC: ci_journal.id"
+          receivable_account_id: "REC: ci_account.id"
+
       - step: "Setup - get receivable journal"
         action: "search"
         model: "account.journal"
@@ -566,6 +668,7 @@ scenarios:
         model: "school_enrollment_payment_template"
         save_as: "payment_template"
         values:
+          customer_invoice_type_id: "REC: ci_type.id"
           name: "Payment Template PTUM"
           code: "PMTPTUM"
           school_id: "EVAL: registry['school'].id"
@@ -591,6 +694,8 @@ scenarios:
         model: "school_enrollment"
         save_as: "enrollment"
         values:
+          customer_invoice_type_id: "REC: ci_type.id"
+          receivable_account_id: "REC: ci_account.id"
           date: "2024-07-01"
           academic_year_id: "EVAL: registry['academic_year'].id"
           academic_term_id: "EVAL: registry['academic_term'].id"

--- a/ssi_school/tests/test_data_enrollment_restart_unlock.yaml
+++ b/ssi_school/tests/test_data_enrollment_restart_unlock.yaml
@@ -3,6 +3,38 @@ options:
 scenarios:
   - name: "Restart Unlocks Payment Term And Detail, Remains Editable"
     steps:
+      - step: "Setup - get customer invoice journal"
+        action: "search"
+        model: "account.journal"
+        domain: [["type", "=", "sale"]]
+        save_as: "ci_journal"
+        limit: 1
+
+      - step: "Setup - get receivable account type"
+        action: "ref"
+        xml_id: "account.data_account_type_receivable"
+        save_as: "ci_account_type"
+
+      - step: "Setup - create customer invoice receivable account"
+        action: "create"
+        model: "account.account"
+        save_as: "ci_account"
+        values:
+          name: "Customer Invoice Receivable RSUCI01"
+          code: "RSUCI01"
+          user_type_id: "REC: ci_account_type.id"
+          reconcile: true
+
+      - step: "Setup - create customer invoice type"
+        action: "create"
+        model: "customer_invoice_type"
+        save_as: "ci_type"
+        values:
+          name: "Customer Invoice Type RSUCI01"
+          code: "RSUCI01"
+          journal_id: "REC: ci_journal.id"
+          receivable_account_id: "REC: ci_account.id"
+
       - step: "Setup - get receivable journal"
         action: "search"
         model: "account.journal"
@@ -116,6 +148,9 @@ scenarios:
         save_as: "enrollment"
         as_user: "base.user_admin"
         values:
+          customer_invoice_type_id: "REC: ci_type.id"
+          receivable_account_id: "REC: ci_account.id"
+          pricelist_id: "REF: product.list0"
           date: "2024-07-01"
           academic_year_id: "EVAL: registry['academic_year'].id"
           academic_term_id: "EVAL: registry['academic_term'].id"

--- a/ssi_school/tests/test_data_school_homeroom_generate.yaml
+++ b/ssi_school/tests/test_data_school_homeroom_generate.yaml
@@ -3,6 +3,38 @@ options:
 scenarios:
   - name: "Homeroom Fill Random And Generate Enrollments"
     steps:
+      - step: "Setup - get customer invoice journal"
+        action: "search"
+        model: "account.journal"
+        domain: [["type", "=", "sale"]]
+        save_as: "ci_journal"
+        limit: 1
+
+      - step: "Setup - get receivable account type"
+        action: "ref"
+        xml_id: "account.data_account_type_receivable"
+        save_as: "ci_account_type"
+
+      - step: "Setup - create customer invoice receivable account"
+        action: "create"
+        model: "account.account"
+        save_as: "ci_account"
+        values:
+          name: "Customer Invoice Receivable HRGCI01"
+          code: "HRGCI01"
+          user_type_id: "REC: ci_account_type.id"
+          reconcile: true
+
+      - step: "Setup - create customer invoice type"
+        action: "create"
+        model: "customer_invoice_type"
+        save_as: "ci_type"
+        values:
+          name: "Customer Invoice Type HRGCI01"
+          code: "HRGCI01"
+          journal_id: "REC: ci_journal.id"
+          receivable_account_id: "REC: ci_account.id"
+
       - step: "Setup - get account type ref"
         action: "ref"
         xml_id: "account.data_account_type_revenue"
@@ -92,6 +124,7 @@ scenarios:
         model: "school_enrollment_payment_template"
         save_as: "payment_template"
         values:
+          customer_invoice_type_id: "REC: ci_type.id"
           name: "Homeroom Generate Payment Template 1"
           code: "HGPMT1"
           school_id: "EVAL: registry['school'].id"
@@ -297,6 +330,38 @@ scenarios:
 
   - name: "Homeroom Non First Term Eligibility"
     steps:
+      - step: "Setup - get customer invoice journal"
+        action: "search"
+        model: "account.journal"
+        domain: [["type", "=", "sale"]]
+        save_as: "ci_journal"
+        limit: 1
+
+      - step: "Setup - get receivable account type"
+        action: "ref"
+        xml_id: "account.data_account_type_receivable"
+        save_as: "ci_account_type"
+
+      - step: "Setup - create customer invoice receivable account"
+        action: "create"
+        model: "account.account"
+        save_as: "ci_account"
+        values:
+          name: "Customer Invoice Receivable HRGCI02"
+          code: "HRGCI02"
+          user_type_id: "REC: ci_account_type.id"
+          reconcile: true
+
+      - step: "Setup - create customer invoice type"
+        action: "create"
+        model: "customer_invoice_type"
+        save_as: "ci_type"
+        values:
+          name: "Customer Invoice Type HRGCI02"
+          code: "HRGCI02"
+          journal_id: "REC: ci_journal.id"
+          receivable_account_id: "REC: ci_account.id"
+
       - step: "Setup - create grade type"
         action: "create"
         model: "school_grade_type"
@@ -459,6 +524,38 @@ scenarios:
 
   - name: "Homeroom Fill Random Respects Remaining Capacity"
     steps:
+      - step: "Setup - get customer invoice journal"
+        action: "search"
+        model: "account.journal"
+        domain: [["type", "=", "sale"]]
+        save_as: "ci_journal"
+        limit: 1
+
+      - step: "Setup - get receivable account type"
+        action: "ref"
+        xml_id: "account.data_account_type_receivable"
+        save_as: "ci_account_type"
+
+      - step: "Setup - create customer invoice receivable account"
+        action: "create"
+        model: "account.account"
+        save_as: "ci_account"
+        values:
+          name: "Customer Invoice Receivable HRGCI03"
+          code: "HRGCI03"
+          user_type_id: "REC: ci_account_type.id"
+          reconcile: true
+
+      - step: "Setup - create customer invoice type"
+        action: "create"
+        model: "customer_invoice_type"
+        save_as: "ci_type"
+        values:
+          name: "Customer Invoice Type HRGCI03"
+          code: "HRGCI03"
+          journal_id: "REC: ci_journal.id"
+          receivable_account_id: "REC: ci_account.id"
+
       - step: "Setup - create grade type"
         action: "create"
         model: "school_grade_type"
@@ -616,6 +713,38 @@ scenarios:
 
   - name: "Homeroom Regenerate Reconciles Draft Enrollments With Candidates"
     steps:
+      - step: "Setup - get customer invoice journal"
+        action: "search"
+        model: "account.journal"
+        domain: [["type", "=", "sale"]]
+        save_as: "ci_journal"
+        limit: 1
+
+      - step: "Setup - get receivable account type"
+        action: "ref"
+        xml_id: "account.data_account_type_receivable"
+        save_as: "ci_account_type"
+
+      - step: "Setup - create customer invoice receivable account"
+        action: "create"
+        model: "account.account"
+        save_as: "ci_account"
+        values:
+          name: "Customer Invoice Receivable HRGCI04"
+          code: "HRGCI04"
+          user_type_id: "REC: ci_account_type.id"
+          reconcile: true
+
+      - step: "Setup - create customer invoice type"
+        action: "create"
+        model: "customer_invoice_type"
+        save_as: "ci_type"
+        values:
+          name: "Customer Invoice Type HRGCI04"
+          code: "HRGCI04"
+          journal_id: "REC: ci_journal.id"
+          receivable_account_id: "REC: ci_account.id"
+
       - step: "Setup - create grade type"
         action: "create"
         model: "school_grade_type"
@@ -805,6 +934,38 @@ scenarios:
       "Homeroom Generate Enrollment Copies Receivable Journal And Account From Default
       Template"
     steps:
+      - step: "Setup - get customer invoice journal"
+        action: "search"
+        model: "account.journal"
+        domain: [["type", "=", "sale"]]
+        save_as: "ci_journal"
+        limit: 1
+
+      - step: "Setup - get receivable account type"
+        action: "ref"
+        xml_id: "account.data_account_type_receivable"
+        save_as: "ci_account_type"
+
+      - step: "Setup - create customer invoice receivable account"
+        action: "create"
+        model: "account.account"
+        save_as: "ci_account"
+        values:
+          name: "Customer Invoice Receivable HRGCI05"
+          code: "HRGCI05"
+          user_type_id: "REC: ci_account_type.id"
+          reconcile: true
+
+      - step: "Setup - create customer invoice type"
+        action: "create"
+        model: "customer_invoice_type"
+        save_as: "ci_type"
+        values:
+          name: "Customer Invoice Type HRGCI05"
+          code: "HRGCI05"
+          journal_id: "REC: ci_journal.id"
+          receivable_account_id: "REC: ci_account.id"
+
       - step: "Get sale journal"
         action: "search"
         model: "account.journal"
@@ -892,6 +1053,7 @@ scenarios:
         model: "school_enrollment_payment_template"
         save_as: "payment_template"
         values:
+          customer_invoice_type_id: "REC: ci_type.id"
           name: "Homeroom Generate Payment Template 6"
           code: "HGPMT6"
           school_id: "EVAL: registry['school'].id"

--- a/ssi_school/tests/test_school_enrollment.py
+++ b/ssi_school/tests/test_school_enrollment.py
@@ -12,6 +12,27 @@ class TestSchoolEnrollmentWorkflow(YamlTransactionCase):
     def test_enrollment_workflow(self):
         self.run_yaml_scenario("test_data_enrollment.yaml")
 
+    def _create_customer_invoice_type(self, suffix):
+        """Create the customer invoice type required by every template."""
+        journal = self.env["account.journal"].search([("type", "=", "sale")], limit=1)
+        receivable_type = self.env.ref("account.data_account_type_receivable")
+        account = self.env["account.account"].create(
+            {
+                "name": "Receivable %s" % suffix,
+                "code": "RCVENR%s" % suffix,
+                "user_type_id": receivable_type.id,
+                "reconcile": True,
+            }
+        )
+        return self.env["customer_invoice_type"].create(
+            {
+                "name": "Customer Invoice Type %s" % suffix,
+                "code": "CITENR%s" % suffix,
+                "journal_id": journal.id,
+                "receivable_account_id": account.id,
+            }
+        )
+
     def test_onchange_receivable_journal_id_from_template(self):
         """Selecting payment_template_id fills receivable_journal_id from the template."""
         journal = self.env["account.journal"].search([("type", "=", "sale")], limit=1)
@@ -20,6 +41,9 @@ class TestSchoolEnrollmentWorkflow(YamlTransactionCase):
                 "name": "Template Receivable Journal OC",
                 "code": "PMTRJOC",
                 "journal_id": journal.id,
+                "customer_invoice_type_id": self._create_customer_invoice_type(
+                    "RJOC"
+                ).id,
             }
         )
         form = Form(self.env["school_enrollment"])
@@ -41,6 +65,9 @@ class TestSchoolEnrollmentWorkflow(YamlTransactionCase):
                 "name": "Template Receivable Account OC",
                 "code": "PMTRAOC",
                 "receivable_account_id": account.id,
+                "customer_invoice_type_id": self._create_customer_invoice_type(
+                    "RAOC"
+                ).id,
             }
         )
         form = Form(self.env["school_enrollment"])
@@ -64,6 +91,9 @@ class TestSchoolEnrollmentWorkflow(YamlTransactionCase):
                 "code": "PMTRRST",
                 "journal_id": journal.id,
                 "receivable_account_id": account.id,
+                "customer_invoice_type_id": self._create_customer_invoice_type(
+                    "RRST"
+                ).id,
             }
         )
         form = Form(self.env["school_enrollment"])

--- a/ssi_school/tests/test_school_enrollment_customer_invoice.py
+++ b/ssi_school/tests/test_school_enrollment_customer_invoice.py
@@ -1,0 +1,16 @@
+# Copyright 2026 OpenSynergy Indonesia
+# Copyright 2026 PT. Simetri Sinergi Indonesia
+# License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl).
+
+from odoo_yaml_test import YamlTransactionCase
+
+from odoo.tests import tagged
+
+
+@tagged("post_install", "-at_install")
+class TestSchoolEnrollmentCustomerInvoice(YamlTransactionCase):
+    """Customer invoice generated from enrollment payment terms."""
+
+    def test_enrollment_customer_invoice(self):
+        """Create, auto confirm, disconnect and delete the customer invoice."""
+        self.run_yaml_scenario("test_data_enrollment_customer_invoice.yaml")

--- a/ssi_school/tests/test_school_enrollment_payment_template.py
+++ b/ssi_school/tests/test_school_enrollment_payment_template.py
@@ -12,6 +12,27 @@ class TestSchoolEnrollmentPaymentTemplate(YamlTransactionCase):
     def test_enrollment_payment_template(self):
         self.run_yaml_scenario("test_data_enrollment_payment_template.yaml")
 
+    def _create_customer_invoice_type(self, suffix):
+        """Create the customer invoice type required by every template."""
+        journal = self.env["account.journal"].search([("type", "=", "sale")], limit=1)
+        receivable_type = self.env.ref("account.data_account_type_receivable")
+        account = self.env["account.account"].create(
+            {
+                "name": "Receivable %s" % suffix,
+                "code": "RCVPMT%s" % suffix,
+                "user_type_id": receivable_type.id,
+                "reconcile": True,
+            }
+        )
+        return self.env["customer_invoice_type"].create(
+            {
+                "name": "Customer Invoice Type %s" % suffix,
+                "code": "CITPMT%s" % suffix,
+                "journal_id": journal.id,
+                "receivable_account_id": account.id,
+            }
+        )
+
     def test_onchange_school_id_clears_grade(self):
         """Mengganti school_id harus mengosongkan grade_id."""
         grade_type = self.env["school_grade_type"].create(
@@ -66,7 +87,13 @@ class TestSchoolEnrollmentPaymentTemplate(YamlTransactionCase):
             }
         )
         template = self.env["school_enrollment_payment_template"].create(
-            {"name": "Template OC", "code": "PMTOC2"}
+            {
+                "name": "Template OC",
+                "code": "PMTOC2",
+                "customer_invoice_type_id": self._create_customer_invoice_type(
+                    "OC2"
+                ).id,
+            }
         )
         term = self.env["school_enrollment_payment_template.term"].create(
             {"name": "Term OC", "sequence": 10, "template_id": template.id}
@@ -98,7 +125,13 @@ class TestSchoolEnrollmentPaymentTemplate(YamlTransactionCase):
             }
         )
         template = self.env["school_enrollment_payment_template"].create(
-            {"name": "Template UOM OC", "code": "PMTOCUOM"}
+            {
+                "name": "Template UOM OC",
+                "code": "PMTOCUOM",
+                "customer_invoice_type_id": self._create_customer_invoice_type(
+                    "UOM"
+                ).id,
+            }
         )
         term = self.env["school_enrollment_payment_template.term"].create(
             {"name": "Term UOM OC", "sequence": 10, "template_id": template.id}
@@ -130,7 +163,13 @@ class TestSchoolEnrollmentPaymentTemplate(YamlTransactionCase):
             }
         )
         template = self.env["school_enrollment_payment_template"].create(
-            {"name": "Template ACC OC", "code": "PMTOCACC"}
+            {
+                "name": "Template ACC OC",
+                "code": "PMTOCACC",
+                "customer_invoice_type_id": self._create_customer_invoice_type(
+                    "ACC"
+                ).id,
+            }
         )
         term = self.env["school_enrollment_payment_template.term"].create(
             {"name": "Term ACC OC", "sequence": 10, "template_id": template.id}

--- a/ssi_school/tests/test_school_enrollment_restart_unlock.py
+++ b/ssi_school/tests/test_school_enrollment_restart_unlock.py
@@ -14,6 +14,7 @@ class TestSchoolEnrollmentRestartUnlock(YamlTransactionCase):
         self.run_yaml_scenario("test_data_enrollment_restart_unlock.yaml")
 
     def _create_base_data(self, suffix):
+        """Build the shared master data used by every scenario here."""
         account_type = self.env.ref("account.data_account_type_revenue")
         account = self.env["account.account"].create(
             {
@@ -78,6 +79,23 @@ class TestSchoolEnrollmentRestartUnlock(YamlTransactionCase):
             }
         )
         journal = self.env["account.journal"].search([("type", "=", "sale")], limit=1)
+        receivable_type = self.env.ref("account.data_account_type_receivable")
+        receivable_account = self.env["account.account"].create(
+            {
+                "name": "School Receivable %s" % suffix,
+                "code": "RSTUNLK%s1100" % suffix,
+                "user_type_id": receivable_type.id,
+                "reconcile": True,
+            }
+        )
+        customer_invoice_type = self.env["customer_invoice_type"].create(
+            {
+                "name": "Customer Invoice Type %s" % suffix,
+                "code": "CIT%s" % suffix,
+                "journal_id": journal.id,
+                "receivable_account_id": receivable_account.id,
+            }
+        )
         return {
             "account": account,
             "product": product,
@@ -87,9 +105,12 @@ class TestSchoolEnrollmentRestartUnlock(YamlTransactionCase):
             "grade": grade,
             "grade_class": grade_class,
             "journal": journal,
+            "receivable_account": receivable_account,
+            "customer_invoice_type": customer_invoice_type,
         }
 
     def _create_enrollment(self, base, name_suffix):
+        """Create an enrollment wired to the customer invoice fixtures."""
         contact = self.env["res.partner"].create(
             {"name": "Student Contact %s" % name_suffix}
         )
@@ -111,7 +132,10 @@ class TestSchoolEnrollmentRestartUnlock(YamlTransactionCase):
                 "grade_class_id": base["grade_class"].id,
                 "student_id": student.id,
                 "currency_id": self.env.company.currency_id.id,
+                "pricelist_id": self.env.ref("product.list0").id,
                 "receivable_journal_id": base["journal"].id,
+                "receivable_account_id": base["receivable_account"].id,
+                "customer_invoice_type_id": base["customer_invoice_type"].id,
             }
         )
 
@@ -199,7 +223,7 @@ class TestSchoolEnrollmentRestartUnlock(YamlTransactionCase):
 
         term.action_create_invoice()
         term.invalidate_cache()
-        self.assertTrue(term.invoice_id)
+        self.assertTrue(term.customer_invoice_id)
 
         enrollment.invalidate_cache()
         self.assertFalse(enrollment.cancel_ok)
@@ -210,7 +234,7 @@ class TestSchoolEnrollmentRestartUnlock(YamlTransactionCase):
 
         term.action_delete_invoice()
         term.invalidate_cache()
-        self.assertFalse(term.invoice_id)
+        self.assertFalse(term.customer_invoice_id)
 
         enrollment.invalidate_cache()
         self.assertTrue(enrollment.cancel_ok)

--- a/ssi_school/views/school_enrollment.xml
+++ b/ssi_school/views/school_enrollment.xml
@@ -228,7 +228,7 @@
                             <field name="amount_untaxed" />
                             <field name="amount_tax" />
                             <field name="amount_total" />
-                            <field name="invoice_id" />
+                            <field name="customer_invoice_id" />
                             <field name="state" />
                             <button
                                     name="action_create_invoice"
@@ -289,6 +289,8 @@
                     <group name="accounting_group" colspan="4" col="2">
                         <field name="receivable_journal_id" />
                         <field name="receivable_account_id" />
+                        <field name="customer_invoice_type_id" />
+                        <field name="auto_confirm_customer_invoice" />
                     </group>
                 </page>
             </xpath>

--- a/ssi_school/views/school_enrollment_payment_template_views.xml
+++ b/ssi_school/views/school_enrollment_payment_template_views.xml
@@ -77,6 +77,8 @@
                 <field name="is_default" />
                 <field name="journal_id" />
                 <field name="receivable_account_id" />
+                <field name="customer_invoice_type_id" />
+                <field name="auto_confirm_customer_invoice" />
             </xpath>
             <xpath expr="//page[1]" position="before">
                 <page name="payment_terms" string="Payment Terms">

--- a/ssi_school/views/school_enrollment_payment_term_views.xml
+++ b/ssi_school/views/school_enrollment_payment_term_views.xml
@@ -44,7 +44,7 @@
             <field name="amount_untaxed" />
             <field name="amount_tax" />
             <field name="amount_total" />
-            <field name="invoice_id" />
+            <field name="customer_invoice_id" />
             <field name="state" />
             <button
                     name="action_create_invoice"

--- a/ssi_school/wizards/school_enrollment_copy_payment_term.py
+++ b/ssi_school/wizards/school_enrollment_copy_payment_term.py
@@ -90,10 +90,10 @@ Solution: Select at least one draft enrollment from the list view before running
                 new_term = term.copy(
                     {
                         "enrollment_id": target.id,
-                        "invoice_id": False,
+                        "customer_invoice_id": False,
                     }
                 )
-                new_term.detail_ids.write({"invoice_line_id": False})
+                new_term.detail_ids.write({"customer_invoice_line_id": False})
 
     def _check_target_enrollments(self):
         self.ensure_one()

--- a/ssi_school/wizards/school_enrollment_payment_term_duplicate.py
+++ b/ssi_school/wizards/school_enrollment_payment_term_duplicate.py
@@ -67,7 +67,7 @@ class SchoolEnrollmentPaymentTermWizardDuplicate(models.TransientModel):
     def _duplicate_term(self):
         self.ensure_one()
         new_term = self.term_id.copy(self._prepare_duplicate_defaults())
-        new_term.detail_ids.write({"invoice_line_id": False})
+        new_term.detail_ids.write({"customer_invoice_line_id": False})
         return {"type": "ir.actions.act_window_close"}
 
     def _prepare_duplicate_defaults(self):
@@ -77,5 +77,5 @@ class SchoolEnrollmentPaymentTermWizardDuplicate(models.TransientModel):
             "sequence": self.sequence,
             "date_invoice": self.date_invoice,
             "date_due": self.date_due,
-            "invoice_id": False,
+            "customer_invoice_id": False,
         }

--- a/ssi_school_operating_unit/__manifest__.py
+++ b/ssi_school_operating_unit/__manifest__.py
@@ -18,6 +18,7 @@
         "ssi_school",
         "ssi_operating_unit_mixin",
         "ssi_financial_accounting_operating_unit",
+        "ssi_customer_invoice_operating_unit",
     ],
     "data": [
         # Security - transactional (school_enrollment)

--- a/ssi_school_operating_unit/models/school_enrollment_payment_term.py
+++ b/ssi_school_operating_unit/models/school_enrollment_payment_term.py
@@ -8,13 +8,18 @@ from odoo import models
 class SchoolEnrollmentPaymentTerm(models.Model):
     """
     Extends School Enrollment Payment Term to propagate
-    operating_unit_id from the parent enrollment to the generated invoice.
+    operating_unit_id from the parent enrollment to the generated
+    customer invoice.
     """
 
     _name = "school_enrollment_payment_term"
     _inherit = "school_enrollment_payment_term"
 
     def _prepare_invoice_data(self):
+        """Add the enrollment operating unit to the customer invoice.
+
+        :return: dict of ``customer_invoice`` values
+        """
         res = super()._prepare_invoice_data()
         res["operating_unit_id"] = self.enrollment_id.operating_unit_id.id
         return res


### PR DESCRIPTION
Mengganti target invoice pada `school_enrollment_payment_term` dari `account.move` menjadi dokumen transaksional `customer_invoice` (modul `ssi_customer_invoice`), sehingga tagihan sekolah lahir dengan nomor dokumen sendiri, multiple approval, dan policy.

## Perubahan

### `ssi_school`

* Dependensi manifest: tambah `ssi_customer_invoice`.
* Rename field (disetujui pada issue):
  * `school_enrollment_payment_term.invoice_id` → `customer_invoice_id` (comodel `customer_invoice`)
  * `school_enrollment_payment_term_detail.invoice_line_id` → `customer_invoice_line_id` (comodel `customer_invoice.line`)
  * `school_enrollment_fee_analysis.invoice_id` → `customer_invoice_id` (kolom SQL view ikut)
* Field konfigurasi baru `customer_invoice_type_id` (required) dan `auto_confirm_customer_invoice` pada `school_enrollment_payment_template`, dengan pasangannya di `school_enrollment` beserta onchange terpisah per field.
* `_prepare_invoice_data`, `_prepare_invoice_line`, `_create_invoice`, `_delete_invoice` ditulis ulang; nama method dipertahankan agar glue Operating Unit tetap bekerja.
* `_delete_invoice` menolak dokumen non-draft dengan `UserError` terstruktur dan mengarahkan ke `action_disconnect_invoice`.
* Policy template cancel, wizard copy & duplicate payment term, dan view menyesuaikan nama field baru.

### `ssi_school_operating_unit`

* Tambah dependensi `ssi_customer_invoice_operating_unit`.

## Uji

* Skenario uji existing diperbarui ke nama field baru (rename, bukan pelemahan) plus fixture `customer_invoice_type` yang kini wajib.
* Skenario uji baru `test_data_enrollment_customer_invoice.yaml` (7 skenario): create, auto confirm, disconnect, delete draft, tolak delete non-draft, tolak cancel enrollment ber-invoice, dan onchange payment template.

Closes #175