### PR TITLE
[UPD] ssi_school - Instruksi Kerja Enrollment, Homeroom, Student Class Mutation

### DIFF
--- a/ssi_school/README.rst
+++ b/ssi_school/README.rst
@@ -105,6 +105,64 @@ Student
 * `Activate Student <docs/school_student/05-activate.html>`_
 * `Print Student <docs/school_student/06-print.html>`_
 
+Enrollment
+----------
+
+* `Create Enrollment <docs/school_enrollment/01-create.html>`_
+* `Edit Enrollment <docs/school_enrollment/02-edit.html>`_
+* `Delete Enrollment <docs/school_enrollment/03-delete.html>`_
+* `Confirm Enrollment <docs/school_enrollment/04-confirm.html>`_
+* `Approve Enrollment <docs/school_enrollment/05-approve.html>`_
+* `Reject Enrollment <docs/school_enrollment/06-reject.html>`_
+* `Finish Enrollment <docs/school_enrollment/09-finish.html>`_
+* `Cancel Enrollment <docs/school_enrollment/10-cancel.html>`_
+* `Restart Enrollment <docs/school_enrollment/12-restart.html>`_
+* `Reset Document Number - Enrollment <docs/school_enrollment/13-reset-number.html>`_
+* `Restart Approval Process - Enrollment <docs/school_enrollment/14-restart-approval.html>`_
+* `Set Result to Passed - Enrollment <docs/school_enrollment/15-pass.html>`_
+* `Set Result to Failed - Enrollment <docs/school_enrollment/16-fail.html>`_
+* `Set Result to Drop Out - Enrollment <docs/school_enrollment/17-drop-out.html>`_
+* `Set Result to Graduate - Enrollment <docs/school_enrollment/18-graduate.html>`_
+* `Create Due Invoice - Enrollment <docs/school_enrollment/19-create-due-invoice.html>`_
+* `Close Addendum - Enrollment <docs/school_enrollment/20-close-addendum.html>`_
+* `Print Enrollment <docs/school_enrollment/21-print.html>`_
+* `Reload Template Policy - Enrollment <docs/school_enrollment/22-reload-template-policy.html>`_
+
+Student Class Mutation
+-----------------------
+
+* `Create Student Class Mutation <docs/school_student_mutation/01-create.html>`_
+* `Edit Student Class Mutation <docs/school_student_mutation/02-edit.html>`_
+* `Delete Student Class Mutation <docs/school_student_mutation/03-delete.html>`_
+* `Confirm Student Class Mutation <docs/school_student_mutation/04-confirm.html>`_
+* `Approve Student Class Mutation <docs/school_student_mutation/05-approve.html>`_
+* `Reject Student Class Mutation <docs/school_student_mutation/06-reject.html>`_
+* `Cancel Student Class Mutation <docs/school_student_mutation/10-cancel.html>`_
+* `Restart Student Class Mutation <docs/school_student_mutation/12-restart.html>`_
+* `Reset Document Number - Student Class Mutation <docs/school_student_mutation/13-reset-number.html>`_
+* `Restart Approval Process - Student Class Mutation <docs/school_student_mutation/14-restart-approval.html>`_
+* `Print Student Class Mutation <docs/school_student_mutation/15-print.html>`_
+* `Reload Template Policy - Student Class Mutation <docs/school_student_mutation/16-reload-template-policy.html>`_
+
+Homeroom
+--------
+
+* `Create Homeroom <docs/school_homeroom/01-create.html>`_
+* `Edit Homeroom <docs/school_homeroom/02-edit.html>`_
+* `Delete Homeroom <docs/school_homeroom/03-delete.html>`_
+* `Confirm Homeroom <docs/school_homeroom/04-confirm.html>`_
+* `Approve Homeroom <docs/school_homeroom/05-approve.html>`_
+* `Reject Homeroom <docs/school_homeroom/06-reject.html>`_
+* `Finish Homeroom <docs/school_homeroom/09-finish.html>`_
+* `Cancel Homeroom <docs/school_homeroom/10-cancel.html>`_
+* `Restart Homeroom <docs/school_homeroom/12-restart.html>`_
+* `Reset Document Number - Homeroom <docs/school_homeroom/13-reset-number.html>`_
+* `Restart Approval Process - Homeroom <docs/school_homeroom/14-restart-approval.html>`_
+* `Fill Random - Homeroom <docs/school_homeroom/15-fill-random.html>`_
+* `Generate Enrollments - Homeroom <docs/school_homeroom/16-generate-enrollments.html>`_
+* `Print Homeroom <docs/school_homeroom/17-print.html>`_
+* `Reload Template Policy - Homeroom <docs/school_homeroom/18-reload-template-policy.html>`_
+
 Enrollment Payment Template
 ----------------------------
 

--- a/ssi_school/docs/school_enrollment/01-create.md
+++ b/ssi_school/docs/school_enrollment/01-create.md
@@ -1,0 +1,80 @@
+# Create Enrollment
+
+> **Module:** ssi*school\
+> **Model:** `school_enrollment`\
+> **Menu:** School > Student Activities > Enrollments\
+> **Actor:** user in group \_Enrollment — User*\
+> **State:** `—` → `draft`\
+> **Inline Actions:** `action_compute_payment` (Compute Payment), `action_create_invoice`
+> (Create Invoice), `action_delete_invoice` (Delete Invoice), `action_disconnect_invoice`
+> (Disconnect Invoice), `action_mark_as_manual` (Mark as Manual), `action_unmark_as_manual`
+> (Unmark as Manual), `action_open_duplicate_wizard` (Duplicate)
+
+## Pre-Condition
+
+- **Data:** The destination Academic Year, Academic Term (open for enrollment), School,
+  Grade, and Grade Class already exist.
+- **Data:** At least one Student is eligible for the selected Grade/Term (a Draft
+  student whose `next_grade_id` matches the Grade, on the first term of the year, or
+  whose `current_grade_id` matches the Grade on later terms).
+- **Config:** An active `policy.template` for this model grants `confirm_ok` for state
+  `draft` to the actor's group (needed later by `04-confirm`).
+- **Access:** User is in group _Enrollment — User_.
+
+## Flow
+
+1. Open the **School > Student Activities > Enrollments** menu.
+2. Click the **New** button. **(14.0: "Create")**
+3. Fill in the required fields:
+   - **Academic Year** _(required)_: Select the academic year of this enrollment.
+   - **Academic Term** _(required)_: Select the term, restricted to terms of the
+     selected Academic Year that are open for enrollment.
+   - **School** _(required)_: Select the destination school.
+   - **Grade** _(required)_: Select the class level, restricted to the school's Grade
+     Type.
+   - **Student** _(required)_: Select the student, restricted to students eligible for
+     the selected Grade/Term.
+   - **Grade Class** _(required)_: Select the homeroom class, restricted to classes that
+     belong to the selected Grade and School.
+   - **Homeroom**: Optional. The Homeroom batch this enrollment is generated from or
+     linked to, if any.
+   - **Date**: Defaults to today's date. Change if needed.
+   - **Currency**: Defaults to the company currency. Change if needed.
+   - **Pricelist**: Optional. Restricted to pricelists that match the selected Currency.
+   - **Payment Template**: Optional. Restricted to templates that match the selected
+     Academic Term, School, and Grade (or templates that leave any of these open). Used
+     by **Compute Payment** below and by **Homeroom**'s enrollment generation.
+4. On the **Billing** tab, click **Compute Payment** to replace the **Payment Terms**
+   tab with the billing lines defined by the selected **Payment Template** (each
+   template term becomes a Payment Term, with its detail lines copied in). This requires
+   a **Payment Template** to be selected first, and only works while the record is in
+   Draft. You may also add, edit, or remove Payment Terms manually instead of, or after,
+   using this button — skipping it leaves **Payment Terms** empty and no billing will be
+   generated for this enrollment.
+5. On each Payment Term line (whether added by **Compute Payment** or manually), the
+   following buttons may be used once the term is Uninvoiced or Invoiced:
+   - **Create Invoice**: Available when the term's status is **Uninvoiced**. Creates a
+     customer invoice for that term immediately, instead of waiting for
+     `19-create-due-invoice`.
+   - **Delete Invoice**: Available when the term's status is **Invoiced**. Deletes the
+     linked draft customer invoice and returns the term to **Uninvoiced**.
+   - **Disconnect Invoice**: Available when the term's status is **Invoiced**. Removes
+     the link to the customer invoice without deleting it.
+   - **Mark as Manual**: Available when the term's status is **Uninvoiced**. Flags the
+     term as manually handled, excluding it from automatic due-invoice generation
+     (`19-create-due-invoice`).
+   - **Unmark as Manual**: Available when the term is marked **Manual**. Reverts the
+     term to normal automatic handling.
+   - **Duplicate**: Available while the enrollment is in Draft. Opens a wizard to create
+     a copy of the term (with all its detail lines) under a new **Term Name**,
+     **Sequence**, **Estimated Invoice Date**, and **Estimated Due Date**; click
+     **Duplicate** (`action_duplicate`) in the wizard footer to confirm. Useful for
+     creating a similar billing term without repeating every detail line manually.
+6. Click **Save**.
+
+## Post-Condition
+
+- A new record is created in **Draft** status.
+- If **Compute Payment** was used, the **Payment Terms** tab is filled according to the
+  selected Payment Template, and the **Payment Summary** tab is recomputed from the
+  detail lines.

