### PR TITLE
[UPD] ssi_school_lead: tambah field student_nickname pada crm.lead

### DIFF
--- a/ssi_school_admission_lead/tests/test_crm_lead_view_architecture.py
+++ b/ssi_school_admission_lead/tests/test_crm_lead_view_architecture.py
@@ -42,12 +42,13 @@ class TestCrmLeadViewArchitecture(YamlTransactionCase):
                 "nationality_id",
                 "allowed_previous_school_ids",
                 "previous_school_id",
+                "student_nickname",
                 "parent_relationship",
             ],
             "Prospective Student group should list student_id, student_birthdate, "
             "student_gender, birth_city, religion_id, nationality_id, "
-            "allowed_previous_school_ids, previous_school_id, parent_relationship "
-            "in that order",
+            "allowed_previous_school_ids, previous_school_id, student_nickname, "
+            "parent_relationship in that order",
         )
         previous_school_id_field = group.xpath(".//field[@name='previous_school_id']")[
             0

--- a/ssi_school_lead/models/crm_lead.py
+++ b/ssi_school_lead/models/crm_lead.py
@@ -123,6 +123,16 @@ class CrmLead(models.Model):
         readonly=False,
         help="Email address of the parent/guardian, mirrored from their contact record.",
     )
+    student_nickname = fields.Char(
+        string="Student Nickname",
+        related="student_id.nickname",
+        store=True,
+        readonly=False,
+        compute_sudo=True,
+        help="Nickname of the prospective student, synchronized from the "
+        "contact referenced by the Student field. Writing this field "
+        "updates that contact's nickname.",
+    )
 
     @api.depends("admission_id")
     def _compute_create_admission_ok(self):

--- a/ssi_school_lead/tests/__init__.py
+++ b/ssi_school_lead/tests/__init__.py
@@ -5,3 +5,4 @@
 from . import test_school_lead  # noqa: F401
 from . import test_crm_lead_parent_contact  # noqa: F401
 from . import test_crm_lead_student_family_link  # noqa: F401
+from . import test_crm_lead_student_nickname  # noqa: F401

--- a/ssi_school_lead/tests/test_crm_lead_student_nickname.py
+++ b/ssi_school_lead/tests/test_crm_lead_student_nickname.py
@@ -1,0 +1,33 @@
+# Copyright 2024 OpenSynergy Indonesia
+# Copyright 2024 PT. Simetri Sinergi Indonesia
+# License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl).
+
+from odoo_yaml_test import YamlTransactionCase
+
+from odoo.tests import tagged
+
+
+@tagged("post_install", "-at_install")
+class TestCrmLeadStudentNickname(YamlTransactionCase):
+    """Test the ``student_nickname`` related field on ``crm.lead``."""
+
+    def test_crm_lead_student_nickname(self):
+        """Run the YAML scenarios covering ``student_nickname`` sync."""
+        self.run_yaml_scenario("test_data_crm_lead_student_nickname.yaml")
+
+    def test_student_nickname_is_not_readonly(self):
+        """Python murni — pemicu P1 (L-01: `fields_get()` mengembalikan dict,
+
+        YAML tidak bisa meng-assert nilai balik method).
+
+        Related field ``store=True`` bawaan Odoo di-set ``readonly=True``
+        secara default (``odoo/fields.py`` - ``Field._setup_attrs``); test
+        ini memverifikasi ``student_nickname`` sudah diberi
+        ``readonly=False`` eksplisit sehingga dapat diedit dari form
+        ``crm.lead``.
+        """
+        fields_info = self.env["crm.lead"].fields_get(["student_nickname"])
+        self.assertFalse(
+            fields_info["student_nickname"]["readonly"],
+            "Field student_nickname should not be readonly",
+        )

