### PR TITLE
[UPD] ssi_school_lead — field student_nisn pada crm.lead dengan inverse sudo

### DIFF
--- a/ssi_school_admission_lead/tests/test_crm_lead_view_architecture.py
+++ b/ssi_school_admission_lead/tests/test_crm_lead_view_architecture.py
@@ -43,12 +43,13 @@ class TestCrmLeadViewArchitecture(YamlTransactionCase):
                 "allowed_previous_school_ids",
                 "previous_school_id",
                 "student_nickname",
+                "student_nisn",
                 "parent_relationship",
             ],
             "Prospective Student group should list student_id, student_birthdate, "
             "student_gender, birth_city, religion_id, nationality_id, "
             "allowed_previous_school_ids, previous_school_id, student_nickname, "
-            "parent_relationship in that order",
+            "student_nisn, parent_relationship in that order",
         )
         previous_school_id_field = group.xpath(".//field[@name='previous_school_id']")[
             0

--- a/ssi_school_lead/models/crm_lead.py
+++ b/ssi_school_lead/models/crm_lead.py
@@ -2,7 +2,8 @@
 # Copyright 2024 PT. Simetri Sinergi Indonesia
 # License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl).
 
-from odoo import api, fields, models
+from odoo import _, api, fields, models
+from odoo.exceptions import UserError
 
 _SYNC_STUDENT_FAMILY_LINK_TRIGGER_FIELDS = [
     "partner_id",
@@ -133,6 +134,85 @@ class CrmLead(models.Model):
         "contact referenced by the Student field. Writing this field "
         "updates that contact's nickname.",
     )
+    student_nisn = fields.Char(
+        string="Student NISN",
+        compute="_compute_student_nisn",
+        compute_sudo=True,
+        inverse="_inverse_student_nisn",
+        search="_search_student_nisn",
+        help="National student number (NISN) of the prospective student, "
+        "read from and written to the contact referenced by the Student "
+        "field. The value is never stored on the lead itself: it lives on "
+        "that contact as an ID number record under the NISN category. "
+        "Writing this field updates the contact even when the current user "
+        "may not edit contact ID numbers directly. Emptying it archives "
+        "the related ID number record instead of deleting it.",
+    )
+
+    @api.depends("student_id")
+    def _compute_student_nisn(self):
+        """Read the NISN of the contact referenced by ``student_id``.
+
+        The contact is read with ``sudo()`` because ``res.partner`` and
+        ``res.partner.id_number`` are only readable in full by the
+        identification configurator groups, while admission officers must
+        still see the number on the lead form.
+
+        :return: nothing; assigns ``student_nisn``
+        """
+        for record in self:
+            result = False
+            if record.student_id:
+                result = record.student_id.sudo().nisn
+            record.student_nisn = result
+
+    def _inverse_student_nisn(self):
+        """Write ``student_nisn`` back onto the prospective student.
+
+        The write goes through ``student_id.sudo()`` so that the NISN of
+        the contact can be maintained from the lead form without granting
+        the admission officer write access to ``res.partner`` or to
+        ``res.partner.id_number``. The elevation is deliberately scoped to
+        the student contact record, never to ``self``.
+
+        An empty value on a lead without a student is a no-op, because the
+        web client submits every editable non-stored field on save even
+        when the lead has no prospective student yet.
+
+        :raises UserError: when a non-empty NISN is set while
+            ``student_id`` is empty
+        :return: nothing; writes ``res.partner.nisn`` of the student
+        """
+        for record in self:
+            if not record.student_id:
+                if record.student_nisn:
+                    error_message = (
+                        _(
+                            """
+Context: Set Student NISN
+Database ID: %s
+Problem: No Student is selected on this lead
+Solution: Select the Student first, then fill in the Student NISN
+"""
+                        )
+                        % record.id
+                    )
+                    raise UserError(error_message)
+                continue
+            record.student_id.sudo().nisn = record.student_nisn
+
+    def _search_student_nisn(self, operator, value):
+        """Search leads by the NISN of their prospective student.
+
+        The lookup is delegated to the ``search`` method of
+        ``res.partner.nisn``, which resolves the NISN category on
+        ``res.partner.id_number``.
+
+        :param operator: the search operator supplied by the domain
+        :param value: the NISN value being searched for
+        :return: an Odoo search domain on ``crm.lead``
+        """
+        return [("student_id.nisn", operator, value)]
 
     @api.depends("admission_id")
     def _compute_create_admission_ok(self):

--- a/ssi_school_lead/tests/__init__.py
+++ b/ssi_school_lead/tests/__init__.py
@@ -6,3 +6,4 @@ from . import test_school_lead  # noqa: F401
 from . import test_crm_lead_parent_contact  # noqa: F401
 from . import test_crm_lead_student_family_link  # noqa: F401
 from . import test_crm_lead_student_nickname  # noqa: F401
+from . import test_crm_lead_student_nisn  # noqa: F401

--- a/ssi_school_lead/tests/test_crm_lead_student_nisn.py
+++ b/ssi_school_lead/tests/test_crm_lead_student_nisn.py
@@ -1,0 +1,22 @@
+# Copyright 2026 OpenSynergy Indonesia
+# Copyright 2026 PT. Simetri Sinergi Indonesia
+# License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl).
+
+from odoo_yaml_test import YamlTransactionCase
+
+from odoo.tests import tagged
+
+
+@tagged("post_install", "-at_install")
+class TestCrmLeadStudentNisn(YamlTransactionCase):
+    """Test the ``student_nisn`` field on ``crm.lead``.
+
+    The field reads and writes ``res.partner.nisn`` of the prospective
+    student through ``sudo()``, so that an admission officer without the
+    partner ID number configurator group can still maintain the NISN from
+    the lead form.
+    """
+
+    def test_crm_lead_student_nisn(self):
+        """Run the YAML scenarios covering ``student_nisn``."""
+        self.run_yaml_scenario("test_data_crm_lead_student_nisn.yaml")

--- a/ssi_school_lead/tests/test_data_crm_lead_student_nisn.yaml
+++ b/ssi_school_lead/tests/test_data_crm_lead_student_nisn.yaml
@@ -16,6 +16,7 @@ scenarios:
               - 0
               - - "REF: base.group_user"
                 - "REF: sales_team.group_sale_salesman"
+                - "REF: ssi_lead.crm_lead_user_group"
                 - "REF: ssi_partner.contacts_configurator_group"
 
       - step: "Create student partner without NISN"
@@ -82,6 +83,7 @@ scenarios:
               - 0
               - - "REF: base.group_user"
                 - "REF: sales_team.group_sale_salesman"
+                - "REF: ssi_lead.crm_lead_user_group"
                 - "REF: ssi_partner.contacts_configurator_group"
 
       - step: "Create student partner that already has a NISN"
@@ -154,6 +156,7 @@ scenarios:
               - 0
               - - "REF: base.group_user"
                 - "REF: sales_team.group_sale_salesman"
+                - "REF: ssi_lead.crm_lead_user_group"
                 - "REF: ssi_partner.contacts_configurator_group"
 
       - step: "Create student partner that already has a NISN"
@@ -236,6 +239,7 @@ scenarios:
               - 0
               - - "REF: base.group_user"
                 - "REF: sales_team.group_sale_salesman"
+                - "REF: ssi_lead.crm_lead_user_group"
                 - "REF: ssi_partner.contacts_configurator_group"
 
       - step: "Create student partner without NISN"
@@ -285,6 +289,7 @@ scenarios:
               - 0
               - - "REF: base.group_user"
                 - "REF: sales_team.group_sale_salesman"
+                - "REF: ssi_lead.crm_lead_user_group"
                 - "REF: ssi_partner.contacts_configurator_group"
 
       - step: "Create CRM lead without student_id and without student_nisn"
@@ -441,6 +446,7 @@ scenarios:
               - 0
               - - "REF: base.group_user"
                 - "REF: sales_team.group_sale_salesman"
+                - "REF: ssi_lead.crm_lead_user_group"
                 - "REF: ssi_partner.contacts_configurator_group"
 
       - step: "Create CRM lead without student_id"
@@ -493,6 +499,7 @@ scenarios:
               - 0
               - - "REF: base.group_user"
                 - "REF: sales_team.group_sale_salesman"
+                - "REF: ssi_lead.crm_lead_user_group"
                 - "REF: ssi_partner.contacts_configurator_group"
 
       - step: "Create student partner with a NISN"

--- a/ssi_school_lead/tests/test_data_crm_lead_student_nisn.yaml
+++ b/ssi_school_lead/tests/test_data_crm_lead_student_nisn.yaml
@@ -1,0 +1,547 @@
+options:
+  auto_refresh: true
+
+scenarios:
+  - name: "CRM Lead Student NISN - Officer sets NISN without ID number rights"
+    steps:
+      - step: "Create admission officer user"
+        action: "create"
+        model: "res.users"
+        save_as: "officer"
+        values:
+          name: "Admission Officer NI1"
+          login: "admission.officer.ni1@example.com"
+          groups_id:
+            - - 6
+              - 0
+              - - "REF: base.group_user"
+                - "REF: sales_team.group_sale_salesman"
+                - "REF: ssi_partner.contacts_configurator_group"
+
+      - step: "Create student partner without NISN"
+        action: "create"
+        model: "res.partner"
+        save_as: "student"
+        values:
+          name: "Student NISN Set NI1"
+
+      - step: "Create CRM lead owned by the admission officer"
+        action: "create"
+        model: "crm.lead"
+        save_as: "lead"
+        as_user: "officer"
+        values:
+          name: "Lead Student NISN Set NI1"
+          user_id: "REC: officer.id"
+          student_id: "REC: student.id"
+
+      - step: "Write student_nisn from the lead as the admission officer"
+        action: "write"
+        target: "lead"
+        as_user: "officer"
+        values:
+          student_nisn: "0021000001"
+
+      - step: "Assert student_nisn on the lead reflects the written value"
+        action: "assert"
+        target: "lead"
+        asserts:
+          student_nisn:
+            type: "value"
+            expected: "0021000001"
+
+      - step: "Assert the student contact carries exactly one NISN ID number"
+        action: "assert"
+        target: "student"
+        asserts:
+          nisn:
+            type: "value"
+            expected: "0021000001"
+          id_numbers:
+            type: "o2m"
+            check: "count"
+            expected_count: 1
+          id_numbers.name:
+            type: "value"
+            expected: "0021000001"
+          id_numbers.category_id.code:
+            type: "value"
+            expected: "nisn"
+
+  - name: "CRM Lead Student NISN - Officer edits an existing NISN"
+    steps:
+      - step: "Create admission officer user"
+        action: "create"
+        model: "res.users"
+        save_as: "officer"
+        values:
+          name: "Admission Officer NI2"
+          login: "admission.officer.ni2@example.com"
+          groups_id:
+            - - 6
+              - 0
+              - - "REF: base.group_user"
+                - "REF: sales_team.group_sale_salesman"
+                - "REF: ssi_partner.contacts_configurator_group"
+
+      - step: "Create student partner that already has a NISN"
+        action: "create"
+        model: "res.partner"
+        save_as: "student"
+        values:
+          name: "Student NISN Edit NI2"
+          nisn: "0021000002"
+
+      - step: "Create CRM lead owned by the admission officer"
+        action: "create"
+        model: "crm.lead"
+        save_as: "lead"
+        as_user: "officer"
+        values:
+          name: "Lead Student NISN Edit NI2"
+          user_id: "REC: officer.id"
+          student_id: "REC: student.id"
+
+      - step: "Assert the lead mirrors the existing NISN"
+        action: "assert"
+        target: "lead"
+        asserts:
+          student_nisn:
+            type: "value"
+            expected: "0021000002"
+
+      - step: "Write a different student_nisn as the admission officer"
+        action: "write"
+        target: "lead"
+        as_user: "officer"
+        values:
+          student_nisn: "0021000012"
+
+      - step: "Assert the lead reflects the new NISN"
+        action: "assert"
+        target: "lead"
+        asserts:
+          student_nisn:
+            type: "value"
+            expected: "0021000012"
+
+      - step: "Assert the ID number was updated, not duplicated"
+        action: "assert"
+        target: "student"
+        asserts:
+          nisn:
+            type: "value"
+            expected: "0021000012"
+          id_numbers:
+            type: "o2m"
+            check: "count"
+            expected_count: 1
+          id_numbers.name:
+            type: "value"
+            expected: "0021000012"
+
+  - name: "CRM Lead Student NISN - Officer empties the NISN"
+    steps:
+      - step: "Create admission officer user"
+        action: "create"
+        model: "res.users"
+        save_as: "officer"
+        values:
+          name: "Admission Officer NI3"
+          login: "admission.officer.ni3@example.com"
+          groups_id:
+            - - 6
+              - 0
+              - - "REF: base.group_user"
+                - "REF: sales_team.group_sale_salesman"
+                - "REF: ssi_partner.contacts_configurator_group"
+
+      - step: "Create student partner that already has a NISN"
+        action: "create"
+        model: "res.partner"
+        save_as: "student"
+        values:
+          name: "Student NISN Empty NI3"
+          nisn: "0021000003"
+
+      - step: "Create CRM lead owned by the admission officer"
+        action: "create"
+        model: "crm.lead"
+        save_as: "lead"
+        as_user: "officer"
+        values:
+          name: "Lead Student NISN Empty NI3"
+          user_id: "REC: officer.id"
+          student_id: "REC: student.id"
+
+      - step: "Empty student_nisn as the admission officer"
+        action: "write"
+        target: "lead"
+        as_user: "officer"
+        values:
+          student_nisn: false
+
+      - step: "Assert student_nisn on the lead is falsy"
+        action: "assert"
+        target: "lead"
+        asserts:
+          student_nisn:
+            type: "value"
+            operator: "is_falsy"
+
+      - step: "Assert the student contact has no active NISN left"
+        action: "assert"
+        target: "student"
+        asserts:
+          nisn:
+            type: "value"
+            operator: "is_falsy"
+          id_numbers:
+            type: "o2m"
+            check: "count"
+            expected_count: 0
+
+      - step: "Assert the ID number record is archived, not deleted"
+        action: "search"
+        model: "res.partner.id_number"
+        domain:
+          - ["partner_id", "=", "REC: student.id"]
+          - ["category_id.code", "=", "nisn"]
+          - ["active", "=", false]
+        save_as: "archived_id_numbers"
+        expect_count: 1
+
+      - step: "Assert the archived ID number keeps its value"
+        action: "assert"
+        target: "archived_id_numbers"
+        asserts:
+          name:
+            type: "value"
+            expected: "0021000003"
+          active:
+            type: "value"
+            expected: false
+
+  - name: "CRM Lead Student NISN - Create the lead with student and NISN at once"
+    steps:
+      - step: "Create admission officer user"
+        action: "create"
+        model: "res.users"
+        save_as: "officer"
+        values:
+          name: "Admission Officer NI4"
+          login: "admission.officer.ni4@example.com"
+          groups_id:
+            - - 6
+              - 0
+              - - "REF: base.group_user"
+                - "REF: sales_team.group_sale_salesman"
+                - "REF: ssi_partner.contacts_configurator_group"
+
+      - step: "Create student partner without NISN"
+        action: "create"
+        model: "res.partner"
+        save_as: "student"
+        values:
+          name: "Student NISN Create NI4"
+
+      - step: "Create CRM lead with student_id and student_nisn together"
+        action: "create"
+        model: "crm.lead"
+        save_as: "lead"
+        as_user: "officer"
+        values:
+          name: "Lead Student NISN Create NI4"
+          user_id: "REC: officer.id"
+          student_id: "REC: student.id"
+          student_nisn: "0021000004"
+
+      - step: "Assert the NISN landed on the student contact"
+        action: "assert"
+        target: "student"
+        asserts:
+          nisn:
+            type: "value"
+            expected: "0021000004"
+          id_numbers:
+            type: "o2m"
+            check: "count"
+            expected_count: 1
+          id_numbers.category_id.code:
+            type: "value"
+            expected: "nisn"
+
+  - name: "CRM Lead Student NISN - Guard, lead without student and without NISN"
+    steps:
+      - step: "Create admission officer user"
+        action: "create"
+        model: "res.users"
+        save_as: "officer"
+        values:
+          name: "Admission Officer NI5"
+          login: "admission.officer.ni5@example.com"
+          groups_id:
+            - - 6
+              - 0
+              - - "REF: base.group_user"
+                - "REF: sales_team.group_sale_salesman"
+                - "REF: ssi_partner.contacts_configurator_group"
+
+      - step: "Create CRM lead without student_id and without student_nisn"
+        action: "create"
+        model: "crm.lead"
+        save_as: "lead"
+        as_user: "officer"
+        values:
+          name: "Lead Student NISN Guard NI5"
+          user_id: "REC: officer.id"
+
+      - step: "Assert the lead was created"
+        action: "assert"
+        target: "lead"
+        asserts:
+          id:
+            type: "value"
+            operator: "is_truthy"
+          student_nisn:
+            type: "value"
+            operator: "is_falsy"
+
+      - step: "Create another lead sending an empty student_nisn explicitly"
+        action: "create"
+        model: "crm.lead"
+        save_as: "lead_explicit"
+        as_user: "officer"
+        values:
+          name: "Lead Student NISN Guard Explicit NI5"
+          user_id: "REC: officer.id"
+          student_nisn: false
+
+      - step: "Assert the lead with an explicit empty NISN was created"
+        action: "assert"
+        target: "lead_explicit"
+        asserts:
+          id:
+            type: "value"
+            operator: "is_truthy"
+          student_nisn:
+            type: "value"
+            operator: "is_falsy"
+
+      - step: "Write an empty student_nisn on a lead without a student"
+        action: "write"
+        target: "lead"
+        as_user: "officer"
+        values:
+          student_nisn: false
+
+      - step: "Assert the lead still has no NISN and raised nothing"
+        action: "assert"
+        target: "lead"
+        asserts:
+          student_nisn:
+            type: "value"
+            operator: "is_falsy"
+
+  - name: "CRM Lead Student NISN - Value follows the selected student"
+    steps:
+      - step: "Create first student partner with a NISN"
+        action: "create"
+        model: "res.partner"
+        save_as: "student_a"
+        values:
+          name: "Student NISN Follow A NI6"
+          nisn: "0021000006"
+
+      - step: "Create second student partner with a different NISN"
+        action: "create"
+        model: "res.partner"
+        save_as: "student_b"
+        values:
+          name: "Student NISN Follow B NI6"
+          nisn: "0021000016"
+
+      - step: "Create CRM lead pointing to the first student"
+        action: "create"
+        model: "crm.lead"
+        save_as: "lead"
+        as_user: "base.user_admin"
+        values:
+          name: "Lead Student NISN Follow NI6"
+          student_id: "REC: student_a.id"
+
+      - step: "Assert the lead mirrors the first student NISN"
+        action: "assert"
+        target: "lead"
+        asserts:
+          student_nisn:
+            type: "value"
+            expected: "0021000006"
+
+      - step: "Point the lead to the second student"
+        action: "write"
+        target: "lead"
+        values:
+          student_id: "REC: student_b.id"
+
+      - step: "Assert the lead now mirrors the second student NISN"
+        action: "assert"
+        target: "lead"
+        asserts:
+          student_nisn:
+            type: "value"
+            expected: "0021000016"
+
+  - name: "CRM Lead Student NISN - Search leads by student NISN"
+    steps:
+      - step: "Create student partner with a NISN to be searched"
+        action: "create"
+        model: "res.partner"
+        save_as: "student"
+        values:
+          name: "Student NISN Search NI7"
+          nisn: "0021000007"
+
+      - step: "Create CRM lead pointing to that student"
+        action: "create"
+        model: "crm.lead"
+        save_as: "lead"
+        as_user: "base.user_admin"
+        values:
+          name: "Lead Student NISN Search NI7"
+          student_id: "REC: student.id"
+
+      - step: "Search leads by student_nisn"
+        action: "search"
+        model: "crm.lead"
+        domain:
+          - ["student_nisn", "=", "0021000007"]
+        save_as: "leads_by_nisn"
+        expect_count: 1
+
+      - step: "Assert the found lead is the created one"
+        action: "assert"
+        target: "leads_by_nisn"
+        asserts:
+          id:
+            type: "value"
+            expected: "REC: lead.id"
+
+  - name: "CRM Lead Student NISN - Negative, NISN without a selected student"
+    steps:
+      - step: "Create admission officer user"
+        action: "create"
+        model: "res.users"
+        save_as: "officer"
+        values:
+          name: "Admission Officer NI8"
+          login: "admission.officer.ni8@example.com"
+          groups_id:
+            - - 6
+              - 0
+              - - "REF: base.group_user"
+                - "REF: sales_team.group_sale_salesman"
+                - "REF: ssi_partner.contacts_configurator_group"
+
+      - step: "Create CRM lead without student_id"
+        action: "create"
+        model: "crm.lead"
+        save_as: "lead"
+        as_user: "officer"
+        values:
+          name: "Lead Student NISN No Student NI8"
+          user_id: "REC: officer.id"
+
+      - step: "Assert student_nisn is falsy on a lead without a student"
+        action: "assert"
+        target: "lead"
+        asserts:
+          student_nisn:
+            type: "value"
+            operator: "is_falsy"
+
+      - step: "Writing a NISN without a student must be rejected"
+        action: "write"
+        target: "lead"
+        as_user: "officer"
+        expect_error:
+          type: "UserError"
+          message_contains: "No Student is selected on this lead"
+        values:
+          student_nisn: "0021000008"
+
+      - step: "Assert no ID number was created for the rejected value"
+        action: "search"
+        model: "res.partner.id_number"
+        domain:
+          - ["name", "=", "0021000008"]
+          - ["category_id.code", "=", "nisn"]
+        save_as: "rejected_id_numbers"
+        expect_count: 0
+
+  - name: "CRM Lead Student NISN - Negative, student with multiple NISN records"
+    steps:
+      - step: "Create admission officer user"
+        action: "create"
+        model: "res.users"
+        save_as: "officer"
+        values:
+          name: "Admission Officer NI9"
+          login: "admission.officer.ni9@example.com"
+          groups_id:
+            - - 6
+              - 0
+              - - "REF: base.group_user"
+                - "REF: sales_team.group_sale_salesman"
+                - "REF: ssi_partner.contacts_configurator_group"
+
+      - step: "Create student partner with a NISN"
+        action: "create"
+        model: "res.partner"
+        save_as: "student"
+        values:
+          name: "Student NISN Multiple NI9"
+          nisn: "0021000009"
+
+      - step: "Get the NISN ID category"
+        action: "ref"
+        xml_id: "ssi_school.partner_identification_nisn"
+        save_as: "nisn_category"
+
+      - step: "Create a second NISN ID number directly"
+        action: "create"
+        model: "res.partner.id_number"
+        save_as: "second_id_number"
+        values:
+          partner_id: "REC: student.id"
+          category_id: "REC: nisn_category.id"
+          name: "0021000019"
+
+      - step: "Assert the student contact now has two NISN ID numbers"
+        action: "assert"
+        target: "student"
+        asserts:
+          id_numbers:
+            type: "o2m"
+            check: "count"
+            expected_count: 2
+
+      - step: "Create CRM lead pointing to that student"
+        action: "create"
+        model: "crm.lead"
+        save_as: "lead"
+        as_user: "officer"
+        values:
+          name: "Lead Student NISN Multiple NI9"
+          user_id: "REC: officer.id"
+          student_id: "REC: student.id"
+
+      - step: "Writing student_nisn from the lead must be rejected"
+        action: "write"
+        target: "lead"
+        as_user: "officer"
+        expect_error:
+          type: "ValidationError"
+          message_contains: "multiple IDs of this type"
+        values:
+          student_nisn: "0021000029"

--- a/ssi_school_lead/views/crm_lead_views.xml
+++ b/ssi_school_lead/views/crm_lead_views.xml
@@ -67,6 +67,7 @@
                     >
                     <field name="student_id" />
                     <field name="student_nickname" />
+                    <field name="student_nisn" />
                     <field name="parent_relationship" />
                 </group>
                 <group name="school_lead_admission_target" string="Admission Target">


### PR DESCRIPTION
Menambah field `student_nisn` pada `crm.lead` di modul `ssi_school_lead`.

## Perubahan

* Field `student_nisn` (Char, non-stored) dengan `compute="_compute_student_nisn"` (+ `@api.depends("student_id")`, `compute_sudo=True`), `inverse="_inverse_student_nisn"`, dan `search="_search_student_nisn"`. Bukan `related=` polos dan tanpa `store=True`.
* `sudo()` dipasang pada **record kontak calon siswa**, bukan pada `self` — inilah yang menembus ACL `res.partner` maupun `res.partner.id_number` sehingga petugas admission tanpa grup `ssi_partner_identification.partner_id_number_configurator_group` tetap bisa menyimpan NISN dari form lead. **Tidak ada satu pun baris ACL, grup, atau record rule baru di diff ini.**
* Guard truthy pada `_inverse_student_nisn`: `UserError` hanya bila `student_nisn` terisi sementara `student_id` kosong; bila keduanya kosong ia tidak melakukan apa-apa, sehingga lead tanpa calon siswa tetap dapat disimpan.
* `_search_student_nisn` mengembalikan `[("student_id.nisn", operator, value)]`, menumpang method `search` milik `res.partner.nisn`.
* Field ditampilkan di grup `school_lead_prospective_student` pada form lead.
* Unit test `odoo-yaml-test` (9 skenario): set NISN sebagai petugas admission, edit tanpa menambah record id_number, kosongkan (id_number diarsipkan), create lead beserta NISN sekaligus, guard lead tanpa calon siswa, propagasi saat `student_id` diganti, search berdomain `student_nisn`, serta dua jalur negatif (`UserError` tanpa student, `ValidationError` multiple IDs).

Closes #191