--- a/ssi_school/docs/school_enrollment/02-edit.md
+++ b/ssi_school/docs/school_enrollment/02-edit.md
@@ -1,0 +1,34 @@
+# Edit Enrollment
+
+> **Module:** ssi*school\
+> **Model:** `school_enrollment`\
+> **Menu:** School > Student Activities > Enrollments\
+> **Actor:** user in group \_Enrollment — User*\
+> **Requires:** `01-create`\
+> **Inline Actions:** `action_compute_payment` (Compute Payment), `action_create_invoice`
+> (Create Invoice), `action_delete_invoice` (Delete Invoice), `action_disconnect_invoice`
+> (Disconnect Invoice), `action_mark_as_manual` (Mark as Manual), `action_unmark_as_manual`
+> (Unmark as Manual), `action_open_duplicate_wizard` (Duplicate)
+
+## Pre-Condition
+
+- **Record:** Status is **Draft**.
+- **Access:** User is in group _Enrollment — User_.
+
+## Flow
+
+1. Open the **School > Student Activities > Enrollments** menu.
+2. Find and open the record to edit.
+3. Change the required fields.
+4. On the **Billing** tab, click **Compute Payment** to discard the current **Payment
+   Terms** and rebuild them from the selected **Payment Template** — for example after
+   changing the Payment Template or the enrollment Date. Skipping this step leaves the
+   existing Payment Terms unchanged.
+5. On each Payment Term line, the **Create Invoice**, **Delete Invoice**, **Disconnect
+   Invoice**, **Mark as Manual**, **Unmark as Manual**, and **Duplicate** buttons may be
+   used the same way as described in `01-create`.
+6. Click **Save**.
+
+## Post-Condition
+
+- The record is updated with the new values.

