### PR TITLE
[UPD] ssi_school_qr_code: skenario uji mengonfigurasi konten QR

### DIFF
--- a/ssi_school_qr_code/tests/test_data_school_qr_code.yaml
+++ b/ssi_school_qr_code/tests/test_data_school_qr_code.yaml
@@ -1,34 +1,39 @@
 scenarios:
-  - name: "Create Student With QR Code Image"
+  # NOTE: this scenario MUST stay first in this file. All scenarios in a
+  # single YAML file share one DB transaction without rollback, so any
+  # ir.model configuration written by an earlier scenario stays applied
+  # for the later ones. Placing it anywhere else would make it pass or
+  # fail by accident.
+  - name: "QR Image Is Falsy When Student Model Has No QR Content"
     steps:
       - step: "Create grade type"
         action: "create"
         model: "school_grade_type"
         save_as: "grade_type"
         values:
-          name: "Grade Type Student QR"
-          code: "GTSQR"
+          name: "Grade Type Student QR Unconfigured"
+          code: "GTSQR1"
           sequence: 10
       - step: "Create school"
         action: "create"
         model: "school"
         save_as: "school"
         values:
-          name: "School for Student QR"
-          code: "SCHSQR"
+          name: "School for Student QR Unconfigured"
+          code: "SCHSQR1"
           grade_type_id: "EVAL: registry['grade_type'].id"
       - step: "Create contact"
         action: "create"
         model: "res.partner"
         save_as: "contact"
         values:
-          name: "Student QR Contact"
-      - step: "Create student"
+          name: "Student QR Unconfigured Contact"
+      - step: "Create student without configuring the QR content"
         action: "create"
         model: "school_student"
         save_as: "student"
         values:
-          name: "Student QR"
+          name: "Student QR Unconfigured"
           code: "STUQR001"
           contact_id: "EVAL: registry['contact'].id"
           school_id: "EVAL: registry['school'].id"
@@ -36,7 +41,7 @@ scenarios:
         action: "call"
         target: "student"
         method: "invalidate_cache"
-      - step: "Assert student created and qr_image computed"
+      - step: "Assert student created and qr_image left empty"
         action: "assert"
         target: "student"
         asserts:
@@ -45,10 +50,192 @@ scenarios:
             operator: "is_truthy"
           name:
             type: "value"
-            expected: "Student QR"
+            expected: "Student QR Unconfigured"
+          qr_image:
+            type: "value"
+            operator: "is_falsy"
+
+  - name: "QR Image Is Generated From Standard Content"
+    steps:
+      - step: "Locate the ir.model row of school_student"
+        action: "search"
+        model: "ir.model"
+        domain: [["model", "=", "school_student"]]
+        save_as: "student_ir_model"
+        limit: 1
+        expect_count: 1
+      - step: "Configure the model to use the standard QR content"
+        action: "write"
+        target: "student_ir_model"
+        values:
+          qr_use_standard_content: true
+      - step: "Create grade type"
+        action: "create"
+        model: "school_grade_type"
+        save_as: "grade_type"
+        values:
+          name: "Grade Type Student QR Standard"
+          code: "GTSQR2"
+          sequence: 10
+      - step: "Create school"
+        action: "create"
+        model: "school"
+        save_as: "school"
+        values:
+          name: "School for Student QR Standard"
+          code: "SCHSQR2"
+          grade_type_id: "EVAL: registry['grade_type'].id"
+      - step: "Create contact"
+        action: "create"
+        model: "res.partner"
+        save_as: "contact"
+        values:
+          name: "Student QR Standard Contact"
+      - step: "Create student"
+        action: "create"
+        model: "school_student"
+        save_as: "student"
+        values:
+          name: "Student QR Standard"
+          code: "STUQR002"
+          contact_id: "EVAL: registry['contact'].id"
+          school_id: "EVAL: registry['school'].id"
+      - step: "Invalidate student cache before reading computed QR image"
+        action: "call"
+        target: "student"
+        method: "invalidate_cache"
+      - step: "Assert qr_image is generated from the standard content"
+        action: "assert"
+        target: "student"
+        asserts:
+          name:
+            type: "value"
+            expected: "Student QR Standard"
           qr_image:
             type: "value"
             operator: "is_truthy"
