### PR TITLE
[UPD] Sembunyikan enrollment_ids & admission_ids di wizard invoice export

### DIFF
--- a/ssi_school_admission_customer_invoice_export/tests/test_school_admission_create_invoice_export.py
+++ b/ssi_school_admission_customer_invoice_export/tests/test_school_admission_create_invoice_export.py
@@ -2,6 +2,7 @@
 # Copyright 2026 PT. Simetri Sinergi Indonesia
 # License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl).
 
+from lxml import etree
 from odoo_yaml_test import YamlTransactionCase
 
 from odoo.tests import tagged
@@ -9,5 +10,66 @@ from odoo.tests import tagged
 
 @tagged("post_install", "-at_install")
 class TestSchoolAdmissionCreateInvoiceExport(YamlTransactionCase):
+    """Cover ``school_admission.wizard_create_invoice_export``.
+
+    Exercises both the YAML behavior scenario (wizard action) and the
+    Python-only wizard form arch assertions below.
+    """
+
     def test_school_admission_create_invoice_export(self):
+        """Run the create-invoice-export wizard scenario."""
         self.run_yaml_scenario("test_data_admission_create_invoice_export.yaml")
+
+    def test_admission_ids_field_is_invisible_without_widget(self):
+        """Assert the source field is hidden but stays in the arch.
+
+        Pure Python test, trigger P1 (L-01/L-02): the arch dict returned
+        by ``fields_view_get()`` is not a surface the ``odoo-yaml-test``
+        DSL can read (``action: call`` discards the return value), and
+        the YAML ``assert`` block only supports dotted ``getattr`` on
+        registry records, never expressions over the view arch XML.
+
+        ``admission_ids`` must stay in the wizard form arch as a
+        machine-only field (``invisible="1"``), without
+        ``widget="many2many_tags"``.
+        """
+        model = self.env["school_admission.wizard_create_invoice_export"]
+        result = model.fields_view_get(view_type="form")
+        arch = etree.fromstring(result["arch"])
+
+        field = arch.find(".//field[@name='admission_ids']")
+        self.assertIsNotNone(field, "admission_ids field not found in arch")
+        self.assertEqual(field.get("invisible"), "1")
+        self.assertIsNone(
+            field.get("widget"),
+            "admission_ids should no longer carry widget=many2many_tags",
+        )
+
+    def test_required_fields_are_not_invisible(self):
+        """Assert the user-fillable fields are not hidden.
+
+        Pure Python test, trigger P1 (L-01/L-02): same rationale as
+        ``test_admission_ids_field_is_invisible_without_widget`` above
+        — the view arch is only inspectable via ``fields_view_get()``.
+
+        ``type_id``, ``date``, ``output_format``, ``date_start`` and
+        ``date_end`` must stay visible (no ``invisible`` attribute) on
+        the wizard form.
+        """
+        model = self.env["school_admission.wizard_create_invoice_export"]
+        result = model.fields_view_get(view_type="form")
+        arch = etree.fromstring(result["arch"])
+
+        for field_name in (
+            "type_id",
+            "date",
+            "output_format",
+            "date_start",
+            "date_end",
+        ):
+            field = arch.find(".//field[@name='%s']" % field_name)
+            self.assertIsNotNone(field, "%s field not found in arch" % field_name)
+            self.assertIsNone(
+                field.get("invisible"),
+                "%s should not be invisible" % field_name,
+            )

--- a/ssi_school_admission_customer_invoice_export/wizards/school_admission_create_invoice_export.xml
+++ b/ssi_school_admission_customer_invoice_export/wizards/school_admission_create_invoice_export.xml
@@ -10,7 +10,7 @@
     <field name="arch" type="xml">
         <form string="Create Invoice Export">
             <group name="main" colspan="4" col="2">
-                <field name="admission_ids" widget="many2many_tags" colspan="2" />
+                <field name="admission_ids" invisible="1" />
                 <field name="type_id" />
                 <field name="date" />
                 <field name="output_format" />

--- a/ssi_school_customer_invoice_export/tests/test_school_enrollment_create_invoice_export.py
+++ b/ssi_school_customer_invoice_export/tests/test_school_enrollment_create_invoice_export.py
@@ -2,6 +2,7 @@
 # Copyright 2026 PT. Simetri Sinergi Indonesia
 # License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl).
 
+from lxml import etree
 from odoo_yaml_test import YamlTransactionCase
 
 from odoo.tests import tagged
@@ -9,5 +10,66 @@ from odoo.tests import tagged
 
 @tagged("post_install", "-at_install")
 class TestSchoolEnrollmentCreateInvoiceExport(YamlTransactionCase):