--- a/ssi_school/docs/school_enrollment/03-delete.md
+++ b/ssi_school/docs/school_enrollment/03-delete.md
@@ -1,0 +1,24 @@
+# Delete Enrollment
+
+> **Module:** ssi*school\
+> **Model:** `school_enrollment`\
+> **Menu:** School > Student Activities > Enrollments\
+> **Actor:** user in group \_Enrollment — User*\
+> **Requires:** `01-create`
+
+## Pre-Condition
+
+- **Record:** Status is **Draft**.
+- **Record:** Document number is still **/** (not yet generated).
+- **Access:** User is in group _Enrollment — User_.
+
+## Flow
+
+1. Open the **School > Student Activities > Enrollments** menu.
+2. Select one or more records to delete (check the checkbox).
+3. Click **Action** > **Delete**.
+4. Click **OK** to confirm.
+
+## Post-Condition
+
+- The selected records are permanently removed from the system.

--- a/ssi_school/docs/school_enrollment/04-confirm.md
+++ b/ssi_school/docs/school_enrollment/04-confirm.md
@@ -1,0 +1,30 @@
+# Confirm Enrollment
+
+> **Module:** ssi*school\
+> **Model:** `school_enrollment`\
+> **Menu:** School > Student Activities > Enrollments\
+> **Actor:** user in group \_Enrollment — User*\
+> **State:** `draft` → `confirm`\
+> **Requires:** `01-create`
+
+## Pre-Condition
+
+- **Record:** Status is **Draft**.
+- **Config:** An active `policy.template` for this model grants `confirm_ok` for state
+  `draft` to the actor's group.
+- **Config:** An active `approval.template` for this model matches this record and has
+  at least one approver level.
+- **Config:** An active `sequence.template` exists for this model.
+- **Access:** User is in group _Enrollment — User_.
+
+## Flow
+
+1. Open the **School > Student Activities > Enrollments** menu.
+2. Open the record to confirm.
+3. Click the **Confirm** button.
+4. Click **OK** on the confirmation dialog.
+
+## Post-Condition
+
+- Status changes to **Waiting for Approval**.
+- Approval records are created for each approver level defined by the approval template.

--- a/ssi_school/docs/school_enrollment/05-approve.md
+++ b/ssi_school/docs/school_enrollment/05-approve.md
@@ -1,0 +1,35 @@
+# Approve Enrollment
+
+> **Module:** ssi_school\
+> **Model:** `school_enrollment`\
+> **Menu:** School > Student Activities > Enrollments\
+> **Actor:** approver on the pending approval level\
+> **State:** `confirm` → `open`\
+> **Requires:** `04-confirm`
+
+## Pre-Condition
+
+- **Record:** Status is **Waiting for Approval**.
+- **Config:** An active `policy.template` grants `approve_ok` to the actor's group.
+- **Access:** User is registered as an approver on the approval level that is currently
+  **pending**. When the template uses sequential approval, only the first unapproved
+  level is pending.
+
+## Flow
+
+1. Open the **School > Student Activities > Enrollments** menu.
+2. Open the record to approve.
+3. Click the **Approve** button.
+4. Click **OK** on the confirmation dialog.
+
+## Post-Condition
+
+- If all approval levels are fulfilled, status changes automatically to **On Progress**
+  (there is no separate Start step — see `07-start` note below).
+- If there are still pending approval levels, status remains **Waiting for Approval**
+  and the next level becomes pending.
+
+> **Note:** `school_enrollment` inherits `mixin.transaction_open`, but
+> `_automatically_insert_open_button` is disabled and no manual Start button is
+> rendered. The transition to **On Progress** always happens automatically as soon as
+> the last approval level is fulfilled — there is no `07-start.md` for this model.

--- a/ssi_school/docs/school_enrollment/06-reject.md
+++ b/ssi_school/docs/school_enrollment/06-reject.md
@@ -1,0 +1,26 @@
+# Reject Enrollment
+
+> **Module:** ssi_school\
+> **Model:** `school_enrollment`\
+> **Menu:** School > Student Activities > Enrollments\
+> **Actor:** approver on the pending approval level\
+> **State:** `confirm` → `reject`\
+> **Requires:** `04-confirm`
+
+## Pre-Condition
+
+- **Record:** Status is **Waiting for Approval**.
+- **Config:** An active `policy.template` grants `reject_ok` to the actor's group.
+- **Access:** User is registered as an approver on the approval level that is currently
+  pending.
+
+## Flow
+
+1. Open the **School > Student Activities > Enrollments** menu.
+2. Open the record to reject.
+3. Click the **Reject** button.
+4. Click **OK** on the confirmation dialog.
+
+## Post-Condition
+
+- Status changes to **Rejected**.

--- a/ssi_school/docs/school_enrollment/09-finish.md
+++ b/ssi_school/docs/school_enrollment/09-finish.md
@@ -1,0 +1,30 @@
+# Finish Enrollment
+
+> **Module:** ssi*school\
+> **Model:** `school_enrollment`\
+> **Menu:** School > Student Activities > Enrollments\
+> **Actor:** user in group \_Enrollment — User*\
+> **State:** `open` → `done`\
+> **Requires:** `05-approve`
+
+## Pre-Condition
+
+- **Record:** Status is **On Progress**.
+- **Record:** The Academic Term of this enrollment is **not** the last term of its
+  Academic Year. When it is the last term, this button is not available — use `15-pass`,
+  `16-fail`, `17-drop-out`, or `18-graduate` instead, which record the academic year
+  result before finishing the enrollment.
+- **Config:** An active `policy.template` grants `done_ok` for state `open` to the
+  actor's group.
+- **Access:** User is in group _Enrollment — User_.
+
+## Flow
+
+1. Open the **School > Student Activities > Enrollments** menu.
+2. Open the record to finish.
+3. Click the **Done** button.
+4. Click **OK** on the confirmation dialog.
+
+## Post-Condition
+
+- Status changes to **Done**.

--- a/ssi_school/docs/school_enrollment/10-cancel.md
+++ b/ssi_school/docs/school_enrollment/10-cancel.md
@@ -1,0 +1,31 @@
+# Cancel Enrollment
+
+> **Module:** ssi*school\
+> **Model:** `school_enrollment`\
+> **Menu:** School > Student Activities > Enrollments\
+> **Actor:** user in group \_Enrollment — Validator*\
+> **State:** `draft` | `open` | `done` → `cancel`\
+> **Requires:** `01-create`
+
+## Pre-Condition
+
+- **Record:** Status is **Draft**, **On Progress**, or **Done**.
+- **Record:** None of the Payment Terms are linked to a customer invoice.
+- **Config:** An active `policy.template` grants `cancel_ok` for that state to the
+  actor's group.
+- **Access:** User is in group _Enrollment — Validator_.
+
+## Flow
+
+1. Open the **School > Student Activities > Enrollments** menu.
+2. Open the record to cancel.
+3. Click the **Cancel** button.
+4. In the wizard that appears, select the **Cancellation Reason**.
+5. Click **Confirm**.
+6. Click **OK** on the confirmation dialog.
+
+## Post-Condition
+
+- Status changes to **Cancelled**.
+- The student's status is set back to **Draft** (no effect if the student was not yet
+  enrolled by this record).

--- a/ssi_school/docs/school_enrollment/12-restart.md
+++ b/ssi_school/docs/school_enrollment/12-restart.md
@@ -1,0 +1,30 @@
+# Restart Enrollment
+
+> **Module:** ssi*school\
+> **Model:** `school_enrollment`\
+> **Menu:** School > Student Activities > Enrollments\
+> **Actor:** user in group \_Enrollment — Validator*\
+> **State:** `cancel` | `reject` → `draft`\
+> **Requires:** `10-cancel`
+
+## Pre-Condition
+
+- **Record:** Status is **Cancelled** or **Rejected**.
+- **Config:** An active `policy.template` grants `restart_ok` for that state to the
+  actor's group.
+- **Access:** User is in group _Enrollment — Validator_.
+
+## Flow
+
+1. Open the **School > Student Activities > Enrollments** menu.
+2. Open the record to restart.
+3. Click the **Restart** button.
+4. Click **OK** on the confirmation dialog.
+
+## Post-Condition
+
+- Status returns to **Draft**.
+- All approval records are removed and the approval template is cleared. A later Confirm
+  starts the approval process from the beginning.
+- Any Payment Term or Payment Term Detail line that had been locked (e.g. by
+  `20-close-addendum`) is unlocked again.

--- a/ssi_school/docs/school_enrollment/13-reset-number.md
+++ b/ssi_school/docs/school_enrollment/13-reset-number.md
@@ -1,0 +1,29 @@
+# Reset Document Number — Enrollment
+
+> **Module:** ssi*school\
+> **Model:** `school_enrollment`\
+> **Menu:** School > Student Activities > Enrollments\
+> **Actor:** user in group \_Enrollment — Validator*\
+> **Requires:** `01-create`
+
+## Pre-Condition
+
+- **Record:** Status is **Draft**.
+- **Config:** An active `sequence.template` exists for this model.
+- **Config:** An active `policy.template` grants `manual_number_ok` for state `draft` to
+  the actor's group.
+- **Access:** User is in group _Enrollment — Validator_.
+
+## Flow
+
+1. Open the **School > Student Activities > Enrollments** menu.
+2. Open the record whose document number will be reset.
+3. Click the **Reset Document Number** button (or edit the **# Document** field directly
+   and change it to **/**).
+4. Click **OK** on the confirmation dialog (only when the button was used).
+
+## Post-Condition
+
+- Document number returns to **/**.
+- The record will receive an automatic number when it transitions to **On Progress**,
+  according to the configured sequence.

--- a/ssi_school/docs/school_enrollment/14-restart-approval.md
+++ b/ssi_school/docs/school_enrollment/14-restart-approval.md
@@ -1,0 +1,32 @@
+# Restart Approval Process — Enrollment
+
+> **Module:** ssi*school\
+> **Model:** `school_enrollment`\
+> **Menu:** School > Student Activities > Enrollments\
+> **Actor:** user in group \_Enrollment — User*\
+> **Requires:** `04-confirm`
+
+## Pre-Condition
+
+- **Record:** Status is **Waiting for Approval**, and the approval process is stalled
+  (for example, the record currently has no approval template assigned, or the assigned
+  template no longer matches).
+- **Config:** An active `policy.template` for this model grants `restart_approval_ok`
+  for state `confirm` to the actor's group.
+- **Config:** An active `approval.template` for this model matches this record, with an
+  approver group configured for its approval level, so the process can be rebuilt once
+  restarted.
+- **Access:** User is in group _Enrollment — User_.
+
+## Flow
+
+1. Open the **School > Student Activities > Enrollments** menu.
+2. Open the record whose approval process is stalled.
+3. Click the **Restart Approval Process** button.
+4. Click **OK** on the confirmation dialog.
+
+## Post-Condition
+
+- Status remains **Waiting for Approval**.
+- The existing approval records are discarded and a new approval process is created from
+  the approval template that now matches the record.

--- a/ssi_school/docs/school_enrollment/15-pass.md
+++ b/ssi_school/docs/school_enrollment/15-pass.md
@@ -1,0 +1,32 @@
+# Set Result to Passed — Enrollment
+
+> **Module:** ssi*school\
+> **Model:** `school_enrollment`\
+> **Menu:** School > Student Activities > Enrollments\
+> **Actor:** user in group \_Enrollment — User*\
+> **State:** `open` → `done`\
+> **Requires:** `05-approve`
+
+## Pre-Condition
+
+- **Record:** Status is **On Progress**.
+- **Record:** The Academic Term of this enrollment is the last term of its Academic Year
+  (this button is only available on the last term; use `09-finish` on earlier terms).
+- **Config:** An active `policy.template` for this model grants `pass_ok` for state
+  `open` to the actor's group.
+- **Access:** User is in group _Enrollment — User_.
+
+## Flow
+
+1. Open the **School > Student Activities > Enrollments** menu.
+2. Open the record to set as Passed.
+3. Click the **Pass** button (`action_set_result_to_passed`).
+4. Click **OK** on the confirmation dialog.
+
+## Post-Condition
+
+- Status changes to **Done**.
+- **Academic Year Result** is set to **Passed**, and **Promote To Grade** is filled with
+  the Grade's configured next grade.
+- The student's status returns to **Waiting for Enrollment**, ready for a new enrollment
+  on the promoted grade.

--- a/ssi_school/docs/school_enrollment/16-fail.md
+++ b/ssi_school/docs/school_enrollment/16-fail.md
@@ -1,0 +1,31 @@
+# Set Result to Failed — Enrollment
+
+> **Module:** ssi*school\
+> **Model:** `school_enrollment`\
+> **Menu:** School > Student Activities > Enrollments\
+> **Actor:** user in group \_Enrollment — User*\
+> **State:** `open` → `done`\
+> **Requires:** `05-approve`
+
+## Pre-Condition
+
+- **Record:** Status is **On Progress**.
+- **Record:** The Academic Term of this enrollment is the last term of its Academic Year
+  (this button is only available on the last term; use `09-finish` on earlier terms).
+- **Config:** An active `policy.template` for this model grants `fail_ok` for state
+  `open` to the actor's group.
+- **Access:** User is in group _Enrollment — User_.
+
+## Flow
+
+1. Open the **School > Student Activities > Enrollments** menu.
+2. Open the record to set as Failed.
+3. Click the **Fail** button (`action_set_result_to_failed`).
+4. Click **OK** on the confirmation dialog.
+
+## Post-Condition
+
+- Status changes to **Done**.
+- **Academic Year Result** is set to **Failed**. **Promote To Grade** is left empty.
+- The student's status returns to **Waiting for Enrollment**, so a new enrollment can be
+  created for the same grade (repeating the year).

--- a/ssi_school/docs/school_enrollment/17-drop-out.md
+++ b/ssi_school/docs/school_enrollment/17-drop-out.md
@@ -1,0 +1,30 @@
+# Set Result to Drop Out — Enrollment
+
+> **Module:** ssi*school\
+> **Model:** `school_enrollment`\
+> **Menu:** School > Student Activities > Enrollments\
+> **Actor:** user in group \_Enrollment — User*\
+> **State:** `open` → `done`\
+> **Requires:** `05-approve`
+
+## Pre-Condition
+
+- **Record:** Status is **On Progress**.
+- **Record:** The Academic Term of this enrollment is the last term of its Academic Year
+  (this button is only available on the last term; use `09-finish` on earlier terms).
+- **Config:** An active `policy.template` for this model grants `drop_out_ok` for state
+  `open` to the actor's group.
+- **Access:** User is in group _Enrollment — User_.
+
+## Flow
+
+1. Open the **School > Student Activities > Enrollments** menu.
+2. Open the record to set as Drop Out.
+3. Click the **Drop Out** button (`action_set_result_to_drop_out`).
+4. Click **OK** on the confirmation dialog.
+
+## Post-Condition
+
+- Status changes to **Done**.
+- **Academic Year Result** is set to **Drop Out**. **Promote To Grade** is left empty.
+- The student's status is set to **Dropped Out / Expelled**.

--- a/ssi_school/docs/school_enrollment/18-graduate.md
+++ b/ssi_school/docs/school_enrollment/18-graduate.md
@@ -1,0 +1,30 @@
+# Set Result to Graduate — Enrollment
+
+> **Module:** ssi*school\
+> **Model:** `school_enrollment`\
+> **Menu:** School > Student Activities > Enrollments\
+> **Actor:** user in group \_Enrollment — User*\
+> **State:** `open` → `done`\
+> **Requires:** `05-approve`
+
+## Pre-Condition
+
+- **Record:** Status is **On Progress**.
+- **Record:** The Academic Term of this enrollment is the last term of its Academic Year
+  (this button is only available on the last term; use `09-finish` on earlier terms).
+- **Config:** An active `policy.template` for this model grants `graduate_ok` for state
+  `open` to the actor's group.
+- **Access:** User is in group _Enrollment — User_.
+
+## Flow
+
+1. Open the **School > Student Activities > Enrollments** menu.
+2. Open the record to set as Graduate.
+3. Click the **Graduate** button (`action_set_result_to_graduate`).
+4. Click **OK** on the confirmation dialog.
+
+## Post-Condition
+
+- Status changes to **Done**.
+- **Academic Year Result** is set to **Graduate**. **Promote To Grade** is left empty.
+- The student's status is set to **Graduated**.

--- a/ssi_school/docs/school_enrollment/19-create-due-invoice.md
+++ b/ssi_school/docs/school_enrollment/19-create-due-invoice.md
@@ -1,0 +1,38 @@
+# Create Due Invoice — Enrollment
+
+> **Module:** ssi*school\
+> **Model:** `school_enrollment`\
+> **Menu:** School > Student Activities > Enrollments\
+> **Actor:** user in group \_Enrollment — User*\
+> **Requires:** `05-approve`
+
+## Pre-Condition
+
+- **Record:** Status is **On Progress**.
+- **Record:** At least one Payment Term is **Uninvoiced** and has an Estimated Invoice
+  Date on or before the date range used in the wizard.
+- **Config:** An active `policy.template` for this model grants `create_invoice_ok` for
+  state `open` to the actor's group.
+- **Access:** User is in group _Enrollment — User_.
+
+## Flow
+
+1. Open the **School > Student Activities > Enrollments** menu.
+2. Open the record whose due Payment Terms will be invoiced.
+3. Click the **Create Due Invoice** button (`action_open_create_due_invoice_wizard`).
+4. In the **Create Due Invoice** wizard, the current record is pre-selected in
+   **Enrollments**; more enrollments may be added.
+5. Fill in the optional fields:
+   - **Date Start**: Optional. Lower bound (inclusive) on Estimated Invoice Date. Leave
+     empty for no lower bound.
+   - **Date End**: Optional. Upper bound (inclusive) on Estimated Invoice Date. Leave
+     empty to process up to today.
+6. Click **Create Due Invoice** (`action_create_due_invoice`) in the wizard footer.
+
+## Post-Condition
+
+- A customer invoice is created for every Payment Term of the selected enrollment(s)
+  that is **Uninvoiced** (Payment Terms marked **Manual** are a separate status and are
+  skipped) and has an Estimated Invoice Date within the selected range.
+- Each processed Payment Term's status changes to **Invoiced** and is linked to its new
+  invoice.

--- a/ssi_school/docs/school_enrollment/20-close-addendum.md
+++ b/ssi_school/docs/school_enrollment/20-close-addendum.md
@@ -1,0 +1,30 @@
+# Close Addendum — Enrollment
+
+> **Module:** ssi*school\
+> **Model:** `school_enrollment`\
+> **Menu:** School > Student Activities > Enrollments\
+> **Actor:** user in group \_Enrollment — Validator*\
+> **Requires:** `05-approve`
+
+## Pre-Condition
+
+- **Record:** Status is **On Progress**.
+- **Record:** At least one Payment Term or Payment Term Detail line is currently
+  unlocked (for example, one added after the enrollment opened).
+- **Config:** An active `policy.template` for this model grants `addendum_ok` for state
+  `open` to the actor's group.
+- **Access:** User is in group _Enrollment — Validator_.
+
+## Flow
+
+1. Open the **School > Student Activities > Enrollments** menu.
+2. Open the record whose addendum Payment Terms will be locked.
+3. On the **Billing** tab, click the **Close Addendum** button
+   (`action_close_addendum`).
+4. Click **OK** on the confirmation dialog.
+
+## Post-Condition
+
+- Status remains **On Progress**.
+- Every currently unlocked Payment Term and Payment Term Detail line becomes locked and
+  can no longer be changed, until the enrollment is restarted (`12-restart`).

--- a/ssi_school/docs/school_enrollment/21-print.md
+++ b/ssi_school/docs/school_enrollment/21-print.md
@@ -1,0 +1,26 @@
+# Print Enrollment
+
+> **Module:** ssi*school\
+> **Model:** `school_enrollment`\
+> **Menu:** School > Student Activities > Enrollments\
+> **Actor:** user in group \_Enrollment — Viewer*\
+> **Requires:** `01-create`
+
+## Pre-Condition
+
+- **Config:** At least one `print_document_type` (with a linked report for
+  `school_enrollment`) is configured, so a report is available to select in step 4.
+- **Access:** User is in group _Enrollment — Viewer_.
+
+## Flow
+
+1. Open the **School > Student Activities > Enrollments** menu.
+2. Open the record to print.
+3. Click **Print** in the header.
+4. In the **Select Report To Print** wizard, select a **Type** (optional filter) and the
+   **Report Template** to generate.
+5. Click **Print**.
+
+## Post-Condition
+
+- The selected report is generated and opened/downloaded.

--- a/ssi_school/docs/school_enrollment/22-reload-template-policy.md
+++ b/ssi_school/docs/school_enrollment/22-reload-template-policy.md
@@ -1,0 +1,29 @@
+# Reload Template Policy — Enrollment
+
+> **Module:** ssi*school\
+> **Model:** `school_enrollment`\
+> **Menu:** School > Student Activities > Enrollments\
+> **Actor:** administrator in group \_Settings / Technical Settings*\
+> **Requires:** `01-create`
+
+## Pre-Condition
+
+- **Record:** None — usable regardless of status.
+- **Config:** At least one active `policy.template` exists for this model, so a matching
+  template can be found.
+- **Access:** User is in group _Settings / Technical Settings_ (`base.group_system`).
+  The **Policies** tab that contains this button is only visible to this group.
+
+## Flow
+
+1. Open the **School > Student Activities > Enrollments** menu.
+2. Open the record whose assigned policy template should be re-evaluated.
+3. On the **Policies** tab, click **Reload Template Policy**.
+
+## Post-Condition
+
+- **Policy Template** is recomputed and re-assigned to the highest-sequence
+  `policy.template` for this model whose condition currently matches the record. This
+  may change which action buttons and policy fields (`confirm_ok`,
+  `restart_approval_ok`, the Pass/Fail/Drop Out/Graduate/Create Due Invoice/Close
+  Addendum policy fields, etc.) are granted, without changing the record's status.

--- a/ssi_school/docs/school_homeroom/01-create.md
+++ b/ssi_school/docs/school_homeroom/01-create.md
@@ -1,0 +1,43 @@
+# Create Homeroom
+
+> **Module:** ssi*school\
+> **Model:** `school_homeroom`\
+> **Menu:** School > Student Activities > Homerooms\
+> **Actor:** user in group \_Homeroom — User*\
+> **State:** `—` → `draft`
+
+## Pre-Condition
+
+- **Data:** The destination Academic Year, Academic Term, School, Grade, and Grade Class
+  already exist.
+- **Data:** At least one Student is eligible for the selected Grade/Term (a Draft
+  student whose `next_grade_id` matches the Grade, on the first term of the year, or
+  whose `current_grade_id` matches the Grade on later terms).
+- **Config:** An active `policy.template` for this model grants `confirm_ok` for state
+  `draft` to the actor's group (needed later by `04-confirm`).
+- **Access:** User is in group _Homeroom — User_.
+
+## Flow
+
+1. Open the **School > Student Activities > Homerooms** menu.
+2. Click the **New** button. **(14.0: "Create")**
+3. Fill in the required fields:
+   - **Academic Year** _(required)_: Select the academic year of this Homeroom batch.
+   - **Academic Term** _(required)_: Select the term, restricted to terms of the
+     selected Academic Year.
+   - **School** _(required)_: Select the school.
+   - **Grade** _(required)_: Select the class level, restricted to the school's Grade
+     Type.
+   - **Grade Class** _(required)_: Select the physical classroom, restricted to classes
+     that belong to the selected Grade and School.
+   - **Teacher**: Optional. The homeroom teacher responsible for this batch.
+   - **Date**: Defaults to today's date. Change if needed.
+   - **Capacity**: Automatically filled from **Grade Class**. Change if needed.
+4. On the **Generate Enrollments** tab, select **Candidate Students** manually, or use
+   `15-fill-random`/`16-generate-enrollments` after saving to fill and generate them in
+   bulk.
+5. Click **Save**.
+
+## Post-Condition
+
+- A new record is created in **Draft** status.

--- a/ssi_school/docs/school_homeroom/02-edit.md
+++ b/ssi_school/docs/school_homeroom/02-edit.md
@@ -1,0 +1,25 @@
+# Edit Homeroom
+
+> **Module:** ssi*school\
+> **Model:** `school_homeroom`\
+> **Menu:** School > Student Activities > Homerooms\
+> **Actor:** user in group \_Homeroom — User*\
+> **Requires:** `01-create`
+
+## Pre-Condition
+
+- **Record:** Status is **Draft**.
+- **Access:** User is in group _Homeroom — User_.
+
+## Flow
+
+1. Open the **School > Student Activities > Homerooms** menu.
+2. Find and open the record to edit.
+3. Change the required fields.
+4. On the **Generate Enrollments** tab, add or remove **Candidate Students** manually as
+   needed.
+5. Click **Save**.
+
+## Post-Condition
+
+- The record is updated with the new values.

--- a/ssi_school/docs/school_homeroom/03-delete.md
+++ b/ssi_school/docs/school_homeroom/03-delete.md
@@ -1,0 +1,24 @@
+# Delete Homeroom
+
+> **Module:** ssi*school\
+> **Model:** `school_homeroom`\
+> **Menu:** School > Student Activities > Homerooms\
+> **Actor:** user in group \_Homeroom — User*\
+> **Requires:** `01-create`
+
+## Pre-Condition
+
+- **Record:** Status is **Draft**.
+- **Record:** Document number is still **/** (not yet generated).
+- **Access:** User is in group _Homeroom — User_.
+
+## Flow
+
+1. Open the **School > Student Activities > Homerooms** menu.
+2. Select one or more records to delete (check the checkbox).
+3. Click **Action** > **Delete**.
+4. Click **OK** to confirm.
+
+## Post-Condition
+
+- The selected records are permanently removed from the system.