--- a/ssi_school_lead/tests/test_data_crm_lead_student_nickname.yaml
+++ b/ssi_school_lead/tests/test_data_crm_lead_student_nickname.yaml
@@ -1,0 +1,221 @@
+options:
+  auto_refresh: true
+
+scenarios:
+  - name: "CRM Lead Student Nickname - Create mirrors student nickname"
+    steps:
+      - step: "Create student partner with nickname"
+        action: "create"
+        model: "res.partner"
+        save_as: "student"
+        values:
+          name: "Student Nickname Full SN1"
+          nickname: "Budi"
+
+      - step: "Create CRM lead with student_id"
+        action: "create"
+        model: "crm.lead"
+        save_as: "lead"
+        as_user: "base.user_admin"
+        values:
+          name: "Lead Student Nickname Full SN1"
+          student_id: "REC: student.id"
+
+      - step: "Assert student_nickname mirrors student partner nickname"
+        action: "assert"
+        target: "lead"
+        asserts:
+          student_nickname:
+            type: "value"
+            expected: "Budi"
+
+  - name: "CRM Lead Student Nickname - Write on lead writes through to student"
+    steps:
+      - step: "Create student partner with initial nickname"
+        action: "create"
+        model: "res.partner"
+        save_as: "student"
+        values:
+          name: "Student Nickname Write-Through SN2"
+          nickname: "Old Nick"
+
+      - step: "Create CRM lead with student_id"
+        action: "create"
+        model: "crm.lead"
+        save_as: "lead"
+        as_user: "base.user_admin"
+        values:
+          name: "Lead Student Nickname Write-Through SN2"
+          student_id: "REC: student.id"
+
+      - step: "Write new student_nickname value on the lead"
+        action: "write"
+        target: "lead"
+        values:
+          student_nickname: "New Nick"
+
+      - step: "Assert student_nickname on lead is updated"
+        action: "assert"
+        target: "lead"
+        asserts:
+          student_nickname:
+            type: "value"
+            expected: "New Nick"
+
+      - step: "Assert student_id.nickname is updated by the related inverse"
+        action: "assert"
+        target: "student"
+        asserts:
+          nickname:
+            type: "value"
+            expected: "New Nick"
+
+  - name: "CRM Lead Student Nickname - Propagates when student partner is updated"
+    steps:
+      - step: "Create student partner with initial nickname"
+        action: "create"
+        model: "res.partner"
+        save_as: "student"
+        values:
+          name: "Student Nickname Propagation SN3"
+          nickname: "First Nick"
+
+      - step: "Create CRM lead with student_id"
+        action: "create"
+        model: "crm.lead"
+        save_as: "lead"
+        as_user: "base.user_admin"
+        values:
+          name: "Lead Student Nickname Propagation SN3"
+          student_id: "REC: student.id"
+
+      - step: "Assert student_nickname mirrors initial student partner nickname"
+        action: "assert"
+        target: "lead"
+        asserts:
+          student_nickname:
+            type: "value"
+            expected: "First Nick"
+
+      - step: "Update student partner nickname"
+        action: "write"
+        target: "student"
+        values:
+          nickname: "Updated Nick"
+
+      - step: "Assert student_nickname on lead follows updated student value"
+        action: "assert"
+        target: "lead"
+        asserts:
+          student_nickname:
+            type: "value"
+            expected: "Updated Nick"
+
+  - name: "CRM Lead Student Nickname - Propagates when student_id is changed"
+    steps:
+      - step: "Create first student partner"
+        action: "create"
+        model: "res.partner"
+        save_as: "student_a"
+        values:
+          name: "Student Nickname A SN4"
+          nickname: "Nick A"
+
+      - step: "Create second student partner with different nickname"
+        action: "create"
+        model: "res.partner"
+        save_as: "student_b"
+        values:
+          name: "Student Nickname B SN4"
+          nickname: "Nick B"
+
+      - step: "Create CRM lead with first student_id"
+        action: "create"
+        model: "crm.lead"
+        save_as: "lead"
+        as_user: "base.user_admin"
+        values:
+          name: "Lead Student Nickname Change Student SN4"
+          student_id: "REC: student_a.id"
+
+      - step: "Assert student_nickname mirrors first student"
+        action: "assert"
+        target: "lead"
+        asserts:
+          student_nickname:
+            type: "value"
+            expected: "Nick A"
+
+      - step: "Change lead student_id to second student"
+        action: "write"
+        target: "lead"
+        values:
+          student_id: "REC: student_b.id"
+
+      - step: "Assert student_nickname now mirrors second student"
+        action: "assert"
+        target: "lead"
+        asserts:
+          student_nickname:
+            type: "value"
+            expected: "Nick B"
+
+  - name: "CRM Lead Student Nickname - Negative, no student_id"
+    steps:
+      - step: "Create CRM lead without student_id"
+        action: "create"
+        model: "crm.lead"
+        save_as: "lead"
+        as_user: "base.user_admin"
+        values:
+          name: "Lead Student Nickname No Student SN5"
+
+      - step: "Assert lead was created successfully"
+        action: "assert"
+        target: "lead"
+        asserts:
+          id:
+            type: "value"
+            operator: "is_truthy"
+
+      - step: "Assert student_nickname is falsy"
+        action: "assert"
+        target: "lead"
+        asserts:
+          student_nickname:
+            type: "value"
+            operator: "is_falsy"
+
+  - name: "CRM Lead Student Nickname - Negative, student without nickname"
+    steps:
+      - step: "Create student partner without nickname"
+        action: "create"
+        model: "res.partner"
+        save_as: "student"
+        values:
+          name: "Student Nickname Empty SN6"
+
+      - step: "Create CRM lead with student having empty nickname"
+        action: "create"
+        model: "crm.lead"
+        save_as: "lead"
+        as_user: "base.user_admin"
+        values:
+          name: "Lead Student Nickname Empty Student SN6"
+          student_id: "REC: student.id"
+
+      - step: "Assert lead was created successfully"
+        action: "assert"
+        target: "lead"
+        asserts:
+          id:
+            type: "value"
+            operator: "is_truthy"
+
+      - step: "Assert student_nickname is falsy, not an error"
+        action: "assert"
+        target: "lead"
+        asserts:
+          student_nickname:
+            type: "value"
+            operator: "is_falsy"

