### PR TITLE
[UPD] Ganti invoice admission payment term ke customer_invoice

### DIFF
--- a/ssi_school_admission/__manifest__.py
+++ b/ssi_school_admission/__manifest__.py
@@ -14,6 +14,7 @@
     "installable": True,
     "depends": [
         "ssi_school",
+        "ssi_customer_invoice",
         "ssi_master_data_mixin",
         "ssi_transaction_confirm_mixin",
         "ssi_transaction_open_mixin",
@@ -81,6 +82,7 @@
         "demo/account_account_demo.xml",
         "demo/account_journal_demo.xml",
         "demo/product_product_demo.xml",
+        "demo/customer_invoice_type_demo.xml",
         "demo/school_admission_fee_template_demo.xml",
         "demo/school_admission_payment_template_demo.xml",
     ],

--- a/ssi_school_admission/demo/customer_invoice_type_demo.xml
+++ b/ssi_school_admission/demo/customer_invoice_type_demo.xml
@@ -1,0 +1,12 @@
+<?xml version="1.0" encoding="utf-8" ?>
+<!-- Copyright 2026 OpenSynergy Indonesia
+     Copyright 2026 PT. Simetri Sinergi Indonesia
+     License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl). -->
+<odoo>
+    <record id="demo_customer_invoice_type" model="customer_invoice_type">
+        <field name="name">School Admission Billing (demo)</field>
+        <field name="code">XSAP-CIT001</field>
+        <field name="journal_id" ref="demo_journal_sale" />
+        <field name="receivable_account_id" ref="demo_account_receivable" />
+    </record>
+</odoo>

--- a/ssi_school_admission/demo/school_admission_payment_template_demo.xml
+++ b/ssi_school_admission/demo/school_admission_payment_template_demo.xml
@@ -13,6 +13,7 @@
         <field name="grade_id" ref="ssi_school.school_grade1_type" />
         <field name="receivable_journal_id" ref="demo_journal_sale" />
         <field name="receivable_account_id" ref="demo_account_receivable" />
+        <field name="customer_invoice_type_id" ref="demo_customer_invoice_type" />
         <field
             name="term_ids"
             eval="[
@@ -69,6 +70,7 @@
         <field name="grade_id" ref="ssi_school.school_grade2_type" />
         <field name="receivable_journal_id" ref="demo_journal_sale" />
         <field name="receivable_account_id" ref="demo_account_receivable" />
+        <field name="customer_invoice_type_id" ref="demo_customer_invoice_type" />
         <field
             name="term_ids"
             eval="[

--- a/ssi_school_admission/models/school_admission.py
+++ b/ssi_school_admission/models/school_admission.py
@@ -242,6 +242,34 @@ class SchoolAdmission(models.Model):
         },
         help=("The account used to record receivables " "for admission payments."),
     )