--- a/ssi_school/docs/school_homeroom/04-confirm.md
+++ b/ssi_school/docs/school_homeroom/04-confirm.md
@@ -1,0 +1,30 @@
+# Confirm Homeroom
+
+> **Module:** ssi*school\
+> **Model:** `school_homeroom`\
+> **Menu:** School > Student Activities > Homerooms\
+> **Actor:** user in group \_Homeroom — User*\
+> **State:** `draft` → `confirm`\
+> **Requires:** `01-create`
+
+## Pre-Condition
+
+- **Record:** Status is **Draft**.
+- **Config:** An active `policy.template` for this model grants `confirm_ok` for state
+  `draft` to the actor's group.
+- **Config:** An active `approval.template` for this model matches this record and has
+  at least one approver level.
+- **Config:** An active `sequence.template` exists for this model.
+- **Access:** User is in group _Homeroom — User_.
+
+## Flow
+
+1. Open the **School > Student Activities > Homerooms** menu.
+2. Open the record to confirm.
+3. Click the **Confirm** button.
+4. Click **OK** on the confirmation dialog.
+
+## Post-Condition
+
+- Status changes to **Waiting for Approval**.
+- Approval records are created for each approver level defined by the approval template.

--- a/ssi_school/docs/school_homeroom/05-approve.md
+++ b/ssi_school/docs/school_homeroom/05-approve.md
@@ -1,0 +1,35 @@
+# Approve Homeroom
+
+> **Module:** ssi_school\
+> **Model:** `school_homeroom`\
+> **Menu:** School > Student Activities > Homerooms\
+> **Actor:** approver on the pending approval level\
+> **State:** `confirm` → `open`\
+> **Requires:** `04-confirm`
+
+## Pre-Condition
+
+- **Record:** Status is **Waiting for Approval**.
+- **Config:** An active `policy.template` grants `approve_ok` to the actor's group.
+- **Access:** User is registered as an approver on the approval level that is currently
+  **pending**. When the template uses sequential approval, only the first unapproved
+  level is pending.
+
+## Flow
+
+1. Open the **School > Student Activities > Homerooms** menu.
+2. Open the record to approve.
+3. Click the **Approve** button.
+4. Click **OK** on the confirmation dialog.
+
+## Post-Condition
+
+- If all approval levels are fulfilled, status changes automatically to **On Progress**
+  (there is no separate Start step — see note below).
+- If there are still pending approval levels, status remains **Waiting for Approval**
+  and the next level becomes pending.
+
+> **Note:** `school_homeroom` inherits `mixin.transaction_open`, but
+> `_automatically_insert_open_button` is disabled and no manual Start button is
+> rendered. The transition to **On Progress** always happens automatically as soon as
+> the last approval level is fulfilled — there is no `07-start.md` for this model.