--- a/ssi_school_lead/views/crm_lead_views.xml
+++ b/ssi_school_lead/views/crm_lead_views.xml
@@ -66,6 +66,7 @@
                         string="Prospective Student"
                     >
                     <field name="student_id" />
+                    <field name="student_nickname" />
                     <field name="parent_relationship" />
                 </group>
                 <group name="school_lead_admission_target" string="Admission Target">


### PR DESCRIPTION
## Ringkasan

Menambahkan field `student_nickname` pada `crm.lead` (modul `ssi_school_lead`) yang
`related` ke `student_id.nickname`, sehingga nama panggilan calon siswa dapat dilihat
dan diedit langsung dari form lead, tersinkron dua arah dengan record kontak siswa
(`res.partner`).

* Field baru: `student_nickname` (`Char`, `related="student_id.nickname"`,
  `store=True`, `readonly=False`, `compute_sudo=True`) di `models/crm_lead.py`.
* Ditampilkan di grup `school_lead_prospective_student` pada
  `views/crm_lead_views.xml`.
* Unit test `odoo-yaml-test` baru: `tests/test_crm_lead_student_nickname.py` +
  `tests/test_data_crm_lead_student_nickname.yaml`, mencakup sinkronisasi
  bidirectional, propagasi saat partner diubah, perpindahan `student_id`, dan
  skenario negatif. Ditambah satu test Python murni (`P1`/`L-01`) yang
  memverifikasi field tidak `readonly` lewat `fields_get`.
* Tidak ada perubahan `__manifest__.py` (dependency `ssi_partner` sudah ada,
  `version` tidak disentuh) maupun security/ACL/onchange/constrains.

Closes #188