+    customer_invoice_type_id = fields.Many2one(
+        string="Customer Invoice Type",
+        comodel_name="customer_invoice_type",
+        readonly=True,
+        states={
+            "draft": [
+                ("readonly", False),
+            ],
+        },
+        help=(
+            "The customer invoice type used for every customer invoice "
+            "generated from the payment terms of this admission."
+        ),
+    )
+    auto_confirm_customer_invoice = fields.Boolean(
+        string="Auto Confirm Customer Invoice",
+        readonly=True,
+        states={
+            "draft": [
+                ("readonly", False),
+            ],
+        },
+        help=(
+            "If enabled, the customer invoice created from a payment "
+            "term of this admission is immediately confirmed instead "
+            "of being left in draft."
+        ),
+    )
     school_student_id = fields.Many2one(
         string="School Student",
         comodel_name="school_student",
@@ -330,6 +358,26 @@ class SchoolAdmission(models.Model):
         self.receivable_account_id = False
         if self.payment_template_id:
             self.receivable_account_id = self.payment_template_id.receivable_account_id
+
+    @api.onchange(
+        "payment_template_id",
+    )
+    def onchange_customer_invoice_type_id(self):
+        self.customer_invoice_type_id = False
+        if self.payment_template_id:
+            self.customer_invoice_type_id = (
+                self.payment_template_id.customer_invoice_type_id
+            )
+
+    @api.onchange(
+        "payment_template_id",
+    )
+    def onchange_auto_confirm_customer_invoice(self):
+        self.auto_confirm_customer_invoice = False
+        if self.payment_template_id:
+            self.auto_confirm_customer_invoice = (
+                self.payment_template_id.auto_confirm_customer_invoice
+            )
 
     def action_compute_payment(self):
         for record in self.sudo():
@@ -512,7 +560,7 @@ Solution: Check create due invoice policy prerequisite
     @ssi_decorator.pre_cancel_action()
     def _10_check_payment_term_invoice(self):
         self.ensure_one()
-        invoiced_terms = self.payment_term_ids.filtered(lambda r: r.invoice_id)
+        invoiced_terms = self.payment_term_ids.filtered(lambda r: r.customer_invoice_id)
         if invoiced_terms:
             error_message = (
                 _(

--- a/ssi_school_admission/models/school_admission_payment_template.py
+++ b/ssi_school_admission/models/school_admission_payment_template.py
@@ -61,6 +61,26 @@ class SchoolAdmissionPaymentTemplate(
             "when this template is selected."
         ),
     )
+    customer_invoice_type_id = fields.Many2one(
+        string="Customer Invoice Type",
+        comodel_name="customer_invoice_type",
+        required=True,
+        ondelete="restrict",
+        help=(
+            "Customer invoice type used for every customer invoice "
+            "generated from the payment terms of an admission that "
+            "uses this template."
+        ),
+    )
+    auto_confirm_customer_invoice = fields.Boolean(
+        string="Auto Confirm Customer Invoice",
+        default=False,
+        help=(
+            "If enabled, the customer invoice created from a payment "
+            "term is immediately confirmed instead of being left in "
+            "draft."
+        ),
+    )
     term_ids = fields.One2many(
         string="Payment Terms",
         comodel_name="school_admission_payment_template.term",

--- a/ssi_school_admission/models/school_admission_payment_term.py
+++ b/ssi_school_admission/models/school_admission_payment_term.py
@@ -5,14 +5,20 @@
 from odoo import _, api, fields, models
 from odoo.exceptions import UserError
 
-ADDENDUM_LOCK_ALLOWED_FIELDS = {"invoice_id", "manually_control", "locked", "sequence"}
+ADDENDUM_LOCK_ALLOWED_FIELDS = {
+    "customer_invoice_id",
+    "manually_control",
+    "locked",
+    "sequence",
+}
 
 
 class SchoolAdmissionPaymentTerm(models.Model):
     """
     Represents a payment installment term within a school admission
-    record, tracking invoice status, amounts, and due dates for
-    one payment period.
+    record, tracking customer invoice status, amounts, and due dates
+    for one payment period. Each term can generate one customer invoice
+    (customer_invoice_id) via action_create_invoice.
     """
 
     _name = "school_admission_payment_term"
@@ -20,7 +26,7 @@ class SchoolAdmissionPaymentTerm(models.Model):
     _order = "sequence, id"
 
     @api.depends(
-        "invoice_id",
+        "customer_invoice_id",
         "admission_id.state",
         "manually_control",
     )
@@ -29,7 +35,7 @@ class SchoolAdmissionPaymentTerm(models.Model):
             if record.admission_id.state in ["draft", "confirm"]:
                 state = "draft"
             elif record.admission_id.state in ["open", "done"]:
-                if record.invoice_id:
+                if record.customer_invoice_id:
                     state = "invoiced"
                 elif record.manually_control:
                     state = "manual"
@@ -123,12 +129,12 @@ class SchoolAdmissionPaymentTerm(models.Model):
         currency_field="currency_id",
         help="The total amount including taxes for this term.",
     )
-    invoice_id = fields.Many2one(
-        string="# Invoice",
-        comodel_name="account.move",
+    customer_invoice_id = fields.Many2one(
+        string="# Customer Invoice",
+        comodel_name="customer_invoice",
         readonly=True,
         ondelete="restrict",
-        help="The invoice generated for this payment term, if any.",
+        help="The customer invoice generated for this payment term, if any.",
     )
     date_invoice = fields.Date(
         string="Estimated Invoice Date",
@@ -290,44 +296,95 @@ Solution: Locked payment terms are permanent; create a new one via addendum inst
         self.write({"manually_control": False})
 
     def _create_invoice(self):
+        """Create the ``customer_invoice`` document for this term.
+
+        Creates the header first, then one ``customer_invoice.line`` per
+        detail line, writing the resulting line back onto the detail it
+        originates from, and finally links the document to this term.
+        Taxes are not computed here: ``customer_invoice`` recomputes them
+        itself on pre-confirm. When the admission has
+        ``auto_confirm_customer_invoice`` enabled, the new document is
+        confirmed right away.
+
+        :return: None
+        """
         self.ensure_one()
-        invoice = self.env["account.move"].create(self._prepare_invoice_data())
-        self.write({"invoice_id": invoice.id})
+        line_model = self.env["customer_invoice.line"]
+        invoice = self.env["customer_invoice"].create(self._prepare_invoice_data())
+        for detail in self.detail_ids:
+            # pylint: disable=protected-access
+            line_data = detail._prepare_invoice_line()
+            line_data["customer_invoice_id"] = invoice.id
+            line = line_model.create(line_data)
+            detail.write({"customer_invoice_line_id": line.id})
+        self.write({"customer_invoice_id": invoice.id})
+        if self.admission_id.auto_confirm_customer_invoice:
+            invoice.action_confirm()
 
     def _disconnect_invoice(self):
+        """Detach the customer invoice from this term without deleting it.
+
+        Only ``customer_invoice_id`` is cleared, so the term falls back to
+        the uninvoiced state while the ``customer_invoice`` document itself
+        is kept.
+
+        :return: None
+        """
         self.ensure_one()
-        self.write({"invoice_id": False})
+        self.write({"customer_invoice_id": False})
 
     def _prepare_invoice_data(self):
+        """Build the ``customer_invoice`` header values for this term.
+
+        Extension point: override in a glue module (Operating Unit, for
+        instance) to add extra header values without touching
+        ``_create_invoice``. Detail lines are deliberately excluded --
+        they are created one by one by ``_create_invoice`` so that each
+        line can be written back to its originating detail.
+
+        :return: dict of ``customer_invoice`` values
+        """
         self.ensure_one()
         admission = self.admission_id
-        partner = admission.student_id
-        journal = admission.receivable_journal_id
-        lines = []
-        for detail in self.detail_ids:
-            lines += [
-                (0, 0, detail._prepare_invoice_line())
-            ]  # pylint: disable=protected-access
+        date = self.date_invoice or fields.Date.today()
         return {
-            "date": fields.Date.today(),
-            "ref": admission.name,
-            "move_type": "out_invoice",
-            "journal_id": journal.id,
-            "partner_id": partner.id,
+            "type_id": admission.customer_invoice_type_id.id,
+            "partner_id": admission.student_id.id,
             "currency_id": admission.currency_id.id,
-            "invoice_user_id": False,
-            "invoice_date": self.date_invoice or fields.Date.today(),
-            "invoice_date_due": self.date_due
-            or self.date_invoice
-            or fields.Date.today(),
-            "invoice_origin": admission.name,
-            "invoice_payment_term_id": False,
-            "invoice_line_ids": lines,
+            "pricelist_id": admission.pricelist_id.id,
+            "journal_id": admission.receivable_journal_id.id,
+            "receivable_account_id": admission.receivable_account_id.id,
+            "date": date,
+            "date_due": self.date_due or date,
+            "customer_document_number": admission.name,
         }
 
     def _delete_invoice(self):
+        """Delete the customer invoice document created from this term.
+
+        Only a document still in ``draft`` may be deleted. Every detail
+        line is unlinked from its ``customer_invoice.line`` first, then the
+        term is detached, and finally the document is deleted (its lines
+        are removed by cascade).
+
+        :raises UserError: when the customer invoice is no longer draft
+        :return: None
+        """
         self.ensure_one()
-        invoice = self.invoice_id
-        self.detail_ids.write({"invoice_line_id": False})
-        self.write({"invoice_id": False})
+        invoice = self.customer_invoice_id
+        if invoice.state != "draft":
+            error_message = (
+                _(
+                    """
+Context: Delete customer invoice of payment term
+Database ID: %s
+Problem: Customer invoice '%s' is not draft anymore and cannot be deleted
+Solution: Use Disconnect Invoice to detach it from the payment term instead
+"""
+                )
+                % (self.id, invoice.display_name)
+            )
+            raise UserError(error_message)
+        self.detail_ids.write({"customer_invoice_line_id": False})
+        self.write({"customer_invoice_id": False})
         invoice.unlink()

--- a/ssi_school_admission/models/school_admission_payment_term_detail.py
+++ b/ssi_school_admission/models/school_admission_payment_term_detail.py
@@ -5,14 +5,14 @@
 from odoo import _, api, fields, models
 from odoo.exceptions import UserError
 
-ADDENDUM_LOCK_ALLOWED_FIELDS = {"invoice_line_id", "locked", "sequence"}
+ADDENDUM_LOCK_ALLOWED_FIELDS = {"customer_invoice_line_id", "locked", "sequence"}
 
 
 class SchoolAdmissionPaymentTermDetail(models.Model):
     """
     Represents a single fee line detail within a school admission
     payment term, specifying the product, amount, and associated
-    journal entry line for one payment item.
+    customer invoice line for one payment item.
     """
 
     _name = "school_admission_payment_term_detail"
@@ -45,12 +45,15 @@ class SchoolAdmissionPaymentTermDetail(models.Model):
         store=True,
         help="The pricelist derived from the parent admission record.",
     )
-    invoice_line_id = fields.Many2one(
-        string="Invoice Line",
-        comodel_name="account.move.line",
+    customer_invoice_line_id = fields.Many2one(
+        string="Customer Invoice Line",
+        comodel_name="customer_invoice.line",
         readonly=True,
         ondelete="restrict",
-        help=("The invoice line linked to this detail " "after the term is invoiced."),
+        help=(
+            "The customer invoice line linked to this detail "
+            "after the term is invoiced."
+        ),
     )
     allowed_product_ids = fields.Many2many(
         comodel_name="product.product",
@@ -159,6 +162,16 @@ Solution: Locked detail lines are permanent; create a new one via the addendum m
         return result
 
     def _prepare_invoice_line(self):
+        """Build the ``customer_invoice.line`` values for this fee line.
+
+        Extension point: override in a glue module to add extra line
+        values. The link to the parent document
+        (``customer_invoice_id``) is intentionally left out -- it is
+        added by ``school_admission_payment_term._create_invoice``,
+        which owns the newly created header.
+
+        :return: dict of ``customer_invoice.line`` values
+        """
         self.ensure_one()
         aa = (
             self.analytic_account_id and self.analytic_account_id.id or False
@@ -167,8 +180,8 @@ Solution: Locked detail lines are permanent; create a new one via the addendum m
             "product_id": self.product_id.id,
             "name": self.name,
             "account_id": self.account_id.id,
-            "quantity": self.uom_quantity,
-            "product_uom_id": self.uom_id.id,
+            "uom_id": self.uom_id.id,
+            "uom_quantity": self.uom_quantity,
             "price_unit": self.price_unit,
             "tax_ids": [(6, 0, self.tax_ids.ids)],
             "analytic_account_id": aa or False,

--- a/ssi_school_admission/policy_template/school_admission.xml
+++ b/ssi_school_admission/policy_template/school_admission.xml
@@ -128,7 +128,7 @@
     <field name="restrict_additional" eval="1" />
     <field name="additional_python_code">result = True
 for term in document.payment_term_ids:
-    if term.invoice_id:
+    if term.customer_invoice_id:
         result = False
         break</field>
 </record>

--- a/ssi_school_admission/tests/__init__.py
+++ b/ssi_school_admission/tests/__init__.py
@@ -13,6 +13,7 @@ from . import (  # noqa: F401
     test_school_admission_payment_term_duplicate,
     test_school_admission_copy_payment_term,
     test_school_admission_create_due_invoice,
+    test_school_admission_customer_invoice,
     test_school_admission_payment_product_configurator,
     test_school_admission_product_summary,
     test_school_admission_test,

--- a/ssi_school_admission/tests/test_data_admission.yaml
+++ b/ssi_school_admission/tests/test_data_admission.yaml
@@ -1,6 +1,38 @@
 scenarios:
   - name: "Admission Full Workflow: Confirm Approve Done With Payment Template"
     steps:
+      - step: "Setup - get customer invoice journal"
+        action: "search"
+        model: "account.journal"
+        domain: [["type", "=", "sale"]]
+        save_as: "ci_journal"
+        limit: 1
+
+      - step: "Setup - get receivable account type"
+        action: "ref"
+        xml_id: "account.data_account_type_receivable"
+        save_as: "ci_account_type"
+
+      - step: "Setup - create customer invoice receivable account"
+        action: "create"
+        model: "account.account"
+        save_as: "ci_account"
+        values:
+          name: "Customer Invoice Receivable ADMCI01"
+          code: "ADMCI01"
+          user_type_id: "REC: ci_account_type.id"
+          reconcile: true
+
+      - step: "Setup - create customer invoice type"
+        action: "create"
+        model: "customer_invoice_type"
+        save_as: "ci_type"
+        values:
+          name: "Customer Invoice Type ADMCI01"
+          code: "ADMCI01"
+          journal_id: "REC: ci_journal.id"
+          receivable_account_id: "REC: ci_account.id"
+
       - step: "Setup - get receivable journal"
         action: "search"
         model: "account.journal"
@@ -103,6 +135,7 @@ scenarios:
         model: "school_admission_payment_template"
         save_as: "payment_template"
         values:
+          customer_invoice_type_id: "REC: ci_type.id"
           name: "Admission Payment Template Test ADM1"
           code: "ADMPMT001"
           school_id: "EVAL: registry['school'].id"

--- a/ssi_school_admission/tests/test_data_admission_addendum.yaml
+++ b/ssi_school_admission/tests/test_data_admission_addendum.yaml
@@ -1,6 +1,38 @@
 scenarios:
   - name: "Addendum - Existing Payment Term Is Locked After Admission Opens"
     steps:
+      - step: "Setup - get customer invoice journal"
+        action: "search"
+        model: "account.journal"
+        domain: [["type", "=", "sale"]]
+        save_as: "ci_journal"
+        limit: 1
+
+      - step: "Setup - get receivable account type"
+        action: "ref"
+        xml_id: "account.data_account_type_receivable"
+        save_as: "ci_account_type"
+
+      - step: "Setup - create customer invoice receivable account"
+        action: "create"
+        model: "account.account"
+        save_as: "ci_account"
+        values:
+          name: "Customer Invoice Receivable ADMCI02"
+          code: "ADMCI02"
+          user_type_id: "REC: ci_account_type.id"
+          reconcile: true
+
+      - step: "Setup - create customer invoice type"
+        action: "create"
+        model: "customer_invoice_type"
+        save_as: "ci_type"
+        values:
+          name: "Customer Invoice Type ADMCI02"
+          code: "ADMCI02"
+          journal_id: "REC: ci_journal.id"
+          receivable_account_id: "REC: ci_account.id"
+
       - step: "Setup - get sale journal"
         action: "search"
         model: "account.journal"
@@ -101,6 +133,7 @@ scenarios:
         model: "school_admission_payment_template"
         save_as: "payment_template"
         values:
+          customer_invoice_type_id: "REC: ci_type.id"
           name: "Admission Payment Template ADADDEN1"
           code: "ADADDEN1001"
           school_id: "EVAL: registry['school'].id"

--- a/ssi_school_admission/tests/test_data_admission_copy_payment_term.yaml
+++ b/ssi_school_admission/tests/test_data_admission_copy_payment_term.yaml
@@ -184,7 +184,7 @@ scenarios:
           sequence:
             type: "value"
             expected: 10
-          invoice_id:
+          customer_invoice_id:
             type: "value"
             operator: "is_falsy"
           detail_ids:
@@ -210,7 +210,7 @@ scenarios:
           price_unit:
             type: "value"
             expected: 500000.0
-          invoice_line_id:
+          customer_invoice_line_id:
             type: "value"
             operator: "is_falsy"
 

--- a/ssi_school_admission/tests/test_data_admission_create_due_invoice.yaml
+++ b/ssi_school_admission/tests/test_data_admission_create_due_invoice.yaml
@@ -1,6 +1,38 @@
 scenarios:
   - name: "Create Due Invoice - No Range Invoices Only Due Terms"
     steps:
+      - step: "Setup - get customer invoice journal"
+        action: "search"
+        model: "account.journal"
+        domain: [["type", "=", "sale"]]
+        save_as: "ci_journal"
+        limit: 1
+
+      - step: "Setup - get receivable account type"
+        action: "ref"
+        xml_id: "account.data_account_type_receivable"
+        save_as: "ci_account_type"
+
+      - step: "Setup - create customer invoice receivable account"
+        action: "create"
+        model: "account.account"
+        save_as: "ci_account"
+        values:
+          name: "Customer Invoice Receivable ADMCI17"
+          code: "ADMCI17"
+          user_type_id: "REC: ci_account_type.id"
+          reconcile: true
+
+      - step: "Setup - create customer invoice type"
+        action: "create"
+        model: "customer_invoice_type"
+        save_as: "ci_type"
+        values:
+          name: "Customer Invoice Type ADMCI17"
+          code: "ADMCI17"
+          journal_id: "REC: ci_journal.id"
+          receivable_account_id: "REC: ci_account.id"
+
       - step: "Setup - get account type ref"
         action: "ref"
         xml_id: "account.data_account_type_revenue"
@@ -93,6 +125,9 @@ scenarios:
         model: "school_admission"
         save_as: "admission"
         values:
+          customer_invoice_type_id: "REC: ci_type.id"
+          receivable_account_id: "REC: ci_account.id"
+          pricelist_id: "REF: product.list0"
           date: "2024-07-01"
           academic_year_id: "REC: academic_year.id"
           academic_term_id: "REC: academic_term.id"
@@ -235,7 +270,7 @@ scenarios:
           state:
             type: "value"
             expected: "invoiced"
-          invoice_id:
+          customer_invoice_id:
             type: "value"
             operator: "is_truthy"
 
@@ -246,7 +281,7 @@ scenarios:
           state:
             type: "value"
             expected: "invoiced"
-          invoice_id:
+          customer_invoice_id:
             type: "value"
             operator: "is_truthy"
 
@@ -257,7 +292,7 @@ scenarios:
           state:
             type: "value"
             expected: "uninvoiced"
-          invoice_id:
+          customer_invoice_id:
             type: "value"
             operator: "is_falsy"
 
@@ -268,7 +303,7 @@ scenarios:
           state:
             type: "value"
             expected: "manual"
-          invoice_id:
+          customer_invoice_id:
             type: "value"
             operator: "is_falsy"
 
@@ -279,12 +314,44 @@ scenarios:
           state:
             type: "value"
             expected: "uninvoiced"
-          invoice_id:
+          customer_invoice_id:
             type: "value"
             operator: "is_falsy"
 
   - name: "Create Due Invoice - Future Date End Includes Term C"
     steps:
+      - step: "Setup - get customer invoice journal"
+        action: "search"
+        model: "account.journal"
+        domain: [["type", "=", "sale"]]
+        save_as: "ci_journal"
+        limit: 1
+
+      - step: "Setup - get receivable account type"
+        action: "ref"
+        xml_id: "account.data_account_type_receivable"
+        save_as: "ci_account_type"
+
+      - step: "Setup - create customer invoice receivable account"
+        action: "create"
+        model: "account.account"
+        save_as: "ci_account"
+        values:
+          name: "Customer Invoice Receivable ADMCI18"
+          code: "ADMCI18"
+          user_type_id: "REC: ci_account_type.id"
+          reconcile: true
+
+      - step: "Setup - create customer invoice type"
+        action: "create"
+        model: "customer_invoice_type"
+        save_as: "ci_type"
+        values:
+          name: "Customer Invoice Type ADMCI18"
+          code: "ADMCI18"
+          journal_id: "REC: ci_journal.id"
+          receivable_account_id: "REC: ci_account.id"
+
       - step: "Setup - get account type ref"
         action: "ref"
         xml_id: "account.data_account_type_revenue"
@@ -377,6 +444,9 @@ scenarios:
         model: "school_admission"
         save_as: "admission"
         values:
+          customer_invoice_type_id: "REC: ci_type.id"
+          receivable_account_id: "REC: ci_account.id"
+          pricelist_id: "REF: product.list0"
           date: "2024-07-01"
           academic_year_id: "REC: academic_year.id"
           academic_term_id: "REC: academic_term.id"
@@ -523,7 +593,7 @@ scenarios:
           state:
             type: "value"
             expected: "invoiced"
-          invoice_id:
+          customer_invoice_id:
             type: "value"
             operator: "is_truthy"
 
@@ -545,6 +615,38 @@ scenarios:
 
   - name: "Create Due Invoice - Date Start Only Excludes Past And Future Terms"
     steps:
+      - step: "Setup - get customer invoice journal"
+        action: "search"
+        model: "account.journal"
+        domain: [["type", "=", "sale"]]
+        save_as: "ci_journal"
+        limit: 1
+
+      - step: "Setup - get receivable account type"
+        action: "ref"
+        xml_id: "account.data_account_type_receivable"
+        save_as: "ci_account_type"
+
+      - step: "Setup - create customer invoice receivable account"
+        action: "create"
+        model: "account.account"
+        save_as: "ci_account"
+        values:
+          name: "Customer Invoice Receivable ADMCI19"
+          code: "ADMCI19"
+          user_type_id: "REC: ci_account_type.id"
+          reconcile: true
+
+      - step: "Setup - create customer invoice type"
+        action: "create"
+        model: "customer_invoice_type"
+        save_as: "ci_type"
+        values:
+          name: "Customer Invoice Type ADMCI19"
+          code: "ADMCI19"
+          journal_id: "REC: ci_journal.id"
+          receivable_account_id: "REC: ci_account.id"
+
       - step: "Setup - get account type ref"
         action: "ref"
         xml_id: "account.data_account_type_revenue"
@@ -637,6 +739,9 @@ scenarios:
         model: "school_admission"
         save_as: "admission"
         values:
+          customer_invoice_type_id: "REC: ci_type.id"
+          receivable_account_id: "REC: ci_account.id"
+          pricelist_id: "REF: product.list0"
           date: "2024-07-01"
           academic_year_id: "REC: academic_year.id"
           academic_term_id: "REC: academic_term.id"
@@ -775,7 +880,7 @@ scenarios:
           state:
             type: "value"
             expected: "invoiced"
-          invoice_id:
+          customer_invoice_id:
             type: "value"
             operator: "is_truthy"
 
@@ -805,6 +910,38 @@ scenarios:
 
   - name: "Create Due Invoice - Both Dates Set Narrows To Term A Only"
     steps:
+      - step: "Setup - get customer invoice journal"
+        action: "search"
+        model: "account.journal"
+        domain: [["type", "=", "sale"]]
+        save_as: "ci_journal"
+        limit: 1
+
+      - step: "Setup - get receivable account type"
+        action: "ref"
+        xml_id: "account.data_account_type_receivable"
+        save_as: "ci_account_type"
+
+      - step: "Setup - create customer invoice receivable account"
+        action: "create"
+        model: "account.account"
+        save_as: "ci_account"
+        values:
+          name: "Customer Invoice Receivable ADMCI20"
+          code: "ADMCI20"
+          user_type_id: "REC: ci_account_type.id"
+          reconcile: true
+
+      - step: "Setup - create customer invoice type"
+        action: "create"
+        model: "customer_invoice_type"
+        save_as: "ci_type"
+        values:
+          name: "Customer Invoice Type ADMCI20"
+          code: "ADMCI20"
+          journal_id: "REC: ci_journal.id"
+          receivable_account_id: "REC: ci_account.id"
+
       - step: "Setup - get account type ref"
         action: "ref"
         xml_id: "account.data_account_type_revenue"
@@ -897,6 +1034,9 @@ scenarios:
         model: "school_admission"
         save_as: "admission"
         values:
+          customer_invoice_type_id: "REC: ci_type.id"
+          receivable_account_id: "REC: ci_account.id"
+          pricelist_id: "REF: product.list0"
           date: "2024-07-01"
           academic_year_id: "REC: academic_year.id"
           academic_term_id: "REC: academic_term.id"
@@ -1028,7 +1168,7 @@ scenarios:
           state:
             type: "value"
             expected: "invoiced"
-          invoice_id:
+          customer_invoice_id:
             type: "value"
             operator: "is_truthy"
 
@@ -1066,6 +1206,38 @@ scenarios:
 
   - name: "Create Due Invoice - Idempotent On Repeated Run"
     steps:
+      - step: "Setup - get customer invoice journal"
+        action: "search"
+        model: "account.journal"
+        domain: [["type", "=", "sale"]]
+        save_as: "ci_journal"
+        limit: 1
+
+      - step: "Setup - get receivable account type"
+        action: "ref"
+        xml_id: "account.data_account_type_receivable"
+        save_as: "ci_account_type"
+
+      - step: "Setup - create customer invoice receivable account"
+        action: "create"
+        model: "account.account"
+        save_as: "ci_account"
+        values:
+          name: "Customer Invoice Receivable ADMCI21"
+          code: "ADMCI21"
+          user_type_id: "REC: ci_account_type.id"
+          reconcile: true
+
+      - step: "Setup - create customer invoice type"
+        action: "create"
+        model: "customer_invoice_type"
+        save_as: "ci_type"
+        values:
+          name: "Customer Invoice Type ADMCI21"
+          code: "ADMCI21"
+          journal_id: "REC: ci_journal.id"
+          receivable_account_id: "REC: ci_account.id"
+
       - step: "Setup - get account type ref"
         action: "ref"
         xml_id: "account.data_account_type_revenue"
@@ -1158,6 +1330,9 @@ scenarios:
         model: "school_admission"
         save_as: "admission"
         values:
+          customer_invoice_type_id: "REC: ci_type.id"
+          receivable_account_id: "REC: ci_account.id"
+          pricelist_id: "REF: product.list0"
           date: "2024-07-01"
           academic_year_id: "REC: academic_year.id"
           academic_term_id: "REC: academic_term.id"
@@ -1243,8 +1418,8 @@ scenarios:
 
       - step: "Assert two invoices exist after the first run"
         action: "search"
-        model: "account.move"
-        domain: [["invoice_origin", "=", "REC: admission.name"]]
+        model: "customer_invoice"
+        domain: [["customer_document_number", "=", "REC: admission.name"]]
         save_as: "invoices_after_run1"
         expect_count: 2
 
@@ -1255,8 +1430,8 @@ scenarios:
 
       - step: "Assert invoice count is unchanged after the second run"
         action: "search"
-        model: "account.move"
-        domain: [["invoice_origin", "=", "REC: admission.name"]]
+        model: "customer_invoice"
+        domain: [["customer_document_number", "=", "REC: admission.name"]]
         save_as: "invoices_after_run2"
         expect_count: 2
 
@@ -1267,7 +1442,7 @@ scenarios:
           state:
             type: "value"
             expected: "invoiced"
-          invoice_id:
+          customer_invoice_id:
             type: "value"
             operator: "is_truthy"
 
@@ -1278,12 +1453,44 @@ scenarios:
           state:
             type: "value"
             expected: "invoiced"
-          invoice_id:
+          customer_invoice_id:
             type: "value"
             operator: "is_truthy"
 
   - name: "Create Due Invoice - Blocked When Selection Includes A Non-Open Admission"
     steps:
+      - step: "Setup - get customer invoice journal"
+        action: "search"
+        model: "account.journal"
+        domain: [["type", "=", "sale"]]
+        save_as: "ci_journal"
+        limit: 1
+
+      - step: "Setup - get receivable account type"
+        action: "ref"
+        xml_id: "account.data_account_type_receivable"
+        save_as: "ci_account_type"
+
+      - step: "Setup - create customer invoice receivable account"
+        action: "create"
+        model: "account.account"
+        save_as: "ci_account"
+        values:
+          name: "Customer Invoice Receivable ADMCI22"
+          code: "ADMCI22"
+          user_type_id: "REC: ci_account_type.id"
+          reconcile: true
+
+      - step: "Setup - create customer invoice type"
+        action: "create"
+        model: "customer_invoice_type"
+        save_as: "ci_type"
+        values:
+          name: "Customer Invoice Type ADMCI22"
+          code: "ADMCI22"
+          journal_id: "REC: ci_journal.id"
+          receivable_account_id: "REC: ci_account.id"
+
       - step: "Setup - get account type ref"
         action: "ref"
         xml_id: "account.data_account_type_revenue"
@@ -1376,6 +1583,9 @@ scenarios:
         model: "school_admission"
         save_as: "admission"
         values:
+          customer_invoice_type_id: "REC: ci_type.id"
+          receivable_account_id: "REC: ci_account.id"
+          pricelist_id: "REF: product.list0"
           date: "2024-07-01"
           academic_year_id: "REC: academic_year.id"
           academic_term_id: "REC: academic_term.id"
@@ -1437,6 +1647,9 @@ scenarios:
         model: "school_admission"
         save_as: "admission_draft"
         values:
+          customer_invoice_type_id: "REC: ci_type.id"
+          receivable_account_id: "REC: ci_account.id"
+          pricelist_id: "REF: product.list0"
           date: "2024-07-01"
           academic_year_id: "REC: academic_year.id"
           academic_term_id: "REC: academic_term.id"
@@ -1478,19 +1691,51 @@ scenarios:
           state:
             type: "value"
             expected: "uninvoiced"
-          invoice_id:
+          customer_invoice_id:
             type: "value"
             operator: "is_falsy"
 
       - step: "Assert no invoice was created for the valid admission either"
         action: "search"
-        model: "account.move"
-        domain: [["invoice_origin", "=", "REC: admission.name"]]
+        model: "customer_invoice"
+        domain: [["customer_document_number", "=", "REC: admission.name"]]
         save_as: "invoices_after_failed_run"
         expect_count: 0
 
   - name: "Create Due Invoice - Blocked When Date Start Is Later Than Date End"
     steps:
+      - step: "Setup - get customer invoice journal"
+        action: "search"
+        model: "account.journal"
+        domain: [["type", "=", "sale"]]
+        save_as: "ci_journal"
+        limit: 1
+
+      - step: "Setup - get receivable account type"
+        action: "ref"
+        xml_id: "account.data_account_type_receivable"
+        save_as: "ci_account_type"
+
+      - step: "Setup - create customer invoice receivable account"
+        action: "create"
+        model: "account.account"
+        save_as: "ci_account"
+        values:
+          name: "Customer Invoice Receivable ADMCI23"
+          code: "ADMCI23"
+          user_type_id: "REC: ci_account_type.id"
+          reconcile: true
+
+      - step: "Setup - create customer invoice type"
+        action: "create"
+        model: "customer_invoice_type"
+        save_as: "ci_type"
+        values:
+          name: "Customer Invoice Type ADMCI23"
+          code: "ADMCI23"
+          journal_id: "REC: ci_journal.id"
+          receivable_account_id: "REC: ci_account.id"
+
       - step: "Setup - get account type ref"
         action: "ref"
         xml_id: "account.data_account_type_revenue"
@@ -1583,6 +1828,9 @@ scenarios:
         model: "school_admission"
         save_as: "admission"
         values:
+          customer_invoice_type_id: "REC: ci_type.id"
+          receivable_account_id: "REC: ci_account.id"
+          pricelist_id: "REF: product.list0"
           date: "2024-07-01"
           academic_year_id: "REC: academic_year.id"
           academic_term_id: "REC: academic_term.id"
@@ -1659,13 +1907,13 @@ scenarios:
           state:
             type: "value"
             expected: "uninvoiced"
-          invoice_id:
+          customer_invoice_id:
             type: "value"
             operator: "is_falsy"
 
       - step: "Assert no invoice was created"
         action: "search"
-        model: "account.move"
-        domain: [["invoice_origin", "=", "REC: admission.name"]]
+        model: "customer_invoice"
+        domain: [["customer_document_number", "=", "REC: admission.name"]]
         save_as: "invoices_after_failed_range"
         expect_count: 0

--- a/ssi_school_admission/tests/test_data_admission_customer_invoice.yaml
+++ b/ssi_school_admission/tests/test_data_admission_customer_invoice.yaml
@@ -1,5 +1,3 @@
-options:
-  auto_refresh: true
 scenarios:
   - name: "Create Customer Invoice From Payment Term"
     steps:
@@ -210,6 +208,15 @@ scenarios:
         target: "admission"
         method: "action_approve_approval"
         as_user: "base.user_admin"
+
+      - step: "Invalidate admission cache after approve"
+        action: "call"
+        target: "admission"
+        method: "invalidate_cache"
+
+      - step: "Assert the admission is open"
+        action: "assert"
+        target: "admission"
         asserts:
           state:
             type: "value"
@@ -220,6 +227,11 @@ scenarios:
         target: "term"
         method: "action_create_invoice"
         as_user: "base.user_admin"
+
+      - step: "Invalidate cache after creating the customer invoice"
+        action: "call"
+        target: "term"
+        method: "invalidate_cache"
 
       - step: "Assert term is invoiced and linked to a customer invoice"
         action: "assert"
@@ -490,6 +502,15 @@ scenarios:
         target: "admission"
         method: "action_approve_approval"
         as_user: "base.user_admin"
+
+      - step: "Invalidate admission cache after approve"
+        action: "call"
+        target: "admission"
+        method: "invalidate_cache"
+
+      - step: "Assert the admission is open"
+        action: "assert"
+        target: "admission"
         asserts:
           state:
             type: "value"
@@ -500,6 +521,11 @@ scenarios:
         target: "term"
         method: "action_create_invoice"
         as_user: "base.user_admin"
+
+      - step: "Invalidate cache after creating the customer invoice"
+        action: "call"
+        target: "term"
+        method: "invalidate_cache"
 
       - step: "Assert the admission asks for an automatic confirmation"
         action: "assert"
@@ -729,6 +755,15 @@ scenarios:
         target: "admission"
         method: "action_approve_approval"
         as_user: "base.user_admin"
+
+      - step: "Invalidate admission cache after approve"
+        action: "call"
+        target: "admission"
+        method: "invalidate_cache"
+
+      - step: "Assert the admission is open"
+        action: "assert"
+        target: "admission"
         asserts:
           state:
             type: "value"
@@ -740,11 +775,21 @@ scenarios:
         method: "action_create_invoice"
         as_user: "base.user_admin"
 
+      - step: "Invalidate cache after creating the customer invoice"
+        action: "call"
+        target: "term"
+        method: "invalidate_cache"
+
       - step: "Disconnect the customer invoice from the payment term"
         action: "call"
         target: "term"
         method: "action_disconnect_invoice"
         as_user: "base.user_admin"
+
+      - step: "Invalidate cache after disconnecting the customer invoice"
+        action: "call"
+        target: "term"
+        method: "invalidate_cache"
 
       - step: "Assert the term is uninvoiced again"
         action: "assert"
@@ -973,6 +1018,15 @@ scenarios:
         target: "admission"
         method: "action_approve_approval"
         as_user: "base.user_admin"
+
+      - step: "Invalidate admission cache after approve"
+        action: "call"
+        target: "admission"
+        method: "invalidate_cache"
+
+      - step: "Assert the admission is open"
+        action: "assert"
+        target: "admission"
         asserts:
           state:
             type: "value"
@@ -984,11 +1038,21 @@ scenarios:
         method: "action_create_invoice"
         as_user: "base.user_admin"
 
+      - step: "Invalidate cache after creating the customer invoice"
+        action: "call"
+        target: "term"
+        method: "invalidate_cache"
+
       - step: "Delete the draft customer invoice"
         action: "call"
         target: "term"
         method: "action_delete_invoice"
         as_user: "base.user_admin"
+
+      - step: "Invalidate cache after deleting the customer invoice"
+        action: "call"
+        target: "term"
+        method: "invalidate_cache"
 
       - step: "Assert the term is uninvoiced again"
         action: "assert"
@@ -1233,6 +1297,15 @@ scenarios:
         target: "admission"
         method: "action_approve_approval"
         as_user: "base.user_admin"
+
+      - step: "Invalidate admission cache after approve"
+        action: "call"
+        target: "admission"
+        method: "invalidate_cache"
+
+      - step: "Assert the admission is open"
+        action: "assert"
+        target: "admission"
         asserts:
           state:
             type: "value"
@@ -1243,6 +1316,11 @@ scenarios:
         target: "term"
         method: "action_create_invoice"
         as_user: "base.user_admin"
+
+      - step: "Invalidate cache after creating the customer invoice"
+        action: "call"
+        target: "term"
+        method: "invalidate_cache"
 
       - step: "Get the generated customer invoice"
         action: "search"
@@ -1269,6 +1347,11 @@ scenarios:
         expect_error:
           type: "UserError"
           message_contains: "not draft anymore"
+
+      - step: "Invalidate cache after the rejected deletion"
+        action: "call"
+        target: "term"
+        method: "invalidate_cache"
 
       - step: "Assert the term is still linked to the customer invoice"
         action: "assert"
@@ -1490,6 +1573,15 @@ scenarios:
         target: "admission"
         method: "action_approve_approval"
         as_user: "base.user_admin"
+
+      - step: "Invalidate admission cache after approve"
+        action: "call"
+        target: "admission"
+        method: "invalidate_cache"
+
+      - step: "Assert the admission is open"
+        action: "assert"
+        target: "admission"
         asserts:
           state:
             type: "value"
@@ -1501,6 +1593,11 @@ scenarios:
         method: "action_create_invoice"
         as_user: "base.user_admin"
 
+      - step: "Invalidate cache after creating the customer invoice"
+        action: "call"
+        target: "term"
+        method: "invalidate_cache"
+
       - step: "Cancelling the admission must be rejected"
         action: "call"
         target: "admission"
@@ -1508,6 +1605,11 @@ scenarios:
         as_user: "base.user_admin"
         expect_error:
           type: "UserError"
+
+      - step: "Invalidate cache after the rejected cancellation"
+        action: "call"
+        target: "admission"
+        method: "invalidate_cache"
 
       - step: "Assert the admission is still open"
         action: "assert"

--- a/ssi_school_admission/tests/test_data_admission_customer_invoice.yaml
+++ b/ssi_school_admission/tests/test_data_admission_customer_invoice.yaml
@@ -1,0 +1,1669 @@
+options:
+  auto_refresh: true
+scenarios:
+  - name: "Create Customer Invoice From Payment Term"
+    steps:
+      - step: "Setup - get sale journal"
+        action: "search"
+        model: "account.journal"
+        domain: [["type", "=", "sale"]]
+        save_as: "journal"
+        limit: 1
+
+      - step: "Setup - get revenue account type"
+        action: "ref"
+        xml_id: "account.data_account_type_revenue"
+        save_as: "revenue_type"
+
+      - step: "Setup - get receivable account type"
+        action: "ref"
+        xml_id: "account.data_account_type_receivable"
+        save_as: "receivable_type"
+
+      - step: "Setup - create income account"
+        action: "create"
+        model: "account.account"
+        save_as: "income_account"
+        values:
+          name: "Admission Fee Income ADCI1"
+          code: "ADCI14200"
+          user_type_id: "REC: revenue_type.id"
+
+      - step: "Setup - create receivable account"
+        action: "create"
+        model: "account.account"
+        save_as: "receivable_account"
+        values:
+          name: "Admission Receivable ADCI1"
+          code: "ADCI11100"
+          user_type_id: "REC: receivable_type.id"
+          reconcile: true
+
+      - step: "Setup - create customer invoice type"
+        action: "create"
+        model: "customer_invoice_type"
+        save_as: "ci_type"
+        values:
+          name: "Customer Invoice Type ADCI1"
+          code: "CITADCI1"
+          journal_id: "REC: journal.id"
+          receivable_account_id: "REC: receivable_account.id"
+
+      - step: "Setup - create product"
+        action: "create"
+        model: "product.product"
+        save_as: "product"
+        values:
+          name: "Admission Fee ADCI1"
+          type: "service"
+          list_price: 1000000.0
+
+      - step: "Setup - create pricelist"
+        action: "create"
+        model: "product.pricelist"
+        save_as: "pricelist"
+        values:
+          name: "Admission Pricelist ADCI1"
+          currency_id: "EVAL: env.company.currency_id.id"
+
+      - step: "Setup - create grade type"
+        action: "create"
+        model: "school_grade_type"
+        save_as: "grade_type"
+        values:
+          name: "Grade Type ADCI1"
+          code: "GTADCI1"
+          sequence: 10
+
+      - step: "Setup - create academic year"
+        action: "create"
+        model: "school_academic_year"
+        save_as: "academic_year"
+        values:
+          name: "2024/2025 ADCI1"
+          code: "AYADCI1"
+          date_start: "2024-07-01"
+          date_end: "2025-06-30"
+
+      - step: "Setup - create academic term"
+        action: "create"
+        model: "school_academic_term"
+        save_as: "academic_term"
+        values:
+          name: "Semester ADCI1"
+          code: "SMADCI1"
+          date_start: "2024-07-01"
+          date_end: "2025-06-30"
+          year_id: "REC: academic_year.id"
+          enrollment_state: "open"
+
+      - step: "Setup - create school"
+        action: "create"
+        model: "school"
+        save_as: "school"
+        values:
+          name: "School ADCI1"
+          code: "SCHADCI1"
+          grade_type_id: "REC: grade_type.id"
+
+      - step: "Setup - create grade"
+        action: "create"
+        model: "school_grade"
+        save_as: "grade"
+        values:
+          name: "Grade ADCI1"
+          code: "GADCI1"
+          sequence: 10
+          type_id: "REC: grade_type.id"
+
+      - step: "Setup - create student contact"
+        action: "create"
+        model: "res.partner"
+        save_as: "contact"
+        values:
+          name: "Student Contact ADCI1"
+
+      - step: "Setup - create payment template"
+        action: "create"
+        model: "school_admission_payment_template"
+        save_as: "payment_template"
+        values:
+          name: "Payment Template ADCI1"
+          code: "PMTADCI1"
+          school_id: "REC: school.id"
+          grade_id: "REC: grade.id"
+          academic_term_id: "REC: academic_term.id"
+          receivable_journal_id: "REC: journal.id"
+          receivable_account_id: "REC: receivable_account.id"
+          customer_invoice_type_id: "REC: ci_type.id"
+          auto_confirm_customer_invoice: false
+
+      - step: "Create admission"
+        action: "create"
+        model: "school_admission"
+        save_as: "admission"
+        values:
+          date: "2024-07-01"
+          academic_year_id: "REC: academic_year.id"
+          academic_term_id: "REC: academic_term.id"
+          school_id: "REC: school.id"
+          grade_id: "REC: grade.id"
+          student_id: "REC: contact.id"
+          currency_id: "EVAL: env.company.currency_id.id"
+          pricelist_id: "REC: pricelist.id"
+          receivable_journal_id: "REC: journal.id"
+          receivable_account_id: "REC: receivable_account.id"
+          customer_invoice_type_id: "REC: payment_template.customer_invoice_type_id.id"
+          auto_confirm_customer_invoice:
+            "REC: payment_template.auto_confirm_customer_invoice"
+
+      - step: "Create payment term"
+        action: "create"
+        model: "school_admission_payment_term"
+        save_as: "term"
+        values:
+          admission_id: "REC: admission.id"
+          name: "Term ADCI1"
+          sequence: 10
+          date_invoice: "2024-07-05"
+          date_due: "2024-07-20"
+
+      - step: "Create first payment term detail"
+        action: "create"
+        model: "school_admission_payment_term_detail"
+        save_as: "detail_1"
+        values:
+          term_id: "REC: term.id"
+          product_id: "REC: product.id"
+          name: "Registration Fee ADCI1"
+          account_id: "REC: income_account.id"
+          uom_quantity: 1.0
+          uom_id: "REF: uom.product_uom_unit"
+          price_unit: 1000000.0
+
+      - step: "Create second payment term detail"
+        action: "create"
+        model: "school_admission_payment_term_detail"
+        save_as: "detail_2"
+        values:
+          term_id: "REC: term.id"
+          product_id: "REC: product.id"
+          name: "Books and Uniform Fee ADCI1"
+          account_id: "REC: income_account.id"
+          uom_quantity: 1.0
+          uom_id: "REF: uom.product_uom_unit"
+          price_unit: 500000.0
+
+      - step: "Confirm admission"
+        action: "call"
+        target: "admission"
+        method: "action_confirm"
+        as_user: "base.user_admin"
+
+      - step: "Invalidate admission cache before approve"
+        action: "call"
+        target: "admission"
+        method: "invalidate_cache"
+
+      - step: "Approve admission"
+        action: "call"
+        target: "admission"
+        method: "action_approve_approval"
+        as_user: "base.user_admin"
+        asserts:
+          state:
+            type: "value"
+            expected: "open"
+
+      - step: "Create customer invoice from the payment term"
+        action: "call"
+        target: "term"
+        method: "action_create_invoice"
+        as_user: "base.user_admin"
+
+      - step: "Assert term is invoiced and linked to a customer invoice"
+        action: "assert"
+        target: "term"
+        asserts:
+          state:
+            type: "value"
+            expected: "invoiced"
+          customer_invoice_id:
+            type: "value"
+            operator: "is_truthy"
+          customer_invoice_id.state:
+            type: "value"
+            expected: "draft"
+          customer_invoice_id.type_id.id:
+            type: "value"
+            expected: "REC: ci_type.id"
+          customer_invoice_id.partner_id.id:
+            type: "value"
+            expected: "REC: contact.id"
+          customer_invoice_id.customer_document_number:
+            type: "value"
+            expected: "REC: admission.name"
+          customer_invoice_id.amount_untaxed:
+            type: "value"
+            expected: 1500000.0
+
+      - step: "Assert first detail is linked to its own customer invoice line"
+        action: "assert"
+        target: "detail_1"
+        asserts:
+          customer_invoice_line_id:
+            type: "value"
+            operator: "is_truthy"
+          customer_invoice_line_id.name:
+            type: "value"
+            expected: "Registration Fee ADCI1"
+          customer_invoice_line_id.price_unit:
+            type: "value"
+            expected: 1000000.0
+          customer_invoice_line_id.customer_invoice_id.id:
+            type: "value"
+            expected: "REC: term.customer_invoice_id.id"
+
+      - step: "Assert second detail is linked to its own customer invoice line"
+        action: "assert"
+        target: "detail_2"
+        asserts:
+          customer_invoice_line_id:
+            type: "value"
+            operator: "is_truthy"
+          customer_invoice_line_id.name:
+            type: "value"
+            expected: "Books and Uniform Fee ADCI1"
+          customer_invoice_line_id.price_unit:
+            type: "value"
+            expected: 500000.0
+          customer_invoice_line_id.customer_invoice_id.id:
+            type: "value"
+            expected: "REC: term.customer_invoice_id.id"
+
+  - name: "Auto Confirm Customer Invoice From Payment Template"
+    steps:
+      - step: "Setup - get sale journal"
+        action: "search"
+        model: "account.journal"
+        domain: [["type", "=", "sale"]]
+        save_as: "journal"
+        limit: 1
+
+      - step: "Setup - get revenue account type"
+        action: "ref"
+        xml_id: "account.data_account_type_revenue"
+        save_as: "revenue_type"
+
+      - step: "Setup - get receivable account type"
+        action: "ref"
+        xml_id: "account.data_account_type_receivable"
+        save_as: "receivable_type"
+
+      - step: "Setup - create income account"
+        action: "create"
+        model: "account.account"
+        save_as: "income_account"
+        values:
+          name: "Admission Fee Income ADCI2"
+          code: "ADCI24200"
+          user_type_id: "REC: revenue_type.id"
+
+      - step: "Setup - create receivable account"
+        action: "create"
+        model: "account.account"
+        save_as: "receivable_account"
+        values:
+          name: "Admission Receivable ADCI2"
+          code: "ADCI21100"
+          user_type_id: "REC: receivable_type.id"
+          reconcile: true
+
+      - step: "Setup - create customer invoice type"
+        action: "create"
+        model: "customer_invoice_type"
+        save_as: "ci_type"
+        values:
+          name: "Customer Invoice Type ADCI2"
+          code: "CITADCI2"
+          journal_id: "REC: journal.id"
+          receivable_account_id: "REC: receivable_account.id"
+
+      - step: "Setup - create product"
+        action: "create"
+        model: "product.product"
+        save_as: "product"
+        values:
+          name: "Admission Fee ADCI2"
+          type: "service"
+          list_price: 1000000.0
+
+      - step: "Setup - create pricelist"
+        action: "create"
+        model: "product.pricelist"
+        save_as: "pricelist"
+        values:
+          name: "Admission Pricelist ADCI2"
+          currency_id: "EVAL: env.company.currency_id.id"
+
+      - step: "Setup - create grade type"
+        action: "create"
+        model: "school_grade_type"
+        save_as: "grade_type"
+        values:
+          name: "Grade Type ADCI2"
+          code: "GTADCI2"
+          sequence: 10
+
+      - step: "Setup - create academic year"
+        action: "create"
+        model: "school_academic_year"
+        save_as: "academic_year"
+        values:
+          name: "2024/2025 ADCI2"
+          code: "AYADCI2"
+          date_start: "2024-07-01"
+          date_end: "2025-06-30"
+
+      - step: "Setup - create academic term"
+        action: "create"
+        model: "school_academic_term"
+        save_as: "academic_term"
+        values:
+          name: "Semester ADCI2"
+          code: "SMADCI2"
+          date_start: "2024-07-01"
+          date_end: "2025-06-30"
+          year_id: "REC: academic_year.id"
+          enrollment_state: "open"
+
+      - step: "Setup - create school"
+        action: "create"
+        model: "school"
+        save_as: "school"
+        values:
+          name: "School ADCI2"
+          code: "SCHADCI2"
+          grade_type_id: "REC: grade_type.id"
+
+      - step: "Setup - create grade"
+        action: "create"
+        model: "school_grade"
+        save_as: "grade"
+        values:
+          name: "Grade ADCI2"
+          code: "GADCI2"
+          sequence: 10
+          type_id: "REC: grade_type.id"
+
+      - step: "Setup - create student contact"
+        action: "create"
+        model: "res.partner"
+        save_as: "contact"
+        values:
+          name: "Student Contact ADCI2"
+
+      - step: "Setup - create payment template"
+        action: "create"
+        model: "school_admission_payment_template"
+        save_as: "payment_template"
+        values:
+          name: "Payment Template ADCI2"
+          code: "PMTADCI2"
+          school_id: "REC: school.id"
+          grade_id: "REC: grade.id"
+          academic_term_id: "REC: academic_term.id"
+          receivable_journal_id: "REC: journal.id"
+          receivable_account_id: "REC: receivable_account.id"
+          customer_invoice_type_id: "REC: ci_type.id"
+          auto_confirm_customer_invoice: true
+
+      - step: "Create admission"
+        action: "create"
+        model: "school_admission"
+        save_as: "admission"
+        values:
+          date: "2024-07-01"
+          academic_year_id: "REC: academic_year.id"
+          academic_term_id: "REC: academic_term.id"
+          school_id: "REC: school.id"
+          grade_id: "REC: grade.id"
+          student_id: "REC: contact.id"
+          currency_id: "EVAL: env.company.currency_id.id"
+          pricelist_id: "REC: pricelist.id"
+          receivable_journal_id: "REC: journal.id"
+          receivable_account_id: "REC: receivable_account.id"
+          customer_invoice_type_id: "REC: payment_template.customer_invoice_type_id.id"
+          auto_confirm_customer_invoice:
+            "REC: payment_template.auto_confirm_customer_invoice"
+
+      - step: "Create payment term"
+        action: "create"
+        model: "school_admission_payment_term"
+        save_as: "term"
+        values:
+          admission_id: "REC: admission.id"
+          name: "Term ADCI2"
+          sequence: 10
+          date_invoice: "2024-07-05"
+          date_due: "2024-07-20"
+
+      - step: "Create first payment term detail"
+        action: "create"
+        model: "school_admission_payment_term_detail"
+        save_as: "detail_1"
+        values:
+          term_id: "REC: term.id"
+          product_id: "REC: product.id"
+          name: "Registration Fee ADCI2"
+          account_id: "REC: income_account.id"
+          uom_quantity: 1.0
+          uom_id: "REF: uom.product_uom_unit"
+          price_unit: 1000000.0
+
+      - step: "Create second payment term detail"
+        action: "create"
+        model: "school_admission_payment_term_detail"
+        save_as: "detail_2"
+        values:
+          term_id: "REC: term.id"
+          product_id: "REC: product.id"
+          name: "Books and Uniform Fee ADCI2"
+          account_id: "REC: income_account.id"
+          uom_quantity: 1.0
+          uom_id: "REF: uom.product_uom_unit"
+          price_unit: 500000.0
+
+      - step: "Confirm admission"
+        action: "call"
+        target: "admission"
+        method: "action_confirm"
+        as_user: "base.user_admin"
+
+      - step: "Invalidate admission cache before approve"
+        action: "call"
+        target: "admission"
+        method: "invalidate_cache"
+
+      - step: "Approve admission"
+        action: "call"
+        target: "admission"
+        method: "action_approve_approval"
+        as_user: "base.user_admin"
+        asserts:
+          state:
+            type: "value"
+            expected: "open"
+
+      - step: "Create customer invoice from the payment term"
+        action: "call"
+        target: "term"
+        method: "action_create_invoice"
+        as_user: "base.user_admin"
+
+      - step: "Assert the admission asks for an automatic confirmation"
+        action: "assert"
+        target: "admission"
+        asserts:
+          auto_confirm_customer_invoice:
+            type: "value"
+            expected: true
+
+      - step: "Assert customer invoice state is confirm"
+        action: "assert"
+        target: "term"
+        asserts:
+          state:
+            type: "value"
+            expected: "invoiced"
+          customer_invoice_id.state:
+            type: "value"
+            expected: "confirm"
+
+  - name: "Disconnect Customer Invoice From Payment Term"
+    steps:
+      - step: "Setup - get sale journal"
+        action: "search"
+        model: "account.journal"
+        domain: [["type", "=", "sale"]]
+        save_as: "journal"
+        limit: 1
+
+      - step: "Setup - get revenue account type"
+        action: "ref"
+        xml_id: "account.data_account_type_revenue"
+        save_as: "revenue_type"
+
+      - step: "Setup - get receivable account type"
+        action: "ref"
+        xml_id: "account.data_account_type_receivable"
+        save_as: "receivable_type"
+
+      - step: "Setup - create income account"
+        action: "create"
+        model: "account.account"
+        save_as: "income_account"
+        values:
+          name: "Admission Fee Income ADCI3"
+          code: "ADCI34200"
+          user_type_id: "REC: revenue_type.id"
+
+      - step: "Setup - create receivable account"
+        action: "create"
+        model: "account.account"
+        save_as: "receivable_account"
+        values:
+          name: "Admission Receivable ADCI3"
+          code: "ADCI31100"
+          user_type_id: "REC: receivable_type.id"
+          reconcile: true
+
+      - step: "Setup - create customer invoice type"
+        action: "create"
+        model: "customer_invoice_type"
+        save_as: "ci_type"
+        values:
+          name: "Customer Invoice Type ADCI3"
+          code: "CITADCI3"
+          journal_id: "REC: journal.id"
+          receivable_account_id: "REC: receivable_account.id"
+
+      - step: "Setup - create product"
+        action: "create"
+        model: "product.product"
+        save_as: "product"
+        values:
+          name: "Admission Fee ADCI3"
+          type: "service"
+          list_price: 1000000.0
+
+      - step: "Setup - create pricelist"
+        action: "create"
+        model: "product.pricelist"
+        save_as: "pricelist"
+        values:
+          name: "Admission Pricelist ADCI3"
+          currency_id: "EVAL: env.company.currency_id.id"
+
+      - step: "Setup - create grade type"
+        action: "create"
+        model: "school_grade_type"
+        save_as: "grade_type"
+        values:
+          name: "Grade Type ADCI3"
+          code: "GTADCI3"
+          sequence: 10
+
+      - step: "Setup - create academic year"
+        action: "create"
+        model: "school_academic_year"
+        save_as: "academic_year"
+        values:
+          name: "2024/2025 ADCI3"
+          code: "AYADCI3"
+          date_start: "2024-07-01"
+          date_end: "2025-06-30"
+
+      - step: "Setup - create academic term"
+        action: "create"
+        model: "school_academic_term"
+        save_as: "academic_term"
+        values:
+          name: "Semester ADCI3"
+          code: "SMADCI3"
+          date_start: "2024-07-01"
+          date_end: "2025-06-30"
+          year_id: "REC: academic_year.id"
+          enrollment_state: "open"
+
+      - step: "Setup - create school"
+        action: "create"
+        model: "school"
+        save_as: "school"
+        values:
+          name: "School ADCI3"
+          code: "SCHADCI3"
+          grade_type_id: "REC: grade_type.id"
+
+      - step: "Setup - create grade"
+        action: "create"
+        model: "school_grade"
+        save_as: "grade"
+        values:
+          name: "Grade ADCI3"
+          code: "GADCI3"
+          sequence: 10
+          type_id: "REC: grade_type.id"
+
+      - step: "Setup - create student contact"
+        action: "create"
+        model: "res.partner"
+        save_as: "contact"
+        values:
+          name: "Student Contact ADCI3"
+
+      - step: "Setup - create payment template"
+        action: "create"
+        model: "school_admission_payment_template"
+        save_as: "payment_template"
+        values:
+          name: "Payment Template ADCI3"
+          code: "PMTADCI3"
+          school_id: "REC: school.id"
+          grade_id: "REC: grade.id"
+          academic_term_id: "REC: academic_term.id"
+          receivable_journal_id: "REC: journal.id"
+          receivable_account_id: "REC: receivable_account.id"
+          customer_invoice_type_id: "REC: ci_type.id"
+          auto_confirm_customer_invoice: false
+
+      - step: "Create admission"
+        action: "create"
+        model: "school_admission"
+        save_as: "admission"
+        values:
+          date: "2024-07-01"
+          academic_year_id: "REC: academic_year.id"
+          academic_term_id: "REC: academic_term.id"
+          school_id: "REC: school.id"
+          grade_id: "REC: grade.id"
+          student_id: "REC: contact.id"
+          currency_id: "EVAL: env.company.currency_id.id"
+          pricelist_id: "REC: pricelist.id"
+          receivable_journal_id: "REC: journal.id"
+          receivable_account_id: "REC: receivable_account.id"
+          customer_invoice_type_id: "REC: payment_template.customer_invoice_type_id.id"
+          auto_confirm_customer_invoice:
+            "REC: payment_template.auto_confirm_customer_invoice"
+
+      - step: "Create payment term"
+        action: "create"
+        model: "school_admission_payment_term"
+        save_as: "term"
+        values:
+          admission_id: "REC: admission.id"
+          name: "Term ADCI3"
+          sequence: 10
+          date_invoice: "2024-07-05"
+          date_due: "2024-07-20"
+
+      - step: "Create first payment term detail"
+        action: "create"
+        model: "school_admission_payment_term_detail"
+        save_as: "detail_1"
+        values:
+          term_id: "REC: term.id"
+          product_id: "REC: product.id"
+          name: "Registration Fee ADCI3"
+          account_id: "REC: income_account.id"
+          uom_quantity: 1.0
+          uom_id: "REF: uom.product_uom_unit"
+          price_unit: 1000000.0
+
+      - step: "Create second payment term detail"
+        action: "create"
+        model: "school_admission_payment_term_detail"
+        save_as: "detail_2"
+        values:
+          term_id: "REC: term.id"
+          product_id: "REC: product.id"
+          name: "Books and Uniform Fee ADCI3"
+          account_id: "REC: income_account.id"
+          uom_quantity: 1.0
+          uom_id: "REF: uom.product_uom_unit"
+          price_unit: 500000.0
+
+      - step: "Confirm admission"
+        action: "call"
+        target: "admission"
+        method: "action_confirm"
+        as_user: "base.user_admin"
+
+      - step: "Invalidate admission cache before approve"
+        action: "call"
+        target: "admission"
+        method: "invalidate_cache"
+
+      - step: "Approve admission"
+        action: "call"
+        target: "admission"
+        method: "action_approve_approval"
+        as_user: "base.user_admin"
+        asserts:
+          state:
+            type: "value"
+            expected: "open"
+
+      - step: "Create customer invoice from the payment term"
+        action: "call"
+        target: "term"
+        method: "action_create_invoice"
+        as_user: "base.user_admin"
+
+      - step: "Disconnect the customer invoice from the payment term"
+        action: "call"
+        target: "term"
+        method: "action_disconnect_invoice"
+        as_user: "base.user_admin"
+
+      - step: "Assert the term is uninvoiced again"
+        action: "assert"
+        target: "term"
+        asserts:
+          customer_invoice_id:
+            type: "value"
+            operator: "is_falsy"
+          state:
+            type: "value"
+            expected: "uninvoiced"
+
+      - step: "Assert the customer invoice document still exists"
+        action: "search"
+        model: "customer_invoice"
+        domain: [["customer_document_number", "=", "REC: admission.name"]]
+        save_as: "kept_invoices"
+        expect_count: 1
+
+  - name: "Delete Draft Customer Invoice Of Payment Term"
+    steps:
+      - step: "Setup - get sale journal"
+        action: "search"
+        model: "account.journal"
+        domain: [["type", "=", "sale"]]
+        save_as: "journal"
+        limit: 1
+
+      - step: "Setup - get revenue account type"
+        action: "ref"
+        xml_id: "account.data_account_type_revenue"
+        save_as: "revenue_type"
+
+      - step: "Setup - get receivable account type"
+        action: "ref"
+        xml_id: "account.data_account_type_receivable"
+        save_as: "receivable_type"
+
+      - step: "Setup - create income account"
+        action: "create"
+        model: "account.account"
+        save_as: "income_account"
+        values:
+          name: "Admission Fee Income ADCI4"
+          code: "ADCI44200"
+          user_type_id: "REC: revenue_type.id"
+
+      - step: "Setup - create receivable account"
+        action: "create"
+        model: "account.account"
+        save_as: "receivable_account"
+        values:
+          name: "Admission Receivable ADCI4"
+          code: "ADCI41100"
+          user_type_id: "REC: receivable_type.id"
+          reconcile: true
+
+      - step: "Setup - create customer invoice type"
+        action: "create"
+        model: "customer_invoice_type"
+        save_as: "ci_type"
+        values:
+          name: "Customer Invoice Type ADCI4"
+          code: "CITADCI4"
+          journal_id: "REC: journal.id"
+          receivable_account_id: "REC: receivable_account.id"
+
+      - step: "Setup - create product"
+        action: "create"
+        model: "product.product"
+        save_as: "product"
+        values:
+          name: "Admission Fee ADCI4"
+          type: "service"
+          list_price: 1000000.0
+
+      - step: "Setup - create pricelist"
+        action: "create"
+        model: "product.pricelist"
+        save_as: "pricelist"
+        values:
+          name: "Admission Pricelist ADCI4"
+          currency_id: "EVAL: env.company.currency_id.id"
+
+      - step: "Setup - create grade type"
+        action: "create"
+        model: "school_grade_type"
+        save_as: "grade_type"
+        values:
+          name: "Grade Type ADCI4"
+          code: "GTADCI4"
+          sequence: 10
+
+      - step: "Setup - create academic year"
+        action: "create"
+        model: "school_academic_year"
+        save_as: "academic_year"
+        values:
+          name: "2024/2025 ADCI4"
+          code: "AYADCI4"
+          date_start: "2024-07-01"
+          date_end: "2025-06-30"
+
+      - step: "Setup - create academic term"
+        action: "create"
+        model: "school_academic_term"
+        save_as: "academic_term"
+        values:
+          name: "Semester ADCI4"
+          code: "SMADCI4"
+          date_start: "2024-07-01"
+          date_end: "2025-06-30"
+          year_id: "REC: academic_year.id"
+          enrollment_state: "open"
+
+      - step: "Setup - create school"
+        action: "create"
+        model: "school"
+        save_as: "school"
+        values:
+          name: "School ADCI4"
+          code: "SCHADCI4"
+          grade_type_id: "REC: grade_type.id"
+
+      - step: "Setup - create grade"
+        action: "create"
+        model: "school_grade"
+        save_as: "grade"
+        values:
+          name: "Grade ADCI4"
+          code: "GADCI4"
+          sequence: 10
+          type_id: "REC: grade_type.id"
+
+      - step: "Setup - create student contact"
+        action: "create"
+        model: "res.partner"
+        save_as: "contact"
+        values:
+          name: "Student Contact ADCI4"
+
+      - step: "Setup - create payment template"
+        action: "create"
+        model: "school_admission_payment_template"
+        save_as: "payment_template"
+        values:
+          name: "Payment Template ADCI4"
+          code: "PMTADCI4"
+          school_id: "REC: school.id"
+          grade_id: "REC: grade.id"
+          academic_term_id: "REC: academic_term.id"
+          receivable_journal_id: "REC: journal.id"
+          receivable_account_id: "REC: receivable_account.id"
+          customer_invoice_type_id: "REC: ci_type.id"
+          auto_confirm_customer_invoice: false
+
+      - step: "Create admission"
+        action: "create"
+        model: "school_admission"
+        save_as: "admission"
+        values:
+          date: "2024-07-01"
+          academic_year_id: "REC: academic_year.id"
+          academic_term_id: "REC: academic_term.id"
+          school_id: "REC: school.id"
+          grade_id: "REC: grade.id"
+          student_id: "REC: contact.id"
+          currency_id: "EVAL: env.company.currency_id.id"
+          pricelist_id: "REC: pricelist.id"
+          receivable_journal_id: "REC: journal.id"
+          receivable_account_id: "REC: receivable_account.id"
+          customer_invoice_type_id: "REC: payment_template.customer_invoice_type_id.id"
+          auto_confirm_customer_invoice:
+            "REC: payment_template.auto_confirm_customer_invoice"
+
+      - step: "Create payment term"
+        action: "create"
+        model: "school_admission_payment_term"
+        save_as: "term"
+        values:
+          admission_id: "REC: admission.id"
+          name: "Term ADCI4"
+          sequence: 10
+          date_invoice: "2024-07-05"
+          date_due: "2024-07-20"
+
+      - step: "Create first payment term detail"
+        action: "create"
+        model: "school_admission_payment_term_detail"
+        save_as: "detail_1"
+        values:
+          term_id: "REC: term.id"
+          product_id: "REC: product.id"
+          name: "Registration Fee ADCI4"
+          account_id: "REC: income_account.id"
+          uom_quantity: 1.0
+          uom_id: "REF: uom.product_uom_unit"
+          price_unit: 1000000.0
+
+      - step: "Create second payment term detail"
+        action: "create"
+        model: "school_admission_payment_term_detail"
+        save_as: "detail_2"
+        values:
+          term_id: "REC: term.id"
+          product_id: "REC: product.id"
+          name: "Books and Uniform Fee ADCI4"
+          account_id: "REC: income_account.id"
+          uom_quantity: 1.0
+          uom_id: "REF: uom.product_uom_unit"
+          price_unit: 500000.0
+
+      - step: "Confirm admission"
+        action: "call"
+        target: "admission"
+        method: "action_confirm"
+        as_user: "base.user_admin"
+
+      - step: "Invalidate admission cache before approve"
+        action: "call"
+        target: "admission"
+        method: "invalidate_cache"
+
+      - step: "Approve admission"
+        action: "call"
+        target: "admission"
+        method: "action_approve_approval"
+        as_user: "base.user_admin"
+        asserts:
+          state:
+            type: "value"
+            expected: "open"
+
+      - step: "Create customer invoice from the payment term"
+        action: "call"
+        target: "term"
+        method: "action_create_invoice"
+        as_user: "base.user_admin"
+
+      - step: "Delete the draft customer invoice"
+        action: "call"
+        target: "term"
+        method: "action_delete_invoice"
+        as_user: "base.user_admin"
+
+      - step: "Assert the term is uninvoiced again"
+        action: "assert"
+        target: "term"
+        asserts:
+          customer_invoice_id:
+            type: "value"
+            operator: "is_falsy"
+          state:
+            type: "value"
+            expected: "uninvoiced"
+
+      - step: "Assert first detail is no longer linked to a line"
+        action: "assert"
+        target: "detail_1"
+        asserts:
+          customer_invoice_line_id:
+            type: "value"
+            operator: "is_falsy"
+
+      - step: "Assert second detail is no longer linked to a line"
+        action: "assert"
+        target: "detail_2"
+        asserts:
+          customer_invoice_line_id:
+            type: "value"
+            operator: "is_falsy"
+
+      - step: "Assert the customer invoice document is gone"
+        action: "search"
+        model: "customer_invoice"
+        domain: [["customer_document_number", "=", "REC: admission.name"]]
+        save_as: "remaining_invoices"
+        expect_count: 0
+
+  - name: "Delete Non Draft Customer Invoice Is Rejected"
+    steps:
+      - step: "Setup - get sale journal"
+        action: "search"
+        model: "account.journal"
+        domain: [["type", "=", "sale"]]
+        save_as: "journal"
+        limit: 1
+
+      - step: "Setup - get revenue account type"
+        action: "ref"
+        xml_id: "account.data_account_type_revenue"
+        save_as: "revenue_type"
+
+      - step: "Setup - get receivable account type"
+        action: "ref"
+        xml_id: "account.data_account_type_receivable"
+        save_as: "receivable_type"
+
+      - step: "Setup - create income account"
+        action: "create"
+        model: "account.account"
+        save_as: "income_account"
+        values:
+          name: "Admission Fee Income ADCI5"
+          code: "ADCI54200"
+          user_type_id: "REC: revenue_type.id"
+
+      - step: "Setup - create receivable account"
+        action: "create"
+        model: "account.account"
+        save_as: "receivable_account"
+        values:
+          name: "Admission Receivable ADCI5"
+          code: "ADCI51100"
+          user_type_id: "REC: receivable_type.id"
+          reconcile: true
+
+      - step: "Setup - create customer invoice type"
+        action: "create"
+        model: "customer_invoice_type"
+        save_as: "ci_type"
+        values:
+          name: "Customer Invoice Type ADCI5"
+          code: "CITADCI5"
+          journal_id: "REC: journal.id"
+          receivable_account_id: "REC: receivable_account.id"
+
+      - step: "Setup - create product"
+        action: "create"
+        model: "product.product"
+        save_as: "product"
+        values:
+          name: "Admission Fee ADCI5"
+          type: "service"
+          list_price: 1000000.0
+
+      - step: "Setup - create pricelist"
+        action: "create"
+        model: "product.pricelist"
+        save_as: "pricelist"
+        values:
+          name: "Admission Pricelist ADCI5"
+          currency_id: "EVAL: env.company.currency_id.id"
+
+      - step: "Setup - create grade type"
+        action: "create"
+        model: "school_grade_type"
+        save_as: "grade_type"
+        values:
+          name: "Grade Type ADCI5"
+          code: "GTADCI5"
+          sequence: 10
+
+      - step: "Setup - create academic year"
+        action: "create"
+        model: "school_academic_year"
+        save_as: "academic_year"
+        values:
+          name: "2024/2025 ADCI5"
+          code: "AYADCI5"
+          date_start: "2024-07-01"
+          date_end: "2025-06-30"
+
+      - step: "Setup - create academic term"
+        action: "create"
+        model: "school_academic_term"
+        save_as: "academic_term"
+        values:
+          name: "Semester ADCI5"
+          code: "SMADCI5"
+          date_start: "2024-07-01"
+          date_end: "2025-06-30"
+          year_id: "REC: academic_year.id"
+          enrollment_state: "open"
+
+      - step: "Setup - create school"
+        action: "create"
+        model: "school"
+        save_as: "school"
+        values:
+          name: "School ADCI5"
+          code: "SCHADCI5"
+          grade_type_id: "REC: grade_type.id"
+
+      - step: "Setup - create grade"
+        action: "create"
+        model: "school_grade"
+        save_as: "grade"
+        values:
+          name: "Grade ADCI5"
+          code: "GADCI5"
+          sequence: 10
+          type_id: "REC: grade_type.id"
+
+      - step: "Setup - create student contact"
+        action: "create"
+        model: "res.partner"
+        save_as: "contact"
+        values:
+          name: "Student Contact ADCI5"
+
+      - step: "Setup - create payment template"
+        action: "create"
+        model: "school_admission_payment_template"
+        save_as: "payment_template"
+        values:
+          name: "Payment Template ADCI5"
+          code: "PMTADCI5"
+          school_id: "REC: school.id"
+          grade_id: "REC: grade.id"
+          academic_term_id: "REC: academic_term.id"
+          receivable_journal_id: "REC: journal.id"
+          receivable_account_id: "REC: receivable_account.id"
+          customer_invoice_type_id: "REC: ci_type.id"
+          auto_confirm_customer_invoice: false
+
+      - step: "Create admission"
+        action: "create"
+        model: "school_admission"
+        save_as: "admission"
+        values:
+          date: "2024-07-01"
+          academic_year_id: "REC: academic_year.id"
+          academic_term_id: "REC: academic_term.id"
+          school_id: "REC: school.id"
+          grade_id: "REC: grade.id"
+          student_id: "REC: contact.id"
+          currency_id: "EVAL: env.company.currency_id.id"
+          pricelist_id: "REC: pricelist.id"
+          receivable_journal_id: "REC: journal.id"
+          receivable_account_id: "REC: receivable_account.id"
+          customer_invoice_type_id: "REC: payment_template.customer_invoice_type_id.id"
+          auto_confirm_customer_invoice:
+            "REC: payment_template.auto_confirm_customer_invoice"
+
+      - step: "Create payment term"
+        action: "create"
+        model: "school_admission_payment_term"
+        save_as: "term"
+        values:
+          admission_id: "REC: admission.id"
+          name: "Term ADCI5"
+          sequence: 10
+          date_invoice: "2024-07-05"
+          date_due: "2024-07-20"
+
+      - step: "Create first payment term detail"
+        action: "create"
+        model: "school_admission_payment_term_detail"
+        save_as: "detail_1"
+        values:
+          term_id: "REC: term.id"
+          product_id: "REC: product.id"
+          name: "Registration Fee ADCI5"
+          account_id: "REC: income_account.id"
+          uom_quantity: 1.0
+          uom_id: "REF: uom.product_uom_unit"
+          price_unit: 1000000.0
+
+      - step: "Create second payment term detail"
+        action: "create"
+        model: "school_admission_payment_term_detail"
+        save_as: "detail_2"
+        values:
+          term_id: "REC: term.id"
+          product_id: "REC: product.id"
+          name: "Books and Uniform Fee ADCI5"
+          account_id: "REC: income_account.id"
+          uom_quantity: 1.0
+          uom_id: "REF: uom.product_uom_unit"
+          price_unit: 500000.0
+
+      - step: "Confirm admission"
+        action: "call"
+        target: "admission"
+        method: "action_confirm"
+        as_user: "base.user_admin"
+
+      - step: "Invalidate admission cache before approve"
+        action: "call"
+        target: "admission"
+        method: "invalidate_cache"
+
+      - step: "Approve admission"
+        action: "call"
+        target: "admission"
+        method: "action_approve_approval"
+        as_user: "base.user_admin"
+        asserts:
+          state:
+            type: "value"
+            expected: "open"
+
+      - step: "Create customer invoice from the payment term"
+        action: "call"
+        target: "term"
+        method: "action_create_invoice"
+        as_user: "base.user_admin"
+
+      - step: "Get the generated customer invoice"
+        action: "search"
+        model: "customer_invoice"
+        domain: [["customer_document_number", "=", "REC: admission.name"]]
+        save_as: "invoice"
+        expect_count: 1
+
+      - step: "Confirm the customer invoice"
+        action: "call"
+        target: "invoice"
+        method: "action_confirm"
+        as_user: "base.user_admin"
+        asserts:
+          state:
+            type: "value"
+            expected: "confirm"
+
+      - step: "Deleting a non-draft customer invoice must be rejected"
+        action: "call"
+        target: "term"
+        method: "action_delete_invoice"
+        as_user: "base.user_admin"
+        expect_error:
+          type: "UserError"
+          message_contains: "not draft anymore"
+
+      - step: "Assert the term is still linked to the customer invoice"
+        action: "assert"
+        target: "term"
+        asserts:
+          customer_invoice_id:
+            type: "value"
+            operator: "is_truthy"
+          state:
+            type: "value"
+            expected: "invoiced"
+
+  - name: "Cancel Admission With Invoiced Payment Term Is Rejected"
+    steps:
+      - step: "Setup - get sale journal"
+        action: "search"
+        model: "account.journal"
+        domain: [["type", "=", "sale"]]
+        save_as: "journal"
+        limit: 1
+
+      - step: "Setup - get revenue account type"
+        action: "ref"
+        xml_id: "account.data_account_type_revenue"
+        save_as: "revenue_type"
+
+      - step: "Setup - get receivable account type"
+        action: "ref"
+        xml_id: "account.data_account_type_receivable"
+        save_as: "receivable_type"
+
+      - step: "Setup - create income account"
+        action: "create"
+        model: "account.account"
+        save_as: "income_account"
+        values:
+          name: "Admission Fee Income ADCI6"
+          code: "ADCI64200"
+          user_type_id: "REC: revenue_type.id"
+
+      - step: "Setup - create receivable account"
+        action: "create"
+        model: "account.account"
+        save_as: "receivable_account"
+        values:
+          name: "Admission Receivable ADCI6"
+          code: "ADCI61100"
+          user_type_id: "REC: receivable_type.id"
+          reconcile: true
+
+      - step: "Setup - create customer invoice type"
+        action: "create"
+        model: "customer_invoice_type"
+        save_as: "ci_type"
+        values:
+          name: "Customer Invoice Type ADCI6"
+          code: "CITADCI6"
+          journal_id: "REC: journal.id"
+          receivable_account_id: "REC: receivable_account.id"
+
+      - step: "Setup - create product"
+        action: "create"
+        model: "product.product"
+        save_as: "product"
+        values:
+          name: "Admission Fee ADCI6"
+          type: "service"
+          list_price: 1000000.0
+
+      - step: "Setup - create pricelist"
+        action: "create"
+        model: "product.pricelist"
+        save_as: "pricelist"
+        values:
+          name: "Admission Pricelist ADCI6"
+          currency_id: "EVAL: env.company.currency_id.id"
+
+      - step: "Setup - create grade type"
+        action: "create"
+        model: "school_grade_type"
+        save_as: "grade_type"
+        values:
+          name: "Grade Type ADCI6"
+          code: "GTADCI6"
+          sequence: 10
+
+      - step: "Setup - create academic year"
+        action: "create"
+        model: "school_academic_year"
+        save_as: "academic_year"
+        values:
+          name: "2024/2025 ADCI6"
+          code: "AYADCI6"
+          date_start: "2024-07-01"
+          date_end: "2025-06-30"
+
+      - step: "Setup - create academic term"
+        action: "create"
+        model: "school_academic_term"
+        save_as: "academic_term"
+        values:
+          name: "Semester ADCI6"
+          code: "SMADCI6"
+          date_start: "2024-07-01"
+          date_end: "2025-06-30"
+          year_id: "REC: academic_year.id"
+          enrollment_state: "open"
+
+      - step: "Setup - create school"
+        action: "create"
+        model: "school"
+        save_as: "school"
+        values:
+          name: "School ADCI6"
+          code: "SCHADCI6"
+          grade_type_id: "REC: grade_type.id"
+
+      - step: "Setup - create grade"
+        action: "create"
+        model: "school_grade"
+        save_as: "grade"
+        values:
+          name: "Grade ADCI6"
+          code: "GADCI6"
+          sequence: 10
+          type_id: "REC: grade_type.id"
+
+      - step: "Setup - create student contact"
+        action: "create"
+        model: "res.partner"
+        save_as: "contact"
+        values:
+          name: "Student Contact ADCI6"
+
+      - step: "Setup - create payment template"
+        action: "create"
+        model: "school_admission_payment_template"
+        save_as: "payment_template"
+        values:
+          name: "Payment Template ADCI6"
+          code: "PMTADCI6"
+          school_id: "REC: school.id"
+          grade_id: "REC: grade.id"
+          academic_term_id: "REC: academic_term.id"
+          receivable_journal_id: "REC: journal.id"
+          receivable_account_id: "REC: receivable_account.id"
+          customer_invoice_type_id: "REC: ci_type.id"
+          auto_confirm_customer_invoice: false
+
+      - step: "Create admission"
+        action: "create"
+        model: "school_admission"
+        save_as: "admission"
+        values:
+          date: "2024-07-01"
+          academic_year_id: "REC: academic_year.id"
+          academic_term_id: "REC: academic_term.id"
+          school_id: "REC: school.id"
+          grade_id: "REC: grade.id"
+          student_id: "REC: contact.id"
+          currency_id: "EVAL: env.company.currency_id.id"
+          pricelist_id: "REC: pricelist.id"
+          receivable_journal_id: "REC: journal.id"
+          receivable_account_id: "REC: receivable_account.id"
+          customer_invoice_type_id: "REC: payment_template.customer_invoice_type_id.id"
+          auto_confirm_customer_invoice:
+            "REC: payment_template.auto_confirm_customer_invoice"
+
+      - step: "Create payment term"
+        action: "create"
+        model: "school_admission_payment_term"
+        save_as: "term"
+        values:
+          admission_id: "REC: admission.id"
+          name: "Term ADCI6"
+          sequence: 10
+          date_invoice: "2024-07-05"
+          date_due: "2024-07-20"
+
+      - step: "Create first payment term detail"
+        action: "create"
+        model: "school_admission_payment_term_detail"
+        save_as: "detail_1"
+        values:
+          term_id: "REC: term.id"
+          product_id: "REC: product.id"
+          name: "Registration Fee ADCI6"
+          account_id: "REC: income_account.id"
+          uom_quantity: 1.0
+          uom_id: "REF: uom.product_uom_unit"
+          price_unit: 1000000.0
+
+      - step: "Create second payment term detail"
+        action: "create"
+        model: "school_admission_payment_term_detail"
+        save_as: "detail_2"
+        values:
+          term_id: "REC: term.id"
+          product_id: "REC: product.id"
+          name: "Books and Uniform Fee ADCI6"
+          account_id: "REC: income_account.id"
+          uom_quantity: 1.0
+          uom_id: "REF: uom.product_uom_unit"
+          price_unit: 500000.0
+
+      - step: "Confirm admission"
+        action: "call"
+        target: "admission"
+        method: "action_confirm"
+        as_user: "base.user_admin"
+
+      - step: "Invalidate admission cache before approve"
+        action: "call"
+        target: "admission"
+        method: "invalidate_cache"
+
+      - step: "Approve admission"
+        action: "call"
+        target: "admission"
+        method: "action_approve_approval"
+        as_user: "base.user_admin"
+        asserts:
+          state:
+            type: "value"
+            expected: "open"
+
+      - step: "Create customer invoice from the payment term"
+        action: "call"
+        target: "term"
+        method: "action_create_invoice"
+        as_user: "base.user_admin"
+
+      - step: "Cancelling the admission must be rejected"
+        action: "call"
+        target: "admission"
+        method: "action_cancel"
+        as_user: "base.user_admin"
+        expect_error:
+          type: "UserError"
+
+      - step: "Assert the admission is still open"
+        action: "assert"
+        target: "admission"
+        asserts:
+          state:
+            type: "value"
+            expected: "open"
+
+  - name: "Payment Template Onchange Fills Customer Invoice Fields"
+    steps:
+      - step: "Setup - get sale journal"
+        action: "search"
+        model: "account.journal"
+        domain: [["type", "=", "sale"]]
+        save_as: "journal"
+        limit: 1
+
+      - step: "Setup - get revenue account type"
+        action: "ref"
+        xml_id: "account.data_account_type_revenue"
+        save_as: "revenue_type"
+
+      - step: "Setup - get receivable account type"
+        action: "ref"
+        xml_id: "account.data_account_type_receivable"
+        save_as: "receivable_type"
+
+      - step: "Setup - create income account"
+        action: "create"
+        model: "account.account"
+        save_as: "income_account"
+        values:
+          name: "Admission Fee Income ADCI7"
+          code: "ADCI74200"
+          user_type_id: "REC: revenue_type.id"
+
+      - step: "Setup - create receivable account"
+        action: "create"
+        model: "account.account"
+        save_as: "receivable_account"
+        values:
+          name: "Admission Receivable ADCI7"
+          code: "ADCI71100"
+          user_type_id: "REC: receivable_type.id"
+          reconcile: true
+
+      - step: "Setup - create customer invoice type"
+        action: "create"
+        model: "customer_invoice_type"
+        save_as: "ci_type"
+        values:
+          name: "Customer Invoice Type ADCI7"
+          code: "CITADCI7"
+          journal_id: "REC: journal.id"
+          receivable_account_id: "REC: receivable_account.id"
+
+      - step: "Setup - create product"
+        action: "create"
+        model: "product.product"
+        save_as: "product"
+        values:
+          name: "Admission Fee ADCI7"
+          type: "service"
+          list_price: 1000000.0
+
+      - step: "Setup - create pricelist"
+        action: "create"
+        model: "product.pricelist"
+        save_as: "pricelist"
+        values:
+          name: "Admission Pricelist ADCI7"
+          currency_id: "EVAL: env.company.currency_id.id"
+
+      - step: "Setup - create grade type"
+        action: "create"
+        model: "school_grade_type"
+        save_as: "grade_type"
+        values:
+          name: "Grade Type ADCI7"
+          code: "GTADCI7"
+          sequence: 10
+
+      - step: "Setup - create academic year"
+        action: "create"
+        model: "school_academic_year"
+        save_as: "academic_year"
+        values:
+          name: "2024/2025 ADCI7"
+          code: "AYADCI7"
+          date_start: "2024-07-01"
+          date_end: "2025-06-30"
+
+      - step: "Setup - create academic term"
+        action: "create"
+        model: "school_academic_term"
+        save_as: "academic_term"
+        values:
+          name: "Semester ADCI7"
+          code: "SMADCI7"
+          date_start: "2024-07-01"
+          date_end: "2025-06-30"
+          year_id: "REC: academic_year.id"
+          enrollment_state: "open"
+
+      - step: "Setup - create school"
+        action: "create"
+        model: "school"
+        save_as: "school"
+        values:
+          name: "School ADCI7"
+          code: "SCHADCI7"
+          grade_type_id: "REC: grade_type.id"
+
+      - step: "Setup - create grade"
+        action: "create"
+        model: "school_grade"
+        save_as: "grade"
+        values:
+          name: "Grade ADCI7"
+          code: "GADCI7"
+          sequence: 10
+          type_id: "REC: grade_type.id"
+
+      - step: "Setup - create student contact"
+        action: "create"
+        model: "res.partner"
+        save_as: "contact"
+        values:
+          name: "Student Contact ADCI7"
+
+      - step: "Setup - create payment template"
+        action: "create"
+        model: "school_admission_payment_template"
+        save_as: "payment_template"
+        values:
+          name: "Payment Template ADCI7"
+          code: "PMTADCI7"
+          school_id: "REC: school.id"
+          grade_id: "REC: grade.id"
+          academic_term_id: "REC: academic_term.id"
+          receivable_journal_id: "REC: journal.id"
+          receivable_account_id: "REC: receivable_account.id"
+          customer_invoice_type_id: "REC: ci_type.id"
+          auto_confirm_customer_invoice: true
+
+      - step: "Selecting the payment template fills the customer invoice fields"
+        action: "form"
+        model: "school_admission"
+        save: false
+        values:
+          payment_template_id: "REC: payment_template"
+        asserts:
+          customer_invoice_type_id.id:
+            type: "value"
+            expected: "REC: ci_type.id"
+          auto_confirm_customer_invoice:
+            type: "value"
+            expected: true

--- a/ssi_school_admission/tests/test_data_admission_payment_date_pattern.yaml
+++ b/ssi_school_admission/tests/test_data_admission_payment_date_pattern.yaml
@@ -1,6 +1,38 @@
 scenarios:
   - name: "Compute Payment - Estimated Invoice and Due Date from Duration"
     steps:
+      - step: "Setup - get customer invoice journal"
+        action: "search"
+        model: "account.journal"
+        domain: [["type", "=", "sale"]]
+        save_as: "ci_journal"
+        limit: 1
+
+      - step: "Setup - get receivable account type"
+        action: "ref"
+        xml_id: "account.data_account_type_receivable"
+        save_as: "ci_account_type"
+
+      - step: "Setup - create customer invoice receivable account"
+        action: "create"
+        model: "account.account"
+        save_as: "ci_account"
+        values:
+          name: "Customer Invoice Receivable ADMCI03"
+          code: "ADMCI03"
+          user_type_id: "REC: ci_account_type.id"
+          reconcile: true
+
+      - step: "Setup - create customer invoice type"
+        action: "create"
+        model: "customer_invoice_type"
+        save_as: "ci_type"
+        values:
+          name: "Customer Invoice Type ADMCI03"
+          code: "ADMCI03"
+          journal_id: "REC: ci_journal.id"
+          receivable_account_id: "REC: ci_account.id"
+
       - step: "Setup - get sale journal"
         action: "search"
         model: "account.journal"
@@ -127,6 +159,7 @@ scenarios:
         model: "school_admission_payment_template"
         save_as: "payment_template"
         values:
+          customer_invoice_type_id: "REC: ci_type.id"
           name: "Admission Payment Template ADPTDUR"
           code: "ADPTDUR001"
           school_id: "EVAL: registry['school'].id"
@@ -243,6 +276,38 @@ scenarios:
 
   - name: "Compute Payment - Term without Duration leaves dates empty"
     steps:
+      - step: "Setup - get customer invoice journal"
+        action: "search"
+        model: "account.journal"
+        domain: [["type", "=", "sale"]]
+        save_as: "ci_journal"
+        limit: 1
+
+      - step: "Setup - get receivable account type"
+        action: "ref"
+        xml_id: "account.data_account_type_receivable"
+        save_as: "ci_account_type"
+
+      - step: "Setup - create customer invoice receivable account"
+        action: "create"
+        model: "account.account"
+        save_as: "ci_account"
+        values:
+          name: "Customer Invoice Receivable ADMCI04"
+          code: "ADMCI04"
+          user_type_id: "REC: ci_account_type.id"
+          reconcile: true
+
+      - step: "Setup - create customer invoice type"
+        action: "create"
+        model: "customer_invoice_type"
+        save_as: "ci_type"
+        values:
+          name: "Customer Invoice Type ADMCI04"
+          code: "ADMCI04"
+          journal_id: "REC: ci_journal.id"
+          receivable_account_id: "REC: ci_account.id"
+
       - step: "Setup - get sale journal"
         action: "search"
         model: "account.journal"
@@ -343,6 +408,7 @@ scenarios:
         model: "school_admission_payment_template"
         save_as: "payment_template"
         values:
+          customer_invoice_type_id: "REC: ci_type.id"
           name: "Admission Payment Template ADPTNODUR"
           code: "ADPTNODUR001"
           school_id: "EVAL: registry['school'].id"

--- a/ssi_school_admission/tests/test_data_admission_payment_product_configurator.yaml
+++ b/ssi_school_admission/tests/test_data_admission_payment_product_configurator.yaml
@@ -1,6 +1,38 @@
 scenarios:
   - name: "Allowed Products - Template Detail - Manual Strategy"
     steps:
+      - step: "Setup - get customer invoice journal"
+        action: "search"
+        model: "account.journal"
+        domain: [["type", "=", "sale"]]
+        save_as: "ci_journal"
+        limit: 1
+
+      - step: "Setup - get receivable account type"
+        action: "ref"
+        xml_id: "account.data_account_type_receivable"
+        save_as: "ci_account_type"
+
+      - step: "Setup - create customer invoice receivable account"
+        action: "create"
+        model: "account.account"
+        save_as: "ci_account"
+        values:
+          name: "Customer Invoice Receivable ADMCI05"
+          code: "ADMCI05"
+          user_type_id: "REC: ci_account_type.id"
+          reconcile: true
+
+      - step: "Setup - create customer invoice type"
+        action: "create"
+        model: "customer_invoice_type"
+        save_as: "ci_type"
+        values:
+          name: "Customer Invoice Type ADMCI05"
+          code: "ADMCI05"
+          journal_id: "REC: ci_journal.id"
+          receivable_account_id: "REC: ci_account.id"
+
       - step: "Get account type ref"
         action: "ref"
         xml_id: "account.data_account_type_revenue"
@@ -32,6 +64,7 @@ scenarios:
         model: "school_admission_payment_template"
         save_as: "template"
         values:
+          customer_invoice_type_id: "REC: ci_type.id"
           name: "Template ADCFG Manual"
           code: "TPLADCFGMAN"
           product_selection_method: "manual"
@@ -71,6 +104,38 @@ scenarios:
 
   - name: "Allowed Products - Template Detail - Manual Strategy Empty"
     steps:
+      - step: "Setup - get customer invoice journal"
+        action: "search"
+        model: "account.journal"
+        domain: [["type", "=", "sale"]]
+        save_as: "ci_journal"
+        limit: 1
+
+      - step: "Setup - get receivable account type"
+        action: "ref"
+        xml_id: "account.data_account_type_receivable"
+        save_as: "ci_account_type"
+
+      - step: "Setup - create customer invoice receivable account"
+        action: "create"
+        model: "account.account"
+        save_as: "ci_account"
+        values:
+          name: "Customer Invoice Receivable ADMCI06"
+          code: "ADMCI06"
+          user_type_id: "REC: ci_account_type.id"
+          reconcile: true
+
+      - step: "Setup - create customer invoice type"
+        action: "create"
+        model: "customer_invoice_type"
+        save_as: "ci_type"
+        values:
+          name: "Customer Invoice Type ADMCI06"
+          code: "ADMCI06"
+          journal_id: "REC: ci_journal.id"
+          receivable_account_id: "REC: ci_account.id"
+
       - step: "Get account type ref"
         action: "ref"
         xml_id: "account.data_account_type_revenue"
@@ -95,6 +160,7 @@ scenarios:
         model: "school_admission_payment_template"
         save_as: "template"
         values:
+          customer_invoice_type_id: "REC: ci_type.id"
           name: "Template ADCFG Empty"
           code: "TPLADCFGEMP"
           product_selection_method: "manual"
@@ -129,6 +195,38 @@ scenarios:
 
   - name: "Allowed Products - Template Detail - Domain Strategy"
     steps:
+      - step: "Setup - get customer invoice journal"
+        action: "search"
+        model: "account.journal"
+        domain: [["type", "=", "sale"]]
+        save_as: "ci_journal"
+        limit: 1
+
+      - step: "Setup - get receivable account type"
+        action: "ref"
+        xml_id: "account.data_account_type_receivable"
+        save_as: "ci_account_type"
+
+      - step: "Setup - create customer invoice receivable account"
+        action: "create"
+        model: "account.account"
+        save_as: "ci_account"
+        values:
+          name: "Customer Invoice Receivable ADMCI07"
+          code: "ADMCI07"
+          user_type_id: "REC: ci_account_type.id"
+          reconcile: true
+
+      - step: "Setup - create customer invoice type"
+        action: "create"
+        model: "customer_invoice_type"
+        save_as: "ci_type"
+        values:
+          name: "Customer Invoice Type ADMCI07"
+          code: "ADMCI07"
+          journal_id: "REC: ci_journal.id"
+          receivable_account_id: "REC: ci_account.id"
+
       - step: "Get account type ref"
         action: "ref"
         xml_id: "account.data_account_type_revenue"
@@ -162,6 +260,7 @@ scenarios:
         model: "school_admission_payment_template"
         save_as: "template"
         values:
+          customer_invoice_type_id: "REC: ci_type.id"
           name: "Template ADCFG Domain"
           code: "TPLADCFGDOM"
           product_selection_method: "domain"
@@ -197,6 +296,38 @@ scenarios:
 
   - name: "Allowed Products - Template Detail - Python Code Strategy"
     steps:
+      - step: "Setup - get customer invoice journal"
+        action: "search"
+        model: "account.journal"
+        domain: [["type", "=", "sale"]]
+        save_as: "ci_journal"
+        limit: 1
+
+      - step: "Setup - get receivable account type"
+        action: "ref"
+        xml_id: "account.data_account_type_receivable"
+        save_as: "ci_account_type"
+
+      - step: "Setup - create customer invoice receivable account"
+        action: "create"
+        model: "account.account"
+        save_as: "ci_account"
+        values:
+          name: "Customer Invoice Receivable ADMCI08"
+          code: "ADMCI08"
+          user_type_id: "REC: ci_account_type.id"
+          reconcile: true
+
+      - step: "Setup - create customer invoice type"
+        action: "create"
+        model: "customer_invoice_type"
+        save_as: "ci_type"
+        values:
+          name: "Customer Invoice Type ADMCI08"
+          code: "ADMCI08"
+          journal_id: "REC: ci_journal.id"
+          receivable_account_id: "REC: ci_account.id"
+
       - step: "Get account type ref"
         action: "ref"
         xml_id: "account.data_account_type_revenue"
@@ -230,6 +361,7 @@ scenarios:
         model: "school_admission_payment_template"
         save_as: "template"
         values:
+          customer_invoice_type_id: "REC: ci_type.id"
           name: "Template ADCFG Code"
           code: "TPLADCFGCOD"
           product_selection_method: "code"
@@ -267,6 +399,38 @@ scenarios:
 
   - name: "Allowed Products - Admission Detail - Manual Strategy"
     steps:
+      - step: "Setup - get customer invoice journal"
+        action: "search"
+        model: "account.journal"
+        domain: [["type", "=", "sale"]]
+        save_as: "ci_journal"
+        limit: 1
+
+      - step: "Setup - get receivable account type"
+        action: "ref"
+        xml_id: "account.data_account_type_receivable"
+        save_as: "ci_account_type"
+
+      - step: "Setup - create customer invoice receivable account"
+        action: "create"
+        model: "account.account"
+        save_as: "ci_account"
+        values:
+          name: "Customer Invoice Receivable ADMCI09"
+          code: "ADMCI09"
+          user_type_id: "REC: ci_account_type.id"
+          reconcile: true
+
+      - step: "Setup - create customer invoice type"
+        action: "create"
+        model: "customer_invoice_type"
+        save_as: "ci_type"
+        values:
+          name: "Customer Invoice Type ADMCI09"
+          code: "ADMCI09"
+          journal_id: "REC: ci_journal.id"
+          receivable_account_id: "REC: ci_account.id"
+
       - step: "Setup - get sale journal"
         action: "search"
         model: "account.journal"
@@ -362,6 +526,7 @@ scenarios:
         model: "school_admission_payment_template"
         save_as: "payment_template"
         values:
+          customer_invoice_type_id: "REC: ci_type.id"
           name: "Template ADCFG Adm Manual"
           code: "TPLADCFGADMMAN"
           school_id: "EVAL: registry['school'].id"
@@ -556,6 +721,38 @@ scenarios:
 
   - name: "Allowed Products - Admission Detail - Domain Strategy"
     steps:
+      - step: "Setup - get customer invoice journal"
+        action: "search"
+        model: "account.journal"
+        domain: [["type", "=", "sale"]]
+        save_as: "ci_journal"
+        limit: 1
+
+      - step: "Setup - get receivable account type"
+        action: "ref"
+        xml_id: "account.data_account_type_receivable"
+        save_as: "ci_account_type"
+
+      - step: "Setup - create customer invoice receivable account"
+        action: "create"
+        model: "account.account"
+        save_as: "ci_account"
+        values:
+          name: "Customer Invoice Receivable ADMCI10"
+          code: "ADMCI10"
+          user_type_id: "REC: ci_account_type.id"
+          reconcile: true
+
+      - step: "Setup - create customer invoice type"
+        action: "create"
+        model: "customer_invoice_type"
+        save_as: "ci_type"
+        values:
+          name: "Customer Invoice Type ADMCI10"
+          code: "ADMCI10"
+          journal_id: "REC: ci_journal.id"
+          receivable_account_id: "REC: ci_account.id"
+
       - step: "Setup - get sale journal"
         action: "search"
         model: "account.journal"
@@ -653,6 +850,7 @@ scenarios:
         model: "school_admission_payment_template"
         save_as: "payment_template"
         values:
+          customer_invoice_type_id: "REC: ci_type.id"
           name: "Template ADCFG Adm Domain"
           code: "TPLADCFGADMDOM"
           school_id: "EVAL: registry['school'].id"
@@ -715,6 +913,38 @@ scenarios:
 
   - name: "Allowed Products - Admission Detail - Python Code Strategy"
     steps:
+      - step: "Setup - get customer invoice journal"
+        action: "search"
+        model: "account.journal"
+        domain: [["type", "=", "sale"]]
+        save_as: "ci_journal"
+        limit: 1
+
+      - step: "Setup - get receivable account type"
+        action: "ref"
+        xml_id: "account.data_account_type_receivable"
+        save_as: "ci_account_type"
+
+      - step: "Setup - create customer invoice receivable account"
+        action: "create"
+        model: "account.account"
+        save_as: "ci_account"
+        values:
+          name: "Customer Invoice Receivable ADMCI11"
+          code: "ADMCI11"
+          user_type_id: "REC: ci_account_type.id"
+          reconcile: true
+
+      - step: "Setup - create customer invoice type"
+        action: "create"
+        model: "customer_invoice_type"
+        save_as: "ci_type"
+        values:
+          name: "Customer Invoice Type ADMCI11"
+          code: "ADMCI11"
+          journal_id: "REC: ci_journal.id"
+          receivable_account_id: "REC: ci_account.id"
+
       - step: "Setup - get sale journal"
         action: "search"
         model: "account.journal"
@@ -812,6 +1042,7 @@ scenarios:
         model: "school_admission_payment_template"
         save_as: "payment_template"
         values:
+          customer_invoice_type_id: "REC: ci_type.id"
           name: "Template ADCFG Adm Code"
           code: "TPLADCFGADMCOD"
           school_id: "EVAL: registry['school'].id"

--- a/ssi_school_admission/tests/test_data_admission_payment_term.yaml
+++ b/ssi_school_admission/tests/test_data_admission_payment_term.yaml
@@ -1,6 +1,38 @@
 scenarios:
   - name: "Admission Payment Term - Create and Delete Invoice"
     steps:
+      - step: "Setup - get customer invoice journal"
+        action: "search"
+        model: "account.journal"
+        domain: [["type", "=", "sale"]]
+        save_as: "ci_journal"
+        limit: 1
+
+      - step: "Setup - get receivable account type"
+        action: "ref"
+        xml_id: "account.data_account_type_receivable"
+        save_as: "ci_account_type"
+
+      - step: "Setup - create customer invoice receivable account"
+        action: "create"
+        model: "account.account"
+        save_as: "ci_account"
+        values:
+          name: "Customer Invoice Receivable ADMCI12"
+          code: "ADMCI12"
+          user_type_id: "REC: ci_account_type.id"
+          reconcile: true
+
+      - step: "Setup - create customer invoice type"
+        action: "create"
+        model: "customer_invoice_type"
+        save_as: "ci_type"
+        values:
+          name: "Customer Invoice Type ADMCI12"
+          code: "ADMCI12"
+          journal_id: "REC: ci_journal.id"
+          receivable_account_id: "REC: ci_account.id"
+
       - step: "Setup - get sale journal"
         action: "search"
         model: "account.journal"
@@ -101,6 +133,7 @@ scenarios:
         model: "school_admission_payment_template"
         save_as: "payment_template"
         values:
+          customer_invoice_type_id: "REC: ci_type.id"
           name: "Admission Payment Template ADPTDEL"
           code: "ADPTDEL001"
           school_id: "EVAL: registry['school'].id"
@@ -126,6 +159,8 @@ scenarios:
         model: "school_admission"
         save_as: "admission"
         values:
+          customer_invoice_type_id: "REC: ci_type.id"
+          receivable_account_id: "REC: ci_account.id"
           date: "2024-07-01"
           academic_year_id: "EVAL: registry['academic_year'].id"
           academic_term_id: "EVAL: registry['academic_term'].id"
@@ -193,7 +228,7 @@ scenarios:
         action: "assert"
         target: "term"
         asserts:
-          invoice_id:
+          customer_invoice_id:
             type: "value"
             operator: "is_truthy"
           state:
@@ -214,7 +249,7 @@ scenarios:
         action: "assert"
         target: "term"
         asserts:
-          invoice_id:
+          customer_invoice_id:
             type: "value"
             operator: "is_falsy"
           state:
@@ -223,6 +258,70 @@ scenarios:
 
   - name: "Admission Payment Term - Disconnect Invoice"
     steps:
+      - step: "Setup - get customer invoice journal"
+        action: "search"
+        model: "account.journal"
+        domain: [["type", "=", "sale"]]
+        save_as: "ci_journal"
+        limit: 1
+
+      - step: "Setup - get receivable account type"
+        action: "ref"
+        xml_id: "account.data_account_type_receivable"
+        save_as: "ci_account_type"
+
+      - step: "Setup - create customer invoice receivable account"
+        action: "create"
+        model: "account.account"
+        save_as: "ci_account"
+        values:
+          name: "Customer Invoice Receivable ADMCI14"
+          code: "ADMCI14"
+          user_type_id: "REC: ci_account_type.id"
+          reconcile: true
+
+      - step: "Setup - create customer invoice type"
+        action: "create"
+        model: "customer_invoice_type"
+        save_as: "ci_type"
+        values:
+          name: "Customer Invoice Type ADMCI14"
+          code: "ADMCI14"
+          journal_id: "REC: ci_journal.id"
+          receivable_account_id: "REC: ci_account.id"
+
+      - step: "Setup - get customer invoice journal"
+        action: "search"
+        model: "account.journal"
+        domain: [["type", "=", "sale"]]
+        save_as: "ci_journal"
+        limit: 1
+
+      - step: "Setup - get receivable account type"
+        action: "ref"
+        xml_id: "account.data_account_type_receivable"
+        save_as: "ci_account_type"
+
+      - step: "Setup - create customer invoice receivable account"
+        action: "create"
+        model: "account.account"
+        save_as: "ci_account"
+        values:
+          name: "Customer Invoice Receivable ADMCI13"
+          code: "ADMCI13"
+          user_type_id: "REC: ci_account_type.id"
+          reconcile: true
+
+      - step: "Setup - create customer invoice type"
+        action: "create"
+        model: "customer_invoice_type"
+        save_as: "ci_type"
+        values:
+          name: "Customer Invoice Type ADMCI13"
+          code: "ADMCI13"
+          journal_id: "REC: ci_journal.id"
+          receivable_account_id: "REC: ci_account.id"
+
       - step: "Setup - get sale journal"
         action: "search"
         model: "account.journal"
@@ -323,6 +422,7 @@ scenarios:
         model: "school_admission_payment_template"
         save_as: "payment_template"
         values:
+          customer_invoice_type_id: "REC: ci_type.id"
           name: "Admission Payment Template ADPTDC"
           code: "ADPTDC001"
           school_id: "EVAL: registry['school'].id"
@@ -348,6 +448,8 @@ scenarios:
         model: "school_admission"
         save_as: "admission"
         values:
+          customer_invoice_type_id: "REC: ci_type.id"
+          receivable_account_id: "REC: ci_account.id"
           date: "2024-07-01"
           academic_year_id: "EVAL: registry['academic_year'].id"
           academic_term_id: "EVAL: registry['academic_term'].id"
@@ -403,7 +505,7 @@ scenarios:
         action: "assert"
         target: "term"
         asserts:
-          invoice_id:
+          customer_invoice_id:
             type: "value"
             operator: "is_truthy"
 
@@ -421,7 +523,7 @@ scenarios:
         action: "assert"
         target: "term"
         asserts:
-          invoice_id:
+          customer_invoice_id:
             type: "value"
             operator: "is_falsy"
           state:
@@ -430,6 +532,70 @@ scenarios:
 
   - name: "Admission Payment Term - Mark and Unmark as Manual"
     steps:
+      - step: "Setup - get customer invoice journal"
+        action: "search"
+        model: "account.journal"
+        domain: [["type", "=", "sale"]]
+        save_as: "ci_journal"
+        limit: 1
+
+      - step: "Setup - get receivable account type"
+        action: "ref"
+        xml_id: "account.data_account_type_receivable"
+        save_as: "ci_account_type"
+
+      - step: "Setup - create customer invoice receivable account"
+        action: "create"
+        model: "account.account"
+        save_as: "ci_account"
+        values:
+          name: "Customer Invoice Receivable ADMCI16"
+          code: "ADMCI16"
+          user_type_id: "REC: ci_account_type.id"
+          reconcile: true
+
+      - step: "Setup - create customer invoice type"
+        action: "create"
+        model: "customer_invoice_type"
+        save_as: "ci_type"
+        values:
+          name: "Customer Invoice Type ADMCI16"
+          code: "ADMCI16"
+          journal_id: "REC: ci_journal.id"
+          receivable_account_id: "REC: ci_account.id"
+
+      - step: "Setup - get customer invoice journal"
+        action: "search"
+        model: "account.journal"
+        domain: [["type", "=", "sale"]]
+        save_as: "ci_journal"
+        limit: 1
+
+      - step: "Setup - get receivable account type"
+        action: "ref"
+        xml_id: "account.data_account_type_receivable"
+        save_as: "ci_account_type"
+
+      - step: "Setup - create customer invoice receivable account"
+        action: "create"
+        model: "account.account"
+        save_as: "ci_account"
+        values:
+          name: "Customer Invoice Receivable ADMCI15"
+          code: "ADMCI15"
+          user_type_id: "REC: ci_account_type.id"
+          reconcile: true
+
+      - step: "Setup - create customer invoice type"
+        action: "create"
+        model: "customer_invoice_type"
+        save_as: "ci_type"
+        values:
+          name: "Customer Invoice Type ADMCI15"
+          code: "ADMCI15"
+          journal_id: "REC: ci_journal.id"
+          receivable_account_id: "REC: ci_account.id"
+
       - step: "Setup - get sale journal"
         action: "search"
         model: "account.journal"
@@ -530,6 +696,7 @@ scenarios:
         model: "school_admission_payment_template"
         save_as: "payment_template"
         values:
+          customer_invoice_type_id: "REC: ci_type.id"
           name: "Admission Payment Template ADPTMM"
           code: "ADPTMM001"
           school_id: "EVAL: registry['school'].id"
@@ -555,6 +722,8 @@ scenarios:
         model: "school_admission"
         save_as: "admission"
         values:
+          customer_invoice_type_id: "REC: ci_type.id"
+          receivable_account_id: "REC: ci_account.id"
           date: "2024-07-01"
           academic_year_id: "EVAL: registry['academic_year'].id"
           academic_term_id: "EVAL: registry['academic_term'].id"

--- a/ssi_school_admission/tests/test_data_admission_payment_term_duplicate.yaml
+++ b/ssi_school_admission/tests/test_data_admission_payment_term_duplicate.yaml
@@ -1,6 +1,38 @@
 scenarios:
   - name: "Admission Payment Term - Duplicate via Wizard"
     steps:
+      - step: "Setup - get customer invoice journal"
+        action: "search"
+        model: "account.journal"
+        domain: [["type", "=", "sale"]]
+        save_as: "ci_journal"
+        limit: 1
+
+      - step: "Setup - get receivable account type"
+        action: "ref"
+        xml_id: "account.data_account_type_receivable"
+        save_as: "ci_account_type"
+
+      - step: "Setup - create customer invoice receivable account"
+        action: "create"
+        model: "account.account"
+        save_as: "ci_account"
+        values:
+          name: "Customer Invoice Receivable ADMCI24"
+          code: "ADMCI24"
+          user_type_id: "REC: ci_account_type.id"
+          reconcile: true
+
+      - step: "Setup - create customer invoice type"
+        action: "create"
+        model: "customer_invoice_type"
+        save_as: "ci_type"
+        values:
+          name: "Customer Invoice Type ADMCI24"
+          code: "ADMCI24"
+          journal_id: "REC: ci_journal.id"
+          receivable_account_id: "REC: ci_account.id"
+
       - step: "Setup - get receivable journal"
         action: "search"
         model: "account.journal"
@@ -110,6 +142,8 @@ scenarios:
         model: "school_admission"
         save_as: "admission"
         values:
+          customer_invoice_type_id: "REC: ci_type.id"
+          receivable_account_id: "REC: ci_account.id"
           date: "2024-07-01"
           academic_year_id: "EVAL: registry['academic_year'].id"
           academic_term_id: "EVAL: registry['academic_term'].id"
@@ -167,7 +201,7 @@ scenarios:
         action: "assert"
         target: "term"
         asserts:
-          invoice_id:
+          customer_invoice_id:
             type: "value"
             operator: "is_truthy"
 
@@ -212,7 +246,7 @@ scenarios:
           date_due:
             type: "value"
             expected: 2024-09-15
-          invoice_id:
+          customer_invoice_id:
             type: "value"
             operator: "is_falsy"
           detail_ids:
@@ -242,7 +276,7 @@ scenarios:
           uom_quantity:
             type: "value"
             expected: 1.0
-          invoice_line_id:
+          customer_invoice_line_id:
             type: "value"
             operator: "is_falsy"
 
@@ -268,7 +302,7 @@ scenarios:
           uom_quantity:
             type: "value"
             expected: 1.0
-          invoice_line_id:
+          customer_invoice_line_id:
             type: "value"
             operator: "is_falsy"
 

--- a/ssi_school_admission/tests/test_school_admission.py
+++ b/ssi_school_admission/tests/test_school_admission.py
@@ -44,6 +44,14 @@ class TestSchoolAdmissionWorkflow(
                 "type_id": grade_type.id,
             }
         )
+        customer_invoice_type = self.env["customer_invoice_type"].create(
+            {
+                "name": "Customer Invoice Type Onchange",
+                "code": "ADMCITONC1",
+                "journal_id": journal.id,
+                "receivable_account_id": account.id,
+            }
+        )
         template = self.env["school_admission_payment_template"].create(
             {
                 "name": "Admission Payment Template Onchange",
@@ -52,6 +60,7 @@ class TestSchoolAdmissionWorkflow(
                 "grade_id": grade.id,
                 "receivable_journal_id": journal.id,
                 "receivable_account_id": account.id,
+                "customer_invoice_type_id": customer_invoice_type.id,
             }
         )
         return template, journal, account

--- a/ssi_school_admission/tests/test_school_admission_customer_invoice.py
+++ b/ssi_school_admission/tests/test_school_admission_customer_invoice.py
@@ -1,0 +1,16 @@
+# Copyright 2026 OpenSynergy Indonesia
+# Copyright 2026 PT. Simetri Sinergi Indonesia
+# License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl).
+
+from odoo_yaml_test import YamlTransactionCase
+
+from odoo.tests import tagged
+
+
+@tagged("post_install", "-at_install")
+class TestSchoolAdmissionCustomerInvoice(YamlTransactionCase):
+    """Customer invoice generated from admission payment terms."""
+
+    def test_admission_customer_invoice(self):
+        """Create, auto confirm, disconnect and delete the customer invoice."""
+        self.run_yaml_scenario("test_data_admission_customer_invoice.yaml")

--- a/ssi_school_admission/tests/test_school_admission_restart_unlock.py
+++ b/ssi_school_admission/tests/test_school_admission_restart_unlock.py
@@ -14,6 +14,7 @@ class TestSchoolAdmissionRestartUnlock(YamlTransactionCase):
         self.run_yaml_scenario("test_data_admission_restart_unlock.yaml")
 
     def _create_base_data(self, suffix):
+        """Build the shared master data used by every scenario here."""
         account_type = self.env.ref("account.data_account_type_revenue")
         account = self.env["account.account"].create(
             {
@@ -70,6 +71,23 @@ class TestSchoolAdmissionRestartUnlock(YamlTransactionCase):
             }
         )
         journal = self.env["account.journal"].search([("type", "=", "sale")], limit=1)
+        receivable_type = self.env.ref("account.data_account_type_receivable")
+        receivable_account = self.env["account.account"].create(
+            {
+                "name": "Admission Receivable %s" % suffix,
+                "code": "ADRSTUNLK%s1100" % suffix,
+                "user_type_id": receivable_type.id,
+                "reconcile": True,
+            }
+        )
+        customer_invoice_type = self.env["customer_invoice_type"].create(
+            {
+                "name": "Customer Invoice Type %s" % suffix,
+                "code": "ADCIT%s" % suffix,
+                "journal_id": journal.id,
+                "receivable_account_id": receivable_account.id,
+            }
+        )
         return {
             "account": account,
             "product": product,
@@ -78,9 +96,12 @@ class TestSchoolAdmissionRestartUnlock(YamlTransactionCase):
             "school": school,
             "grade": grade,
             "journal": journal,
+            "receivable_account": receivable_account,
+            "customer_invoice_type": customer_invoice_type,
         }
 
     def _create_admission(self, base, name_suffix):
+        """Create an admission wired to the customer invoice fixtures."""
         student_contact = self.env["res.partner"].create(
             {"name": "Student Contact %s" % name_suffix}
         )
@@ -92,9 +113,11 @@ class TestSchoolAdmissionRestartUnlock(YamlTransactionCase):
                 "school_id": base["school"].id,
                 "grade_id": base["grade"].id,
                 "student_id": student_contact.id,
-                "pricelist_id": False,
+                "pricelist_id": self.env.ref("product.list0").id,
                 "currency_id": self.env.company.currency_id.id,
                 "receivable_journal_id": base["journal"].id,
+                "receivable_account_id": base["receivable_account"].id,
+                "customer_invoice_type_id": base["customer_invoice_type"].id,
             }
         )
 
@@ -182,7 +205,7 @@ class TestSchoolAdmissionRestartUnlock(YamlTransactionCase):
 
         term.action_create_invoice()
         term.invalidate_cache()
-        self.assertTrue(term.invoice_id)
+        self.assertTrue(term.customer_invoice_id)
 
         admission.invalidate_cache()
         self.assertFalse(admission.cancel_ok)
@@ -193,7 +216,7 @@ class TestSchoolAdmissionRestartUnlock(YamlTransactionCase):
 
         term.action_delete_invoice()
         term.invalidate_cache()
-        self.assertFalse(term.invoice_id)
+        self.assertFalse(term.customer_invoice_id)
 
         admission.invalidate_cache()
         self.assertTrue(admission.cancel_ok)

--- a/ssi_school_admission/views/school_admission.xml
+++ b/ssi_school_admission/views/school_admission.xml
@@ -171,7 +171,7 @@
                             <field name="amount_untaxed" />
                             <field name="amount_tax" />
                             <field name="amount_total" />
-                            <field name="invoice_id" />
+                            <field name="customer_invoice_id" />
                             <field name="state" />
                             <button
                                     name="action_create_invoice"
@@ -237,6 +237,8 @@
                     <group name="accounting_group" colspan="4" col="2">
                         <field name="receivable_journal_id" />
                         <field name="receivable_account_id" />
+                        <field name="customer_invoice_type_id" />
+                        <field name="auto_confirm_customer_invoice" />
                     </group>
                 </page>
                 <page name="admission_source" string="Admission Source">

--- a/ssi_school_admission/views/school_admission_payment_template.xml
+++ b/ssi_school_admission/views/school_admission_payment_template.xml
@@ -70,6 +70,8 @@
                 <field name="grade_type_id" invisible="1" />
                 <field name="receivable_journal_id" />
                 <field name="receivable_account_id" />
+                <field name="customer_invoice_type_id" />
+                <field name="auto_confirm_customer_invoice" />
             </xpath>
             <xpath expr="//page[1]" position="before">
                 <page name="payment_terms" string="Payment Terms">

--- a/ssi_school_admission/views/school_admission_payment_term.xml
+++ b/ssi_school_admission/views/school_admission_payment_term.xml
@@ -44,7 +44,7 @@
             <field name="amount_untaxed" />
             <field name="amount_tax" />
             <field name="amount_total" />
-            <field name="invoice_id" />
+            <field name="customer_invoice_id" />
             <field name="state" />
             <button
                     name="action_create_invoice"
@@ -122,7 +122,7 @@
                                 attrs="{'readonly': [('locked','=',True)]}"
                             />
                         <field name="state" />
-                        <field name="invoice_id" />
+                        <field name="customer_invoice_id" />
                         <field name="currency_id" invisible="1" />
                         <field name="locked" invisible="1" />
                         <field name="admission_state" invisible="1" />

--- a/ssi_school_admission/wizards/school_admission_copy_payment_term.py
+++ b/ssi_school_admission/wizards/school_admission_copy_payment_term.py
@@ -90,10 +90,10 @@ Solution: Select at least one draft admission from the list view before running 
                 new_term = term.copy(
                     {
                         "admission_id": target.id,
-                        "invoice_id": False,
+                        "customer_invoice_id": False,
                     }
                 )
-                new_term.detail_ids.write({"invoice_line_id": False})
+                new_term.detail_ids.write({"customer_invoice_line_id": False})
 
     def _check_target_admissions(self):
         self.ensure_one()

--- a/ssi_school_admission/wizards/school_admission_payment_term_duplicate.py
+++ b/ssi_school_admission/wizards/school_admission_payment_term_duplicate.py
@@ -67,7 +67,7 @@ class SchoolAdmissionPaymentTermWizardDuplicate(models.TransientModel):
     def _duplicate_term(self):
         self.ensure_one()
         new_term = self.term_id.copy(self._prepare_duplicate_defaults())
-        new_term.detail_ids.write({"invoice_line_id": False})
+        new_term.detail_ids.write({"customer_invoice_line_id": False})
         return {"type": "ir.actions.act_window_close"}
 
     def _prepare_duplicate_defaults(self):
@@ -77,5 +77,5 @@ class SchoolAdmissionPaymentTermWizardDuplicate(models.TransientModel):
             "sequence": self.sequence,
             "date_invoice": self.date_invoice,
             "date_due": self.date_due,
-            "invoice_id": False,
+            "customer_invoice_id": False,
         }

--- a/ssi_school_admission_operating_unit/__manifest__.py
+++ b/ssi_school_admission_operating_unit/__manifest__.py
@@ -18,6 +18,7 @@
         "ssi_school_admission",
         "ssi_operating_unit_mixin",
         "ssi_financial_accounting_operating_unit",
+        "ssi_customer_invoice_operating_unit",
     ],
     "data": [
         "security/res_groups/school_admission.xml",

--- a/ssi_school_admission_operating_unit/models/school_admission_payment_term.py
+++ b/ssi_school_admission_operating_unit/models/school_admission_payment_term.py
@@ -8,13 +8,18 @@ from odoo import models
 class SchoolAdmissionPaymentTerm(models.Model):
     """
     Extends School Admission Payment Term to propagate
-    operating_unit_id from the parent admission to the generated invoice.
+    operating_unit_id from the parent admission to the generated
+    customer invoice.
     """
 
     _name = "school_admission_payment_term"
     _inherit = "school_admission_payment_term"
 
     def _prepare_invoice_data(self):
+        """Add the admission operating unit to the customer invoice.
+
+        :return: dict of ``customer_invoice`` values
+        """
         res = super()._prepare_invoice_data()
         res["operating_unit_id"] = self.admission_id.operating_unit_id.id
         return res

--- a/ssi_school_lead/tests/test_data_school_lead.yaml
+++ b/ssi_school_lead/tests/test_data_school_lead.yaml
@@ -302,11 +302,44 @@ scenarios:
           sequence: 10
           type_id: "EVAL: registry['grade_type'].id"
 
+      - step: "Setup - get customer invoice journal"
+        action: "search"
+        model: "account.journal"
+        domain: [["type", "=", "sale"]]
+        save_as: "ci_journal"
+        limit: 1
+
+      - step: "Setup - get receivable account type"
+        action: "ref"
+        xml_id: "account.data_account_type_receivable"
+        save_as: "ci_account_type"
+
+      - step: "Setup - create customer invoice receivable account"
+        action: "create"
+        model: "account.account"
+        save_as: "ci_account"
+        values:
+          name: "Customer Invoice Receivable SLPT"
+          code: "CIRECSLPT"
+          user_type_id: "REC: ci_account_type.id"
+          reconcile: true
+
+      - step: "Setup - create customer invoice type"
+        action: "create"
+        model: "customer_invoice_type"
+        save_as: "ci_type"
+        values:
+          name: "Customer Invoice Type SLPT"
+          code: "CITSLPT"
+          journal_id: "REC: ci_journal.id"
+          receivable_account_id: "REC: ci_account.id"
+
       - step: "Create payment template with term and detail"
         action: "create"
         model: "school_admission_payment_template"
         save_as: "payment_template"
         values:
+          customer_invoice_type_id: "REC: ci_type.id"
           name: "Payment Template SLPT"
           code: "PTSLPT"
           school_id: "EVAL: registry['school'].id"

--- a/ssi_school_lead/tests/test_school_lead.py
+++ b/ssi_school_lead/tests/test_school_lead.py
@@ -13,6 +13,30 @@ class TestSchoolLead(YamlTransactionCase):
     def test_school_lead(self):
         self.run_yaml_scenario("test_data_school_lead.yaml")
 
+    def _create_customer_invoice_type(self, suffix):
+        """Create the customer invoice type required by a payment template.
+
+        :param suffix: unique suffix used to build the record name/code
+        :return: the created ``customer_invoice_type`` record
+        """
+        journal = self.env["account.journal"].search([("type", "=", "sale")], limit=1)
+        account = self.env["account.account"].create(
+            {
+                "name": "Customer Invoice Receivable %s" % suffix,
+                "code": "CIREC%s" % suffix,
+                "user_type_id": self.env.ref("account.data_account_type_receivable").id,
+                "reconcile": True,
+            }
+        )
+        return self.env["customer_invoice_type"].create(
+            {
+                "name": "Customer Invoice Type %s" % suffix,
+                "code": "CIT%s" % suffix,
+                "journal_id": journal.id,
+                "receivable_account_id": account.id,
+            }
+        )
+
     def test_onchange_payment_template_id_auto_populates(self):
         """payment_template_id should auto-populate when school, grade, and term match."""
         year = self.env["school_academic_year"].create(
@@ -54,6 +78,7 @@ class TestSchoolLead(YamlTransactionCase):
                 "school_id": school.id,
                 "grade_id": grade.id,
                 "academic_term_id": term.id,
+                "customer_invoice_type_id": self._create_customer_invoice_type("OC").id,
             }
         )
         student = self.env["res.partner"].create({"name": "Student OC"})
@@ -120,6 +145,9 @@ class TestSchoolLead(YamlTransactionCase):
                 "school_id": school_a.id,
                 "grade_id": grade.id,
                 "academic_term_id": term.id,
+                "customer_invoice_type_id": self._create_customer_invoice_type(
+                    "OC2"
+                ).id,
             }
         )
         student = self.env["res.partner"].create({"name": "Student OC2"})
@@ -196,6 +224,9 @@ class TestSchoolLead(YamlTransactionCase):
                 "academic_term_id": term.id,
                 "receivable_journal_id": journal.id,
                 "receivable_account_id": account.id,
+                "customer_invoice_type_id": self._create_customer_invoice_type(
+                    "OC3"
+                ).id,
             }
         )
         student = self.env["res.partner"].create({"name": "Student OC3"})