--- a/ssi_school/docs/school_homeroom/06-reject.md
+++ b/ssi_school/docs/school_homeroom/06-reject.md
@@ -1,0 +1,26 @@
+# Reject Homeroom
+
+> **Module:** ssi_school\
+> **Model:** `school_homeroom`\
+> **Menu:** School > Student Activities > Homerooms\
+> **Actor:** approver on the pending approval level\
+> **State:** `confirm` → `reject`\
+> **Requires:** `04-confirm`
+
+## Pre-Condition
+
+- **Record:** Status is **Waiting for Approval**.
+- **Config:** An active `policy.template` grants `reject_ok` to the actor's group.
+- **Access:** User is registered as an approver on the approval level that is currently
+  pending.
+
+## Flow
+
+1. Open the **School > Student Activities > Homerooms** menu.
+2. Open the record to reject.
+3. Click the **Reject** button.
+4. Click **OK** on the confirmation dialog.
+
+## Post-Condition
+
+- Status changes to **Rejected**.

--- a/ssi_school/docs/school_homeroom/09-finish.md
+++ b/ssi_school/docs/school_homeroom/09-finish.md
@@ -1,0 +1,26 @@
+# Finish Homeroom
+
+> **Module:** ssi*school\
+> **Model:** `school_homeroom`\
+> **Menu:** School > Student Activities > Homerooms\
+> **Actor:** user in group \_Homeroom — User*\
+> **State:** `open` → `done`\
+> **Requires:** `05-approve`
+
+## Pre-Condition
+
+- **Record:** Status is **On Progress**.
+- **Config:** An active `policy.template` grants `done_ok` for state `open` to the
+  actor's group.
+- **Access:** User is in group _Homeroom — User_.
+
+## Flow
+
+1. Open the **School > Student Activities > Homerooms** menu.
+2. Open the record to finish.
+3. Click the **Done** button.
+4. Click **OK** on the confirmation dialog.
+
+## Post-Condition
+
+- Status changes to **Done**.

--- a/ssi_school/docs/school_homeroom/10-cancel.md
+++ b/ssi_school/docs/school_homeroom/10-cancel.md
@@ -1,0 +1,29 @@
+# Cancel Homeroom
+
+> **Module:** ssi*school\
+> **Model:** `school_homeroom`\
+> **Menu:** School > Student Activities > Homerooms\
+> **Actor:** user in group \_Homeroom — Validator*\
+> **State:** `draft` | `confirm` | `reject` → `cancel`\
+> **Requires:** `01-create`
+
+## Pre-Condition
+
+- **Record:** Status is **Draft**, **Waiting for Approval**, or **Rejected**. Once the
+  batch reaches **On Progress** or **Done**, it can no longer be cancelled.
+- **Config:** An active `policy.template` grants `cancel_ok` for that state to the
+  actor's group.
+- **Access:** User is in group _Homeroom — Validator_.
+
+## Flow
+
+1. Open the **School > Student Activities > Homerooms** menu.
+2. Open the record to cancel.
+3. Click the **Cancel** button.
+4. In the wizard that appears, select the **Cancellation Reason**.
+5. Click **Confirm**.
+6. Click **OK** on the confirmation dialog.
+
+## Post-Condition
+
+- Status changes to **Cancelled**.

--- a/ssi_school/docs/school_homeroom/12-restart.md
+++ b/ssi_school/docs/school_homeroom/12-restart.md
@@ -1,0 +1,28 @@
+# Restart Homeroom
+
+> **Module:** ssi*school\
+> **Model:** `school_homeroom`\
+> **Menu:** School > Student Activities > Homerooms\
+> **Actor:** user in group \_Homeroom — Validator*\
+> **State:** `cancel` | `reject` → `draft`\
+> **Requires:** `10-cancel`
+
+## Pre-Condition
+
+- **Record:** Status is **Cancelled** or **Rejected**.
+- **Config:** An active `policy.template` grants `restart_ok` for that state to the
+  actor's group.
+- **Access:** User is in group _Homeroom — Validator_.
+
+## Flow
+
+1. Open the **School > Student Activities > Homerooms** menu.
+2. Open the record to restart.
+3. Click the **Restart** button.
+4. Click **OK** on the confirmation dialog.
+
+## Post-Condition
+
+- Status returns to **Draft**.
+- All approval records are removed and the approval template is cleared. A later Confirm
+  starts the approval process from the beginning.