+    """Cover ``school_enrollment.wizard_create_invoice_export``.
+
+    Exercises both the YAML behavior scenario (wizard action) and the
+    Python-only wizard form arch assertions below.
+    """
+
     def test_school_enrollment_create_invoice_export(self):
+        """Run the create-invoice-export wizard scenario."""
         self.run_yaml_scenario("test_data_enrollment_create_invoice_export.yaml")
+
+    def test_enrollment_ids_field_is_invisible_without_widget(self):
+        """Assert the source field is hidden but stays in the arch.
+
+        Pure Python test, trigger P1 (L-01/L-02): the arch dict returned
+        by ``fields_view_get()`` is not a surface the ``odoo-yaml-test``
+        DSL can read (``action: call`` discards the return value), and
+        the YAML ``assert`` block only supports dotted ``getattr`` on
+        registry records, never expressions over the view arch XML.
+
+        ``enrollment_ids`` must stay in the wizard form arch as a
+        machine-only field (``invisible="1"``), without
+        ``widget="many2many_tags"``.
+        """
+        model = self.env["school_enrollment.wizard_create_invoice_export"]
+        result = model.fields_view_get(view_type="form")
+        arch = etree.fromstring(result["arch"])
+
+        field = arch.find(".//field[@name='enrollment_ids']")
+        self.assertIsNotNone(field, "enrollment_ids field not found in arch")
+        self.assertEqual(field.get("invisible"), "1")
+        self.assertIsNone(
+            field.get("widget"),
+            "enrollment_ids should no longer carry widget=many2many_tags",
+        )
+
+    def test_required_fields_are_not_invisible(self):
+        """Assert the user-fillable fields are not hidden.
+
+        Pure Python test, trigger P1 (L-01/L-02): same rationale as
+        ``test_enrollment_ids_field_is_invisible_without_widget`` above
+        — the view arch is only inspectable via ``fields_view_get()``.
+
+        ``type_id``, ``date``, ``output_format``, ``date_start`` and
+        ``date_end`` must stay visible (no ``invisible`` attribute) on
+        the wizard form.
+        """
+        model = self.env["school_enrollment.wizard_create_invoice_export"]
+        result = model.fields_view_get(view_type="form")
+        arch = etree.fromstring(result["arch"])
+
+        for field_name in (
+            "type_id",
+            "date",
+            "output_format",
+            "date_start",
+            "date_end",
+        ):
+            field = arch.find(".//field[@name='%s']" % field_name)
+            self.assertIsNotNone(field, "%s field not found in arch" % field_name)
+            self.assertIsNone(
+                field.get("invisible"),
+                "%s should not be invisible" % field_name,
+            )

--- a/ssi_school_customer_invoice_export/wizards/school_enrollment_create_invoice_export.xml
+++ b/ssi_school_customer_invoice_export/wizards/school_enrollment_create_invoice_export.xml
@@ -13,7 +13,7 @@
     <field name="arch" type="xml">
         <form string="Create Invoice Export">
             <group name="main" colspan="4" col="2">
-                <field name="enrollment_ids" widget="many2many_tags" colspan="2" />
+                <field name="enrollment_ids" invisible="1" />
                 <field name="type_id" />
                 <field name="date" />
                 <field name="output_format" />


### PR DESCRIPTION
## Ringkasan

Menyembunyikan field sumber (`enrollment_ids` / `admission_ids`) pada form
wizard Create Invoice Export kedua modul. Field ini `readonly=True` dan
terisi otomatis dari `active_ids` lewat `default_get` — sebelumnya
ditampilkan sebagai baris pertama dengan `widget="many2many_tags"`,
memenuhi dialog saat banyak record dipilih dan mendorong field yang perlu
diisi user (`type_id`, `date`, `output_format`, `date_start`, `date_end`)
ke bawah.

## Perubahan

- `ssi_school_customer_invoice_export`: `enrollment_ids` pada form wizard
  jadi `invisible="1"`, atribut `widget="many2many_tags"` dan `colspan="2"`
  dihapus. Field tetap ada di arch (dibutuhkan
  `_check_enrollments()`/`_create_invoice_export()`).
- `ssi_school_admission_customer_invoice_export`: hal yang sama untuk
  `admission_ids`.
- Tidak ada perubahan pada `wizards/*.py`, XML ID, `ir.actions.act_window`,
  atau field isian lain.
- Unit test Python murni ditambahkan di kedua modul untuk memverifikasi
  arch view (P1/L-01/L-02): field sumber invisible tanpa widget, field
  isian tetap tampil tanpa invisible.

Closes #195