+
+  - name: "QR Image Is Generated From Custom Python Content"
+    steps:
+      - step: "Locate the ir.model row of school_student"
+        action: "search"
+        model: "ir.model"
+        domain: [["model", "=", "school_student"]]
+        save_as: "student_ir_model"
+        limit: 1
+        expect_count: 1
+      - step: "Configure a custom content built from a student field"
+        action: "write"
+        target: "student_ir_model"
+        values:
+          qr_use_standard_content: false
+          qr_python_code: "result = document.code"
+      - step: "Create grade type"
+        action: "create"
+        model: "school_grade_type"
+        save_as: "grade_type"
+        values:
+          name: "Grade Type Student QR Custom"
+          code: "GTSQR3"
+          sequence: 10
+      - step: "Create school"
+        action: "create"
+        model: "school"
+        save_as: "school"
+        values:
+          name: "School for Student QR Custom"
+          code: "SCHSQR3"
+          grade_type_id: "EVAL: registry['grade_type'].id"
+      - step: "Create contact"
+        action: "create"
+        model: "res.partner"
+        save_as: "contact"
+        values:
+          name: "Student QR Custom Contact"
+      - step: "Create student"
+        action: "create"
+        model: "school_student"
+        save_as: "student"
+        values:
+          name: "Student QR Custom"
+          code: "STUQR003"
+          contact_id: "EVAL: registry['contact'].id"
+          school_id: "EVAL: registry['school'].id"
+      - step: "Invalidate student cache before reading computed QR image"
+        action: "call"
+        target: "student"
+        method: "invalidate_cache"
+      - step: "Assert qr_image is generated from the custom content"
+        action: "assert"
+        target: "student"
+        asserts:
+          code:
+            type: "value"
+            expected: "STUQR003"
+          qr_image:
+            type: "value"
+            operator: "is_truthy"
+
+  - name: "QR Image Is Falsy When Custom Content Never Assigns Result"
+    steps:
+      - step: "Locate the ir.model row of school_student"
+        action: "search"
+        model: "ir.model"
+        domain: [["model", "=", "school_student"]]
+        save_as: "student_ir_model"
+        limit: 1
+        expect_count: 1
+      - step: "Configure a custom content that never assigns result"
+        action: "write"
+        target: "student_ir_model"
+        values:
+          qr_use_standard_content: false
+          qr_python_code: "pass"
+      - step: "Create grade type"
+        action: "create"
+        model: "school_grade_type"
+        save_as: "grade_type"
+        values:
+          name: "Grade Type Student QR Broken"
+          code: "GTSQR4"
+          sequence: 10
+      - step: "Create school"
+        action: "create"
+        model: "school"
+        save_as: "school"
+        values:
+          name: "School for Student QR Broken"
+          code: "SCHSQR4"
+          grade_type_id: "EVAL: registry['grade_type'].id"
+      - step: "Create contact"
+        action: "create"
+        model: "res.partner"
+        save_as: "contact"
+        values:
+          name: "Student QR Broken Contact"
+      - step: "Create student"
+        action: "create"
+        model: "school_student"
+        save_as: "student"
+        values:
+          name: "Student QR Broken"
+          code: "STUQR004"
+          contact_id: "EVAL: registry['contact'].id"
+          school_id: "EVAL: registry['school'].id"
+      - step: "Invalidate student cache before reading computed QR image"
+        action: "call"
+        target: "student"
+        method: "invalidate_cache"
+      - step: "Assert qr_image stays empty without leaking an exception"
+        action: "assert"
+        target: "student"
+        asserts:
+          name:
+            type: "value"
+            expected: "Student QR Broken"
+          qr_image:
+            type: "value"
+            operator: "is_falsy"
 
   - name: "Edit Student Master Data Preserved With QR Mixin"
     steps:

--- a/ssi_school_qr_code/tests/test_school_qr_code.py
+++ b/ssi_school_qr_code/tests/test_school_qr_code.py
@@ -9,5 +9,19 @@ from odoo.tests import tagged
 
 @tagged("post_install", "-at_install")
 class TestSchoolQrCode(YamlTransactionCase):
+    """Scenario tests for ``school_student`` with ``mixin.qr_code``.
+
+    ``ssi_school_qr_code`` ships no QR configuration data on purpose:
+    the QR content is configured ad hoc per deployment on the
+    ``ir.model`` row of ``school_student``. The scenarios therefore
+    configure that row themselves and cover the unconfigured,
+    standard-content, custom-content, and broken-custom-content
+    paths of ``qr_image``.
+    """
+
     def test_school_qr_code(self):
+        """Run the ``qr_image`` and master data scenarios.
+
+        :return: nothing; assertions live in the YAML scenarios
+        """
         self.run_yaml_scenario("test_data_school_qr_code.yaml")


### PR DESCRIPTION
Skenario uji `TestSchoolQrCode` gagal di CI dengan `school_student.qr_image: expected truthy, got False` dan memerahkan setiap PR di repo ini.

Penyebabnya bukan regresi. `ssi_qr_code_mixin` 14.0.2.1.2 menambahkan gerbang `if content:` sebelum `qrcode.make()`. Sebelumnya `qrcode.make("")` tetap menghasilkan PNG, sehingga assert truthy lolos secara kebetulan atas QR yang isinya kosong. Skenario uji tidak pernah mengonfigurasi konten QR: ia membuat `school_student` lalu langsung meng-assert `qr_image`, padahal `_get_qr_content` membaca `qr_use_standard_content` / `qr_python_code` pada baris `ir.model` model tersebut.

`ssi_school_qr_code` sengaja ber-`"data": []` — konfigurasi konten QR selalu dilakukan ad-hoc per deployment, bukan di-ship sebagai data modul. Jadi yang cacat adalah test-nya, bukan modulnya dan bukan mixin-nya.

## Perubahan

Skenario kini mengonfigurasi konten QR-nya sendiri lewat `action: search` pada `ir.model` berdomain `[["model", "=", "school_student"]]` lalu `action: write` pada alias itu:

1. **Belum terkonfigurasi** → `qr_image` falsy. Wajib berada paling atas: seluruh skenario dalam satu berkas YAML berbagi satu transaksi DB tanpa rollback, jadi konfigurasi `ir.model` dari skenario sebelumnya tetap melekat. Skenario inilah yang mengunci perilaku gerbang `if content:` dan mencegah kembalinya kelulusan-kebetulan.
2. **Standard content** (`qr_use_standard_content = True`) → `qr_image` truthy. Kontennya `_get_qr_standard_content()` yang selalu tak kosong, sehingga assert tidak bergantung pada nilai `web.base.url` maupun field siswa mana pun.
3. **Custom content** (`qr_use_standard_content = False`, `qr_python_code: result = document.code`) → `qr_image` truthy.
4. **Custom content rusak** (`qr_python_code: pass`, `result` tak pernah ditugaskan) → `qr_image` falsy tanpa exception yang bocor keluar.

Langkah eksplisit `action: call` → `invalidate_cache` dipertahankan sebelum tiap assert `qr_image`; field itu non-stored dan `_compute_qr_image` sengaja tanpa `@api.depends`. Assert hanya memeriksa truthy/falsy — isi base64 tidak di-assert karena keluaran PNG `qrcode` tidak dijamin byte-stabil lintas versi pustaka.

Docstring class & method pada `tests/test_school_qr_code.py` dilengkapi.

## Ruang lingkup

Perubahan hanya di `tests/`. Tidak ada perubahan pada `models/` maupun `__manifest__.py` — modul tidak mulai men-ship data konfigurasi QR. Tidak ada perubahan di repo `ssi-mixin`; gerbang `if content:` adalah perilaku benar dan dipertahankan. Tidak ada assert yang dihapus, di-skip, atau dilonggarkan.

Closes #198