--- a/ssi_school/docs/school_homeroom/13-reset-number.md
+++ b/ssi_school/docs/school_homeroom/13-reset-number.md
@@ -1,0 +1,29 @@
+# Reset Document Number — Homeroom
+
+> **Module:** ssi*school\
+> **Model:** `school_homeroom`\
+> **Menu:** School > Student Activities > Homerooms\
+> **Actor:** user in group \_Homeroom — Validator*\
+> **Requires:** `01-create`
+
+## Pre-Condition
+
+- **Record:** Status is **Draft**.
+- **Config:** An active `sequence.template` exists for this model.
+- **Config:** An active `policy.template` grants `manual_number_ok` for state `draft` to
+  the actor's group.
+- **Access:** User is in group _Homeroom — Validator_.
+
+## Flow
+
+1. Open the **School > Student Activities > Homerooms** menu.
+2. Open the record whose document number will be reset.
+3. Click the **Reset Document Number** button (or edit the **# Document** field directly
+   and change it to **/**).
+4. Click **OK** on the confirmation dialog (only when the button was used).
+
+## Post-Condition
+
+- Document number returns to **/**.
+- The record will receive an automatic number when it transitions to **On Progress**,
+  according to the configured sequence.

--- a/ssi_school/docs/school_homeroom/14-restart-approval.md
+++ b/ssi_school/docs/school_homeroom/14-restart-approval.md
@@ -1,0 +1,32 @@
+# Restart Approval Process — Homeroom
+
+> **Module:** ssi*school\
+> **Model:** `school_homeroom`\
+> **Menu:** School > Student Activities > Homerooms\
+> **Actor:** user in group \_Homeroom — User*\
+> **Requires:** `04-confirm`
+
+## Pre-Condition
+
+- **Record:** Status is **Waiting for Approval**, and the approval process is stalled
+  (for example, the record currently has no approval template assigned, or the assigned
+  template no longer matches).
+- **Config:** An active `policy.template` for this model grants `restart_approval_ok`
+  for state `confirm` to the actor's group.
+- **Config:** An active `approval.template` for this model matches this record, with an
+  approver group configured for its approval level, so the process can be rebuilt once
+  restarted.
+- **Access:** User is in group _Homeroom — User_.
+
+## Flow
+
+1. Open the **School > Student Activities > Homerooms** menu.
+2. Open the record whose approval process is stalled.
+3. Click the **Restart Approval Process** button.
+4. Click **OK** on the confirmation dialog.
+
+## Post-Condition
+
+- Status remains **Waiting for Approval**.
+- The existing approval records are discarded and a new approval process is created from
+  the approval template that now matches the record.

--- a/ssi_school/docs/school_homeroom/15-fill-random.md
+++ b/ssi_school/docs/school_homeroom/15-fill-random.md
@@ -1,0 +1,32 @@
+# Fill Random — Homeroom
+
+> **Module:** ssi*school\
+> **Model:** `school_homeroom`\
+> **Menu:** School > Student Activities > Homerooms\
+> **Actor:** user in group \_Homeroom — User*\
+> **Requires:** `01-create`
+
+## Pre-Condition
+
+- **Record:** Status is **Draft** or **On Progress**.
+- **Record:** Remaining seats are available (**Capacity** minus current **Candidate
+  Students** and **Enrolled Count** is greater than zero).
+- **Record:** At least one eligible student (matching the selected Grade/Term) is not
+  already a Candidate or already enrolled under this batch.
+- **Config:** An active `policy.template` for this model grants `fill_random_ok` for
+  that state to the actor's group.
+- **Access:** User is in group _Homeroom — User_.
+
+## Flow
+
+1. Open the **School > Student Activities > Homerooms** menu.
+2. Open the record to fill.
+3. On the **Generate Enrollments** tab, click the **Fill Random** button
+   (`action_fill_random`).
+
+## Post-Condition
+
+- **Candidate Students** is filled with a random selection of eligible students, up to
+  the number of remaining seats. If no seats remain or no eligible students are
+  available, the list is left unchanged.
+- Status does not change.

--- a/ssi_school/docs/school_homeroom/16-generate-enrollments.md
+++ b/ssi_school/docs/school_homeroom/16-generate-enrollments.md
@@ -1,0 +1,40 @@
+# Generate Enrollments — Homeroom
+
+> **Module:** ssi*school\
+> **Model:** `school_homeroom`\
+> **Menu:** School > Student Activities > Homerooms\
+> **Actor:** user in group \_Homeroom — User*\
+> **Requires:** `05-approve`
+
+## Pre-Condition
+
+- **Record:** Status is **On Progress**.
+- **Record:** **Candidate Students** contains at least one student that does not yet
+  have an Enrollment under this batch.
+- **Record:** Every Enrollment previously generated under this batch whose student is no
+  longer in **Candidate Students** must already be in Draft status (otherwise it must be
+  cancelled/adjusted manually first, or the student added back to **Candidate
+  Students**).
+- **Config:** An active `policy.template` for this model grants
+  `generate_enrollments_ok` for state `open` to the actor's group.
+- **Access:** User is in group _Homeroom — User_.
+
+## Flow
+
+1. Open the **School > Student Activities > Homerooms** menu.
+2. Open the record whose enrollments will be generated.
+3. On the **Generate Enrollments** tab, add or adjust **Candidate Students** if needed
+   (manually or via `15-fill-random`).
+4. Click the **Generate Enrollments** button (`action_generate_enrollments`).
+5. Click **OK** on the confirmation dialog.
+
+## Post-Condition
+
+- Any Draft Enrollment previously generated under this batch whose student is no longer
+  a Candidate is deleted.
+- One background job per remaining new Candidate Student is enqueued to create a Draft
+  `school_enrollment` record (see `ssi_school/school_enrollment/01-create`) pre-filled
+  from this batch's Academic Year, Academic Term, School, Grade, Grade Class, and
+  default Payment Template. Results appear on the **Enrollments** tab as each job
+  completes.
+- Status does not change.

--- a/ssi_school/docs/school_homeroom/17-print.md
+++ b/ssi_school/docs/school_homeroom/17-print.md
@@ -1,0 +1,26 @@
+# Print Homeroom
+
+> **Module:** ssi*school\
+> **Model:** `school_homeroom`\
+> **Menu:** School > Student Activities > Homerooms\
+> **Actor:** user in group \_Homeroom — Viewer*\
+> **Requires:** `01-create`
+
+## Pre-Condition
+
+- **Config:** At least one `print_document_type` (with a linked report for
+  `school_homeroom`) is configured, so a report is available to select in step 4.
+- **Access:** User is in group _Homeroom — Viewer_.
+
+## Flow
+
+1. Open the **School > Student Activities > Homerooms** menu.
+2. Open the record to print.
+3. Click **Print** in the header.
+4. In the **Select Report To Print** wizard, select a **Type** (optional filter) and the
+   **Report Template** to generate.
+5. Click **Print**.
+
+## Post-Condition
+
+- The selected report is generated and opened/downloaded.

--- a/ssi_school/docs/school_homeroom/18-reload-template-policy.md
+++ b/ssi_school/docs/school_homeroom/18-reload-template-policy.md
@@ -1,0 +1,29 @@
+# Reload Template Policy — Homeroom
+
+> **Module:** ssi*school\
+> **Model:** `school_homeroom`\
+> **Menu:** School > Student Activities > Homerooms\
+> **Actor:** administrator in group \_Settings / Technical Settings*\
+> **Requires:** `01-create`
+
+## Pre-Condition
+
+- **Record:** None — usable regardless of status.
+- **Config:** At least one active `policy.template` exists for this model, so a matching
+  template can be found.
+- **Access:** User is in group _Settings / Technical Settings_ (`base.group_system`).
+  The **Policies** tab that contains this button is only visible to this group.
+
+## Flow
+
+1. Open the **School > Student Activities > Homerooms** menu.
+2. Open the record whose assigned policy template should be re-evaluated.
+3. On the **Policies** tab, click **Reload Template Policy**.
+
+## Post-Condition
+
+- **Policy Template** is recomputed and re-assigned to the highest-sequence
+  `policy.template` for this model whose condition currently matches the record. This
+  may change which action buttons and policy fields (`confirm_ok`,
+  `restart_approval_ok`, `fill_random_ok`, `generate_enrollments_ok`, etc.) are granted,
+  without changing the record's status.

--- a/ssi_school/docs/school_student_mutation/01-create.md
+++ b/ssi_school/docs/school_student_mutation/01-create.md
@@ -1,0 +1,42 @@
+# Create Student Class Mutation
+
+> **Module:** ssi*school\
+> **Model:** `school_student_mutation`\
+> **Menu:** School > Student Activities > Student Class Mutations\
+> **Actor:** user in group \_Student Class Mutation — User*\
+> **State:** `—` → `draft`
+
+## Pre-Condition
+
+- **Data:** The student to be moved has an open Enrollment (status **On Progress**).
+- **Data:** At least one other Grade Class exists within the same Grade and School as
+  the student's current Enrollment, to be selected as the destination.
+- **Config:** An active `policy.template` for this model grants `confirm_ok` for state
+  `draft` to the actor's group (needed later by `04-confirm`).
+- **Access:** User is in group _Student Class Mutation — User_.
+
+## Flow
+
+1. Open the **School > Student Activities > Student Class Mutations** menu.
+2. Click the **New** button. **(14.0: "Create")**
+3. Fill in the required fields:
+   - **Student** _(required)_: Select the student whose grade class is being changed.
+   - **Enrollment** _(required)_: Automatically filled with the student's open
+     Enrollment if there is exactly one. Restricted to the student's Enrollments
+     currently in **On Progress**. Change if the student has more than one candidate
+     (not expected in normal use).
+   - **Source Grade Class**: Automatically filled from **Enrollment**.
+   - **Source Homeroom**: Automatically filled from **Enrollment**.
+   - **Destination Grade Class** _(required)_: Select the grade class the student will
+     be moved into, restricted to classes in the same Grade and School as the
+     Enrollment, excluding the current class.
+   - **Destination Homeroom**: Automatically filled if an open Homeroom batch for the
+     selected **Destination Grade Class** (matching the Enrollment's Academic Year,
+     Term, and Grade) exists. Change if needed, or leave empty if no batch exists.
+   - **Date**: Defaults to today's date. Change if needed.
+   - **Reason**: Optional explanation for the mutation.
+4. Click **Save**.
+
+## Post-Condition
+
+- A new record is created in **Draft** status.

--- a/ssi_school/docs/school_student_mutation/02-edit.md
+++ b/ssi_school/docs/school_student_mutation/02-edit.md
@@ -1,0 +1,23 @@
+# Edit Student Class Mutation
+
+> **Module:** ssi*school\
+> **Model:** `school_student_mutation`\
+> **Menu:** School > Student Activities > Student Class Mutations\
+> **Actor:** user in group \_Student Class Mutation — User*\
+> **Requires:** `01-create`
+
+## Pre-Condition
+
+- **Record:** Status is **Draft**.
+- **Access:** User is in group _Student Class Mutation — User_.
+
+## Flow
+
+1. Open the **School > Student Activities > Student Class Mutations** menu.
+2. Find and open the record to edit.
+3. Change the required fields.
+4. Click **Save**.
+
+## Post-Condition
+
+- The record is updated with the new values.

--- a/ssi_school/docs/school_student_mutation/03-delete.md
+++ b/ssi_school/docs/school_student_mutation/03-delete.md
@@ -1,0 +1,24 @@
+# Delete Student Class Mutation
+
+> **Module:** ssi*school\
+> **Model:** `school_student_mutation`\
+> **Menu:** School > Student Activities > Student Class Mutations\
+> **Actor:** user in group \_Student Class Mutation — User*\
+> **Requires:** `01-create`
+
+## Pre-Condition
+
+- **Record:** Status is **Draft**.
+- **Record:** Document number is still **/** (not yet generated).
+- **Access:** User is in group _Student Class Mutation — User_.
+
+## Flow
+
+1. Open the **School > Student Activities > Student Class Mutations** menu.
+2. Select one or more records to delete (check the checkbox).
+3. Click **Action** > **Delete**.
+4. Click **OK** to confirm.
+
+## Post-Condition
+
+- The selected records are permanently removed from the system.

--- a/ssi_school/docs/school_student_mutation/04-confirm.md
+++ b/ssi_school/docs/school_student_mutation/04-confirm.md
@@ -1,0 +1,33 @@
+# Confirm Student Class Mutation
+
+> **Module:** ssi*school\
+> **Model:** `school_student_mutation`\
+> **Menu:** School > Student Activities > Student Class Mutations\
+> **Actor:** user in group \_Student Class Mutation — User*\
+> **State:** `draft` → `confirm`\
+> **Requires:** `01-create`
+
+## Pre-Condition
+
+- **Record:** Status is **Draft**.
+- **Record:** The Enrollment is still **On Progress**.
+- **Record:** No other Draft or Waiting for Approval mutation already exists for the
+  same Enrollment.
+- **Config:** An active `policy.template` for this model grants `confirm_ok` for state
+  `draft` to the actor's group.
+- **Config:** An active `approval.template` for this model matches this record and has
+  at least one approver level.
+- **Config:** An active `sequence.template` exists for this model.
+- **Access:** User is in group _Student Class Mutation — User_.
+
+## Flow
+
+1. Open the **School > Student Activities > Student Class Mutations** menu.
+2. Open the record to confirm.
+3. Click the **Confirm** button.
+4. Click **OK** on the confirmation dialog.
+
+## Post-Condition
+
+- Status changes to **Waiting for Approval**.
+- Approval records are created for each approver level defined by the approval template.

--- a/ssi_school/docs/school_student_mutation/05-approve.md
+++ b/ssi_school/docs/school_student_mutation/05-approve.md
@@ -1,0 +1,40 @@
+# Approve Student Class Mutation
+
+> **Module:** ssi_school\
+> **Model:** `school_student_mutation`\
+> **Menu:** School > Student Activities > Student Class Mutations\
+> **Actor:** approver on the pending approval level\
+> **State:** `confirm` → `done`\
+> **Requires:** `04-confirm`
+
+## Pre-Condition
+
+- **Record:** Status is **Waiting for Approval**.
+- **Record:** The Enrollment is still **On Progress**.
+- **Record:** The Destination Grade Class is not already at full capacity.
+- **Config:** An active `policy.template` grants `approve_ok` to the actor's group.
+- **Access:** User is registered as an approver on the approval level that is currently
+  **pending**. When the template uses sequential approval, only the first unapproved
+  level is pending.
+
+## Flow
+
+1. Open the **School > Student Activities > Student Class Mutations** menu.
+2. Open the record to approve.
+3. Click the **Approve** button.
+4. Click **OK** on the confirmation dialog.
+
+## Post-Condition
+
+- If all approval levels are fulfilled, status changes automatically to **Done** and the
+  linked Enrollment's Grade Class and Homeroom are updated to the Destination Grade
+  Class and Destination Homeroom. Once Done, the mutation is terminal and can no longer
+  be cancelled or reverted — to undo it, create a new mutation in the opposite
+  direction.
+- If there are still pending approval levels, status remains **Waiting for Approval**
+  and the next level becomes pending.
+
+> **Note:** `school_student_mutation` does **not** inherit `mixin.transaction_open` and
+> has no manual Finish button (`_automatically_insert_done_button` is disabled). The
+> transition to **Done** always happens automatically as soon as the last approval level
+> is fulfilled — there is no `07-start.md` or `09-finish.md` for this model.

--- a/ssi_school/docs/school_student_mutation/06-reject.md
+++ b/ssi_school/docs/school_student_mutation/06-reject.md
@@ -1,0 +1,26 @@
+# Reject Student Class Mutation
+
+> **Module:** ssi_school\
+> **Model:** `school_student_mutation`\
+> **Menu:** School > Student Activities > Student Class Mutations\
+> **Actor:** approver on the pending approval level\
+> **State:** `confirm` → `reject`\
+> **Requires:** `04-confirm`
+
+## Pre-Condition
+
+- **Record:** Status is **Waiting for Approval**.
+- **Config:** An active `policy.template` grants `reject_ok` to the actor's group.
+- **Access:** User is registered as an approver on the approval level that is currently
+  pending.
+
+## Flow
+
+1. Open the **School > Student Activities > Student Class Mutations** menu.
+2. Open the record to reject.
+3. Click the **Reject** button.
+4. Click **OK** on the confirmation dialog.
+
+## Post-Condition
+
+- Status changes to **Rejected**.

--- a/ssi_school/docs/school_student_mutation/10-cancel.md
+++ b/ssi_school/docs/school_student_mutation/10-cancel.md
@@ -1,0 +1,29 @@
+# Cancel Student Class Mutation
+
+> **Module:** ssi*school\
+> **Model:** `school_student_mutation`\
+> **Menu:** School > Student Activities > Student Class Mutations\
+> **Actor:** user in group \_Student Class Mutation — Validator*\
+> **State:** `draft` | `confirm` | `reject` → `cancel`\
+> **Requires:** `01-create`
+
+## Pre-Condition
+
+- **Record:** Status is **Draft**, **Waiting for Approval**, or **Rejected**. Once the
+  mutation reaches **Done**, it is terminal and can no longer be cancelled.
+- **Config:** An active `policy.template` grants `cancel_ok` for that state to the
+  actor's group.
+- **Access:** User is in group _Student Class Mutation — Validator_.
+
+## Flow
+
+1. Open the **School > Student Activities > Student Class Mutations** menu.
+2. Open the record to cancel.
+3. Click the **Cancel** button.
+4. In the wizard that appears, select the **Cancellation Reason**.
+5. Click **Confirm**.
+6. Click **OK** on the confirmation dialog.
+
+## Post-Condition
+
+- Status changes to **Cancelled**.

--- a/ssi_school/docs/school_student_mutation/12-restart.md
+++ b/ssi_school/docs/school_student_mutation/12-restart.md
@@ -1,0 +1,28 @@
+# Restart Student Class Mutation
+
+> **Module:** ssi*school\
+> **Model:** `school_student_mutation`\
+> **Menu:** School > Student Activities > Student Class Mutations\
+> **Actor:** user in group \_Student Class Mutation — Validator*\
+> **State:** `cancel` | `reject` → `draft`\
+> **Requires:** `10-cancel`
+
+## Pre-Condition
+
+- **Record:** Status is **Cancelled** or **Rejected**.
+- **Config:** An active `policy.template` grants `restart_ok` for that state to the
+  actor's group.
+- **Access:** User is in group _Student Class Mutation — Validator_.
+
+## Flow
+
+1. Open the **School > Student Activities > Student Class Mutations** menu.
+2. Open the record to restart.
+3. Click the **Restart** button.
+4. Click **OK** on the confirmation dialog.
+
+## Post-Condition
+
+- Status returns to **Draft**.
+- All approval records are removed and the approval template is cleared. A later Confirm
+  starts the approval process from the beginning.

--- a/ssi_school/docs/school_student_mutation/13-reset-number.md
+++ b/ssi_school/docs/school_student_mutation/13-reset-number.md
@@ -1,0 +1,29 @@
+# Reset Document Number — Student Class Mutation
+
+> **Module:** ssi*school\
+> **Model:** `school_student_mutation`\
+> **Menu:** School > Student Activities > Student Class Mutations\
+> **Actor:** user in group \_Student Class Mutation — Validator*\
+> **Requires:** `01-create`
+
+## Pre-Condition
+
+- **Record:** Status is **Draft**.
+- **Config:** An active `sequence.template` exists for this model.
+- **Config:** An active `policy.template` grants `manual_number_ok` for state `draft` to
+  the actor's group.
+- **Access:** User is in group _Student Class Mutation — Validator_.
+
+## Flow
+
+1. Open the **School > Student Activities > Student Class Mutations** menu.
+2. Open the record whose document number will be reset.
+3. Click the **Reset Document Number** button (or edit the **# Document** field directly
+   and change it to **/**).
+4. Click **OK** on the confirmation dialog (only when the button was used).
+
+## Post-Condition
+
+- Document number returns to **/**.
+- The record will receive an automatic number when it transitions to **Done**, according
+  to the configured sequence.

--- a/ssi_school/docs/school_student_mutation/14-restart-approval.md
+++ b/ssi_school/docs/school_student_mutation/14-restart-approval.md
@@ -1,0 +1,32 @@
+# Restart Approval Process — Student Class Mutation
+
+> **Module:** ssi*school\
+> **Model:** `school_student_mutation`\
+> **Menu:** School > Student Activities > Student Class Mutations\
+> **Actor:** user in group \_Student Class Mutation — User*\
+> **Requires:** `04-confirm`
+
+## Pre-Condition
+
+- **Record:** Status is **Waiting for Approval**, and the approval process is stalled
+  (for example, the record currently has no approval template assigned, or the assigned
+  template no longer matches).
+- **Config:** An active `policy.template` for this model grants `restart_approval_ok`
+  for state `confirm` to the actor's group.
+- **Config:** An active `approval.template` for this model matches this record, with an
+  approver group configured for its approval level, so the process can be rebuilt once
+  restarted.
+- **Access:** User is in group _Student Class Mutation — User_.
+
+## Flow
+
+1. Open the **School > Student Activities > Student Class Mutations** menu.
+2. Open the record whose approval process is stalled.
+3. Click the **Restart Approval Process** button.
+4. Click **OK** on the confirmation dialog.
+
+## Post-Condition
+
+- Status remains **Waiting for Approval**.
+- The existing approval records are discarded and a new approval process is created from
+  the approval template that now matches the record.

--- a/ssi_school/docs/school_student_mutation/15-print.md
+++ b/ssi_school/docs/school_student_mutation/15-print.md
@@ -1,0 +1,27 @@
+# Print Student Class Mutation
+
+> **Module:** ssi*school\
+> **Model:** `school_student_mutation`\
+> **Menu:** School > Student Activities > Student Class Mutations\
+> **Actor:** user in group \_Student Class Mutation — Viewer*\
+> **Requires:** `01-create`
+
+## Pre-Condition
+
+- **Config:** At least one `print_document_type` (with a linked report for
+  `school_student_mutation`) is configured, so a report is available to select in
+  step 4.
+- **Access:** User is in group _Student Class Mutation — Viewer_.
+
+## Flow
+
+1. Open the **School > Student Activities > Student Class Mutations** menu.
+2. Open the record to print.
+3. Click **Print** in the header.
+4. In the **Select Report To Print** wizard, select a **Type** (optional filter) and the
+   **Report Template** to generate.
+5. Click **Print**.
+
+## Post-Condition
+
+- The selected report is generated and opened/downloaded.

--- a/ssi_school/docs/school_student_mutation/16-reload-template-policy.md
+++ b/ssi_school/docs/school_student_mutation/16-reload-template-policy.md
@@ -1,0 +1,28 @@
+# Reload Template Policy — Student Class Mutation
+
+> **Module:** ssi*school\
+> **Model:** `school_student_mutation`\
+> **Menu:** School > Student Activities > Student Class Mutations\
+> **Actor:** administrator in group \_Settings / Technical Settings*\
+> **Requires:** `01-create`
+
+## Pre-Condition
+
+- **Record:** None — usable regardless of status.
+- **Config:** At least one active `policy.template` exists for this model, so a matching
+  template can be found.
+- **Access:** User is in group _Settings / Technical Settings_ (`base.group_system`).
+  The **Policies** tab that contains this button is only visible to this group.
+
+## Flow
+
+1. Open the **School > Student Activities > Student Class Mutations** menu.
+2. Open the record whose assigned policy template should be re-evaluated.
+3. On the **Policies** tab, click **Reload Template Policy**.
+
+## Post-Condition
+
+- **Policy Template** is recomputed and re-assigned to the highest-sequence
+  `policy.template` for this model whose condition currently matches the record. This
+  may change which action buttons and policy fields (`confirm_ok`,
+  `restart_approval_ok`, etc.) are granted, without changing the record's status.


### PR DESCRIPTION
## Ringkasan

Menambahkan Instruksi Kerja (IK) lengkap untuk tiga model transaksional inti `ssi_school` yang sebelumnya tidak punya satu pun IK: `school_enrollment`, `school_homeroom`, dan `school_student_mutation`.

Mencakup:
- Aksi bawaan mixin: Create/Edit/Delete, Confirm/Approve/Reject, Finish (bila ada), Cancel, Restart, Reset Document Number, Restart Approval Process, Print, Reload Template Policy.
- Aksi khas modul: Pass/Fail/Drop Out/Graduate/Create Due Invoice/Close Addendum pada `school_enrollment`; Fill Random/Generate Enrollments pada `school_homeroom`.
- Aksi inline (Compute Payment, tombol baris Payment Term) dideklarasikan lewat `Inline Actions:` pada `01-create`/`02-edit`.
- `README.rst` diperbarui dengan entri `Work Instruction` ketiga model.

Tidak ada perubahan kode - murni dokumentasi (`type:docs`).

Catatan desain (sudah diverifikasi ke kode, lihat riwayat komentar issue):
- `school_enrollment` & `school_homeroom` tidak punya `07-start.md` (tombol Start tidak pernah dirender, transisi confirm→open otomatis).
- `school_student_mutation` tidak punya `07-start.md` maupun `09-finish.md` (tidak inherit `mixin.transaction_open`, transisi confirm→done otomatis).
- Ketiga model punya `14-restart-approval.md` (tombol "Restart Approval Process" dari `ssi_transaction_confirm_mixin`, dirender tanpa syarat).
- Print termasuk cakupan (bawaan `mixin.transaction` via `_automatically_insert_print_button = True`, tidak di-override di ketiga model).

## Verifikasi

- `assets/validate-ik.sh ssi_school` → 0 ERROR (peringatan yang tersisa adalah blind spot terdokumentasi: tombol mixin milik model lain yang sudah ada IK-nya sebelum PR ini, dan `action_copy_payment_term` yang sengaja tidak diberi IK karena hanya dapat diakses lewat menu Action/gear - bukan tombol form view).
- Pre-commit (`prettier`, dll.) hijau.

## Test plan

- [x] `validate-ik.sh` 0 error
- [x] Pre-commit hijau
- [ ] CI GitHub hijau

Closes #214