### PR TITLE
[UPD] ssi_school_lead: tambahkan label Parent Address pada blok alamat form crm.lead

### DIFF
--- a/ssi_school_lead/views/crm_lead_views.xml
+++ b/ssi_school_lead/views/crm_lead_views.xml
@@ -21,6 +21,7 @@
                         name="school_lead_parent_contact"
                         string="Parent/Guardian Contact"
                     >
+                    <label for="parent_street" string="Parent Address" />
                     <div class="o_address_format">
                         <field
                                 name="parent_street"


### PR DESCRIPTION
## Ringkasan

Menambahkan elemen `<label for="parent_street" string="Parent Address"/>` pada view form `crm.lead` (`ssi_school_lead`), tepat sebelum `<div class="o_address_format">` di dalam grup `school_lead_parent_contact` yang sudah ada. Mengikuti pola label alamat baku `res.partner` (`base.view_partner_form`).

- Tidak ada perubahan model/field.
- `string` grup `school_lead_parent_contact` tetap `"Parent/Guardian Contact"`.
- XML ID `crm_lead_school_form_view` tidak berubah.
- Tidak ada perubahan Python/security/manifest.

Closes #185

## Test plan

- [x] View XML valid (divalidasi via pre-commit `oca-checks-odoo-module` / `Check Xml`)
- [ ] CI: update `ssi_school_lead` berhasil, seluruh test yang ada tetap hijau