### PR DESCRIPTION
Ganti target invoice payment term admission dari `account.move` ke dokumen transaksional `customer_invoice` (modul `ssi_customer_invoice`), kembar dengan perubahan payment term enrollment di PR #177.

## ssi_school_admission

* Rename field: `school_admission_payment_term.invoice_id` → `customer_invoice_id` (comodel `customer_invoice`) dan `school_admission_payment_term_detail.invoice_line_id` → `customer_invoice_line_id` (comodel `customer_invoice.line`).
* Tambah field konfigurasi `customer_invoice_type_id` (wajib) dan `auto_confirm_customer_invoice` pada `school_admission_payment_template`, beserta pasangannya di `school_admission` lengkap dengan onchange terpisah per field.
* Tulis ulang `_prepare_invoice_data`, `_prepare_invoice_line`, `_create_invoice`, dan `_delete_invoice`; `_delete_invoice` kini menolak dokumen non-draft dengan `UserError` terstruktur dan mengarahkan ke `action_disconnect_invoice`.
* Sesuaikan policy template cancel, wizard copy & duplicate payment term, view terkait, serta data demo.
* Tambah dependensi `ssi_customer_invoice` pada manifest.
* Perbarui skenario uji existing ke nama field baru dan tambah skenario uji baru `test_data_admission_customer_invoice.yaml`.

## ssi_school_admission_operating_unit

* Tambah dependensi `ssi_customer_invoice_operating_unit` agar operating unit ikut terisi pada dokumen `customer_invoice` yang dihasilkan payment term.

Closes #176