### PR TITLE
[UPD] ssi_school_student_graduation - Instruksi Kerja

### DIFF
--- a/ssi_school_student_graduation/README.rst
+++ b/ssi_school_student_graduation/README.rst
@@ -20,6 +20,48 @@ transaction:
   and side effect from the individual document.
 
 
+Work Instruction
+================
+
+Student Graduation
+-------------------
+
+* `Create Student Graduation <docs/school_student_graduation/01-create.html>`_
+* `Edit Student Graduation <docs/school_student_graduation/02-edit.html>`_
+* `Delete Student Graduation <docs/school_student_graduation/03-delete.html>`_
+* `Confirm Student Graduation <docs/school_student_graduation/04-confirm.html>`_
+* `Approve Student Graduation <docs/school_student_graduation/05-approve.html>`_
+* `Reject Student Graduation <docs/school_student_graduation/06-reject.html>`_
+* `Cancel Student Graduation <docs/school_student_graduation/10-cancel.html>`_
+* `Restart Student Graduation <docs/school_student_graduation/12-restart.html>`_
+* `Reset Document Number - Student Graduation
+  <docs/school_student_graduation/13-reset-number.html>`_
+* `Restart Approval Process - Student Graduation
+  <docs/school_student_graduation/14-restart-approval.html>`_
+* `Print Student Graduation <docs/school_student_graduation/15-print.html>`_
+* `Reload Template Policy - Student Graduation
+  <docs/school_student_graduation/16-reload-template-policy.html>`_
+
+Graduation Batch
+-----------------
+
+* `Create Graduation Batch <docs/school_student_graduation_batch/01-create.html>`_
+* `Edit Graduation Batch <docs/school_student_graduation_batch/02-edit.html>`_
+* `Delete Graduation Batch <docs/school_student_graduation_batch/03-delete.html>`_
+* `Confirm Graduation Batch <docs/school_student_graduation_batch/04-confirm.html>`_
+* `Approve Graduation Batch <docs/school_student_graduation_batch/05-approve.html>`_
+* `Reject Graduation Batch <docs/school_student_graduation_batch/06-reject.html>`_
+* `Cancel Graduation Batch <docs/school_student_graduation_batch/10-cancel.html>`_
+* `Restart Graduation Batch <docs/school_student_graduation_batch/12-restart.html>`_
+* `Reset Document Number - Graduation Batch
+  <docs/school_student_graduation_batch/13-reset-number.html>`_
+* `Restart Approval Process - Graduation Batch
+  <docs/school_student_graduation_batch/14-restart-approval.html>`_
+* `Print Graduation Batch <docs/school_student_graduation_batch/15-print.html>`_
+* `Reload Template Policy - Graduation Batch
+  <docs/school_student_graduation_batch/16-reload-template-policy.html>`_
+
+
 Installation
 ============
 

--- a/ssi_school_student_graduation/docs/school_student_graduation/01-create.md
+++ b/ssi_school_student_graduation/docs/school_student_graduation/01-create.md
@@ -1,0 +1,35 @@
+# Create Student Graduation
+
+> **Module:** ssi*school_student_graduation\
+> **Model:** `school_student_graduation`\
+> **Menu:** School > Student Activities > Student Graduations\
+> **Actor:** user in group \_School Student Graduation — User*\
+> **State:** `—` → `draft`
+
+## Pre-Condition
+
+- **Data:** The student to be graduated is currently in the **Enrolled** state
+  (`school_student.state = "enrol"`).
+- **Config:** An active `policy.template` for this model grants `confirm_ok` for state
+  `draft` to the actor's group (needed later by `04-confirm`).
+- **Access:** User is in group _School Student Graduation — User_.
+
+## Flow
+
+1. Open the **School > Student Activities > Student Graduations** menu.
+2. Click the **New** button. **(14.0: "Create")**
+3. Fill in the required fields:
+   - **Student** _(required)_: Select the student being graduated. Must currently be
+     **Enrolled**.
+   - **Active Enrollment**: Automatically filled, read-only, from the student's
+     currently open enrollment.
+   - **Academic Year**: Automatically filled, read-only, from the Active Enrollment.
+   - **Academic Term**: Automatically filled, read-only, from the Active Enrollment.
+   - **Date**: Defaults to today's date. Change if needed.
+   - **Graduation Date**: Optional. The official date the student graduated.
+   - **Note**: Optional remarks about this graduation.
+4. Click **Save**.
+
+## Post-Condition
+
+- A new record is created in **Draft** status.

--- a/ssi_school_student_graduation/docs/school_student_graduation/02-edit.md
+++ b/ssi_school_student_graduation/docs/school_student_graduation/02-edit.md
@@ -1,0 +1,23 @@
+# Edit Student Graduation
+
+> **Module:** ssi*school_student_graduation\
+> **Model:** `school_student_graduation`\
+> **Menu:** School > Student Activities > Student Graduations\
+> **Actor:** user in group \_School Student Graduation — User*\
+> **Requires:** `01-create`
+
+## Pre-Condition
+
+- **Record:** Status is **Draft**.
+- **Access:** User is in group _School Student Graduation — User_.
+
+## Flow
+
+1. Open the **School > Student Activities > Student Graduations** menu.
+2. Find and open the record to edit.
+3. Change the required fields.
+4. Click **Save**.
+
+## Post-Condition
+
+- The record is updated with the new values.

--- a/ssi_school_student_graduation/docs/school_student_graduation/03-delete.md
+++ b/ssi_school_student_graduation/docs/school_student_graduation/03-delete.md
@@ -1,0 +1,24 @@
+# Delete Student Graduation
+
+> **Module:** ssi*school_student_graduation\
+> **Model:** `school_student_graduation`\
+> **Menu:** School > Student Activities > Student Graduations\
+> **Actor:** user in group \_School Student Graduation — User*\
+> **Requires:** `01-create`
+
+## Pre-Condition
+
+- **Record:** Status is **Draft**.
+- **Record:** Document number is still **/** (not yet generated).
+- **Access:** User is in group _School Student Graduation — User_.
+
+## Flow
+
+1. Open the **School > Student Activities > Student Graduations** menu.
+2. Select one or more records to delete (check the checkbox).
+3. Click **Action** > **Delete**.
+4. Click **OK** to confirm.
+
+## Post-Condition
+
+- The selected records are permanently removed from the system.

--- a/ssi_school_student_graduation/docs/school_student_graduation/04-confirm.md
+++ b/ssi_school_student_graduation/docs/school_student_graduation/04-confirm.md
@@ -1,0 +1,33 @@
+# Confirm Student Graduation
+
+> **Module:** ssi*school_student_graduation\
+> **Model:** `school_student_graduation`\
+> **Menu:** School > Student Activities > Student Graduations\
+> **Actor:** user in group \_School Student Graduation — User*\
+> **State:** `draft` → `confirm`\
+> **Requires:** `01-create`
+
+## Pre-Condition
+
+- **Record:** Status is **Draft**.
+- **Record:** The student is still in the **Enrolled** state.
+- **Record:** No other Draft or Waiting for Approval graduation already exists for the
+  same student.
+- **Config:** An active `policy.template` for this model grants `confirm_ok` for state
+  `draft` to the actor's group.
+- **Config:** An active `approval.template` for this model matches this record and has
+  at least one approver level.
+- **Config:** An active `sequence.template` exists for this model.
+- **Access:** User is in group _School Student Graduation — User_.
+
+## Flow
+
+1. Open the **School > Student Activities > Student Graduations** menu.
+2. Open the record to confirm.
+3. Click the **Confirm** button.
+4. Click **OK** on the confirmation dialog.
+
+## Post-Condition
+
+- Status changes to **Waiting for Approval**.
+- Approval records are created for each approver level defined by the approval template.

--- a/ssi_school_student_graduation/docs/school_student_graduation/05-approve.md
+++ b/ssi_school_student_graduation/docs/school_student_graduation/05-approve.md
@@ -1,0 +1,38 @@
+# Approve Student Graduation
+
+> **Module:** ssi_school_student_graduation\
+> **Model:** `school_student_graduation`\
+> **Menu:** School > Student Activities > Student Graduations\
+> **Actor:** approver on the pending approval level\
+> **State:** `confirm` → `done`\
+> **Requires:** `04-confirm`
+
+## Pre-Condition
+
+- **Record:** Status is **Waiting for Approval**.
+- **Record:** The student is still in the **Enrolled** state.
+- **Config:** An active `policy.template` grants `approve_ok` to the actor's group.
+- **Access:** User is registered as an approver on the approval level that is currently
+  **pending**. When the template uses sequential approval, only the first unapproved
+  level is pending.
+
+## Flow
+
+1. Open the **School > Student Activities > Student Graduations** menu.
+2. Open the record to approve.
+3. Click the **Approve** button.
+4. Click **OK** on the confirmation dialog.
+
+## Post-Condition
+
+- If all approval levels are fulfilled, status changes automatically to **Done**, the
+  student is moved to the **Graduate** state, and — if the student has an active
+  enrollment — that enrollment's academic year result is set to **Graduate**. Once Done,
+  the graduation is terminal and can no longer be cancelled or reverted.
+- If there are still pending approval levels, status remains **Waiting for Approval**
+  and the next level becomes pending.
+
+> **Note:** `school_student_graduation` does **not** have a manual Finish button
+> (`_automatically_insert_done_button` is disabled). The transition to **Done** always
+> happens automatically as soon as the last approval level is fulfilled — there is no
+> `07-start.md` or `09-finish.md` for this model.

--- a/ssi_school_student_graduation/docs/school_student_graduation/06-reject.md
+++ b/ssi_school_student_graduation/docs/school_student_graduation/06-reject.md
@@ -1,0 +1,26 @@
+# Reject Student Graduation
+
+> **Module:** ssi_school_student_graduation\
+> **Model:** `school_student_graduation`\
+> **Menu:** School > Student Activities > Student Graduations\
+> **Actor:** approver on the pending approval level\
+> **State:** `confirm` → `reject`\
+> **Requires:** `04-confirm`
+
+## Pre-Condition
+
+- **Record:** Status is **Waiting for Approval**.
+- **Config:** An active `policy.template` grants `reject_ok` to the actor's group.
+- **Access:** User is registered as an approver on the approval level that is currently
+  pending.
+
+## Flow
+
+1. Open the **School > Student Activities > Student Graduations** menu.
+2. Open the record to reject.
+3. Click the **Reject** button.
+4. Click **OK** on the confirmation dialog.
+
+## Post-Condition
+
+- Status changes to **Rejected**.

--- a/ssi_school_student_graduation/docs/school_student_graduation/10-cancel.md
+++ b/ssi_school_student_graduation/docs/school_student_graduation/10-cancel.md
@@ -1,0 +1,29 @@
+# Cancel Student Graduation
+
+> **Module:** ssi*school_student_graduation\
+> **Model:** `school_student_graduation`\
+> **Menu:** School > Student Activities > Student Graduations\
+> **Actor:** user in group \_School Student Graduation — Validator*\
+> **State:** `draft` | `confirm` | `reject` → `cancel`\
+> **Requires:** `01-create`
+
+## Pre-Condition
+
+- **Record:** Status is **Draft**, **Waiting for Approval**, or **Rejected**. Once the
+  graduation reaches **Done**, it is terminal and can no longer be cancelled.
+- **Config:** An active `policy.template` grants `cancel_ok` for that state to the
+  actor's group.
+- **Access:** User is in group _School Student Graduation — Validator_.
+
+## Flow
+
+1. Open the **School > Student Activities > Student Graduations** menu.
+2. Open the record to cancel.
+3. Click the **Cancel** button.
+4. In the wizard that appears, select the **Cancellation Reason**.
+5. Click **Confirm**.
+6. Click **OK** on the confirmation dialog.
+
+## Post-Condition
+
+- Status changes to **Cancelled**.

--- a/ssi_school_student_graduation/docs/school_student_graduation/12-restart.md
+++ b/ssi_school_student_graduation/docs/school_student_graduation/12-restart.md
@@ -1,0 +1,28 @@
+# Restart Student Graduation
+
+> **Module:** ssi*school_student_graduation\
+> **Model:** `school_student_graduation`\
+> **Menu:** School > Student Activities > Student Graduations\
+> **Actor:** user in group \_School Student Graduation — Validator*\
+> **State:** `cancel` | `reject` → `draft`\
+> **Requires:** `10-cancel`
+
+## Pre-Condition
+
+- **Record:** Status is **Cancelled** or **Rejected**.
+- **Config:** An active `policy.template` grants `restart_ok` for that state to the
+  actor's group.
+- **Access:** User is in group _School Student Graduation — Validator_.
+
+## Flow
+
+1. Open the **School > Student Activities > Student Graduations** menu.
+2. Open the record to restart.
+3. Click the **Restart** button.
+4. Click **OK** on the confirmation dialog.
+
+## Post-Condition
+
+- Status returns to **Draft**.
+- All approval records are removed and the approval template is cleared. A later Confirm
+  starts the approval process from the beginning.

--- a/ssi_school_student_graduation/docs/school_student_graduation/13-reset-number.md
+++ b/ssi_school_student_graduation/docs/school_student_graduation/13-reset-number.md
@@ -1,0 +1,29 @@
+# Reset Document Number — Student Graduation
+
+> **Module:** ssi*school_student_graduation\
+> **Model:** `school_student_graduation`\
+> **Menu:** School > Student Activities > Student Graduations\
+> **Actor:** user in group \_School Student Graduation — Validator*\
+> **Requires:** `01-create`
+
+## Pre-Condition
+
+- **Record:** Status is **Draft**.
+- **Config:** An active `sequence.template` exists for this model.
+- **Config:** An active `policy.template` grants `manual_number_ok` for state `draft` to
+  the actor's group.
+- **Access:** User is in group _School Student Graduation — Validator_.
+
+## Flow
+
+1. Open the **School > Student Activities > Student Graduations** menu.
+2. Open the record whose document number will be reset.
+3. Click the **Reset Document Number** button (or edit the **# Document** field directly
+   and change it to **/**).
+4. Click **OK** on the confirmation dialog (only when the button was used).
+
+## Post-Condition
+
+- Document number returns to **/**.
+- The record will receive an automatic number when it transitions to **Done**, according
+  to the configured sequence.

--- a/ssi_school_student_graduation/docs/school_student_graduation/14-restart-approval.md
+++ b/ssi_school_student_graduation/docs/school_student_graduation/14-restart-approval.md
@@ -1,0 +1,32 @@
+# Restart Approval Process — Student Graduation
+
+> **Module:** ssi*school_student_graduation\
+> **Model:** `school_student_graduation`\
+> **Menu:** School > Student Activities > Student Graduations\
+> **Actor:** user in group \_School Student Graduation — User*\
+> **Requires:** `04-confirm`
+
+## Pre-Condition
+
+- **Record:** Status is **Waiting for Approval**, and the approval process is stalled
+  (for example, the record currently has no approval template assigned, or the assigned
+  template no longer matches).
+- **Config:** An active `policy.template` for this model grants `restart_approval_ok`
+  for state `confirm` to the actor's group.
+- **Config:** An active `approval.template` for this model matches this record, with an
+  approver group configured for its approval level, so the process can be rebuilt once
+  restarted.
+- **Access:** User is in group _School Student Graduation — User_.
+
+## Flow
+
+1. Open the **School > Student Activities > Student Graduations** menu.
+2. Open the record whose approval process is stalled.
+3. Click the **Restart Approval Process** button.
+4. Click **OK** on the confirmation dialog.
+
+## Post-Condition
+
+- Status remains **Waiting for Approval**.
+- The existing approval records are discarded and a new approval process is created from
+  the approval template that now matches the record.

--- a/ssi_school_student_graduation/docs/school_student_graduation/15-print.md
+++ b/ssi_school_student_graduation/docs/school_student_graduation/15-print.md
@@ -1,0 +1,27 @@
+# Print Student Graduation
+
+> **Module:** ssi*school_student_graduation\
+> **Model:** `school_student_graduation`\
+> **Menu:** School > Student Activities > Student Graduations\
+> **Actor:** user in group \_School Student Graduation — Viewer*\
+> **Requires:** `01-create`
+
+## Pre-Condition
+
+- **Config:** At least one `print_document_type` (with a linked report for
+  `school_student_graduation`) is configured, so a report is available to select in
+  step 4.
+- **Access:** User is in group _School Student Graduation — Viewer_.
+
+## Flow
+
+1. Open the **School > Student Activities > Student Graduations** menu.
+2. Open the record to print.
+3. Click **Print** in the header.
+4. In the **Select Report To Print** wizard, select a **Type** (optional filter) and the
+   **Report Template** to generate.
+5. Click **Print**.
+
+## Post-Condition
+
+- The selected report is generated and opened/downloaded.

--- a/ssi_school_student_graduation/docs/school_student_graduation/16-reload-template-policy.md
+++ b/ssi_school_student_graduation/docs/school_student_graduation/16-reload-template-policy.md
@@ -1,0 +1,28 @@
+# Reload Template Policy — Student Graduation
+
+> **Module:** ssi*school_student_graduation\
+> **Model:** `school_student_graduation`\
+> **Menu:** School > Student Activities > Student Graduations\
+> **Actor:** administrator in group \_Settings / Technical Settings*\
+> **Requires:** `01-create`
+
+## Pre-Condition
+
+- **Record:** None — usable regardless of status.
+- **Config:** At least one active `policy.template` exists for this model, so a matching
+  template can be found.
+- **Access:** User is in group _Settings / Technical Settings_ (`base.group_system`).
+  The **Policies** tab that contains this button is only visible to this group.
+
+## Flow
+
+1. Open the **School > Student Activities > Student Graduations** menu.
+2. Open the record whose assigned policy template should be re-evaluated.
+3. On the **Policies** tab, click **Reload Template Policy**.
+
+## Post-Condition
+
+- **Policy Template** is recomputed and re-assigned to the highest-sequence
+  `policy.template` for this model whose condition currently matches the record. This
+  may change which action buttons and policy fields (`confirm_ok`,
+  `restart_approval_ok`, etc.) are granted, without changing the record's status.

--- a/ssi_school_student_graduation/docs/school_student_graduation_batch/01-create.md
+++ b/ssi_school_student_graduation/docs/school_student_graduation_batch/01-create.md
@@ -1,0 +1,42 @@
+# Create Graduation Batch
+
+> **Module:** ssi*school_student_graduation\
+> **Model:** `school_student_graduation_batch`\
+> **Menu:** School > Student Activities > Graduation Batches\
+> **Actor:** user in group \_School Student Graduation Batch — User*\
+> **State:** `—` → `draft`\
+> **Inline Actions:** `action_populate_lines` (Populate Eligible Students)
+
+## Pre-Condition
+
+- **Data:** At least one student is currently **Enrolled** and at their final grade (no
+  **Next Grade** set on the enrollment), so at least one line can be found when
+  populating.
+- **Config:** An active `policy.template` for this model grants `confirm_ok` for state
+  `draft` to the actor's group (needed later by `04-confirm`).
+- **Access:** User is in group _School Student Graduation Batch — User_.
+
+## Flow
+
+1. Open the **School > Student Activities > Graduation Batches** menu.
+2. Click the **New** button. **(14.0: "Create")**
+3. Fill in the fields:
+   - **Date**: Defaults to today's date. Also used as the **Date** and **Graduation
+     Date** of every Student Graduation document this batch generates. Change if needed.
+   - **Academic Year**: Optional filter. When set, only students whose active enrollment
+     belongs to this academic year are proposed when populating lines.
+   - **Academic Term**: Optional filter. When set, only students whose active enrollment
+     belongs to this academic term are proposed when populating lines.
+   - **Grade**: Optional filter. When set, only students whose active enrollment belongs
+     to this grade are proposed when populating lines.
+4. On the **Students** tab, click **Populate Eligible Students** to fill the **Lines**
+   list with every student currently **Enrolled**, at their final grade, and matching
+   the **Academic Year** / **Academic Term** / **Grade** filters above (any filter left
+   empty is not applied). This replaces the current lines. You may also add or remove
+   student lines manually instead of, or after, populating. At least one line must
+   remain — completing this batch will fail without one.
+5. Click **Save**.
+
+## Post-Condition
+
+- A new record is created in **Draft** status.

--- a/ssi_school_student_graduation/docs/school_student_graduation_batch/02-edit.md
+++ b/ssi_school_student_graduation/docs/school_student_graduation_batch/02-edit.md
@@ -1,0 +1,28 @@
+# Edit Graduation Batch
+
+> **Module:** ssi*school_student_graduation\
+> **Model:** `school_student_graduation_batch`\
+> **Menu:** School > Student Activities > Graduation Batches\
+> **Actor:** user in group \_School Student Graduation Batch — User*\
+> **Requires:** `01-create`\
+> **Inline Actions:** `action_populate_lines` (Populate Eligible Students)
+
+## Pre-Condition
+
+- **Record:** Status is **Draft**.
+- **Access:** User is in group _School Student Graduation Batch — User_.
+
+## Flow
+
+1. Open the **School > Student Activities > Graduation Batches** menu.
+2. Find and open the record to edit.
+3. Change the required fields.
+4. On the **Students** tab, click **Populate Eligible Students** to refill the **Lines**
+   list from the current filters (this replaces the current lines), or add/ remove
+   student lines manually. At least one line must remain — completing this batch will
+   fail without one.
+5. Click **Save**.
+
+## Post-Condition
+
+- The record is updated with the new values.

--- a/ssi_school_student_graduation/docs/school_student_graduation_batch/03-delete.md
+++ b/ssi_school_student_graduation/docs/school_student_graduation_batch/03-delete.md
@@ -1,0 +1,24 @@
+# Delete Graduation Batch
+
+> **Module:** ssi*school_student_graduation\
+> **Model:** `school_student_graduation_batch`\
+> **Menu:** School > Student Activities > Graduation Batches\
+> **Actor:** user in group \_School Student Graduation Batch — User*\
+> **Requires:** `01-create`
+
+## Pre-Condition
+
+- **Record:** Status is **Draft**.
+- **Record:** Document number is still **/** (not yet generated).
+- **Access:** User is in group _School Student Graduation Batch — User_.
+
+## Flow
+
+1. Open the **School > Student Activities > Graduation Batches** menu.
+2. Select one or more records to delete (check the checkbox).
+3. Click **Action** > **Delete**.
+4. Click **OK** to confirm.
+
+## Post-Condition
+
+- The selected records are permanently removed from the system.

--- a/ssi_school_student_graduation/docs/school_student_graduation_batch/04-confirm.md
+++ b/ssi_school_student_graduation/docs/school_student_graduation_batch/04-confirm.md
@@ -1,0 +1,31 @@
+# Confirm Graduation Batch
+
+> **Module:** ssi*school_student_graduation\
+> **Model:** `school_student_graduation_batch`\
+> **Menu:** School > Student Activities > Graduation Batches\
+> **Actor:** user in group \_School Student Graduation Batch — User*\
+> **State:** `draft` → `confirm`\
+> **Requires:** `01-create`
+
+## Pre-Condition
+
+- **Record:** Status is **Draft**.
+- **Record:** At least one student line exists in the **Students** tab.
+- **Config:** An active `policy.template` for this model grants `confirm_ok` for state
+  `draft` to the actor's group.
+- **Config:** An active `approval.template` for this model matches this record and has
+  at least one approver level.
+- **Config:** An active `sequence.template` exists for this model.
+- **Access:** User is in group _School Student Graduation Batch — User_.
+
+## Flow
+
+1. Open the **School > Student Activities > Graduation Batches** menu.
+2. Open the record to confirm.
+3. Click the **Confirm** button.
+4. Click **OK** on the confirmation dialog.
+
+## Post-Condition
+
+- Status changes to **Waiting for Approval**.
+- Approval records are created for each approver level defined by the approval template.

--- a/ssi_school_student_graduation/docs/school_student_graduation_batch/05-approve.md
+++ b/ssi_school_student_graduation/docs/school_student_graduation_batch/05-approve.md
@@ -1,0 +1,44 @@
+# Approve Graduation Batch
+
+> **Module:** ssi_school_student_graduation\
+> **Model:** `school_student_graduation_batch`\
+> **Menu:** School > Student Activities > Graduation Batches\
+> **Actor:** approver on the pending approval level\
+> **State:** `confirm` → `done`\
+> **Requires:** `04-confirm`
+
+## Pre-Condition
+
+- **Record:** Status is **Waiting for Approval**.
+- **Record:** At least one student line exists.
+- **Record:** Every student line is still in the **Enrolled** state.
+- **Config:** An active `policy.template` grants `approve_ok` to the actor's group.
+- **Access:** User is registered as an approver on the approval level that is currently
+  **pending**. When the template uses sequential approval, only the first unapproved
+  level is pending.
+
+## Flow
+
+1. Open the **School > Student Activities > Graduation Batches** menu.
+2. Open the record to approve.
+3. Click the **Approve** button.
+4. Click **OK** on the confirmation dialog.
+
+## Post-Condition
+
+- If all approval levels are fulfilled, status changes automatically to **Done**. For
+  every student line, a **Student Graduation** document is created and driven straight
+  through its own Confirm/Done transition, so every guard and side effect defined on the
+  individual document (student state check, single-active-graduation check, enrollment
+  result update, ...) still applies — the student is moved to the **Graduate** state
+  and, if the student has an active enrollment, that enrollment's academic year result
+  is set to **Graduate**. Each line keeps a link to the **Student Graduation** document
+  generated for it, as an audit trail. Once Done, the batch is terminal and can no
+  longer be cancelled or reverted.
+- If there are still pending approval levels, status remains **Waiting for Approval**
+  and the next level becomes pending.
+
+> **Note:** `school_student_graduation_batch` does **not** have a manual Finish button
+> (`_automatically_insert_done_button` is disabled). The transition to **Done** always
+> happens automatically as soon as the last approval level is fulfilled — there is no
+> `07-start.md` or `09-finish.md` for this model.

--- a/ssi_school_student_graduation/docs/school_student_graduation_batch/06-reject.md
+++ b/ssi_school_student_graduation/docs/school_student_graduation_batch/06-reject.md
@@ -1,0 +1,26 @@
+# Reject Graduation Batch
+
+> **Module:** ssi_school_student_graduation\
+> **Model:** `school_student_graduation_batch`\
+> **Menu:** School > Student Activities > Graduation Batches\
+> **Actor:** approver on the pending approval level\
+> **State:** `confirm` → `reject`\
+> **Requires:** `04-confirm`
+
+## Pre-Condition
+
+- **Record:** Status is **Waiting for Approval**.
+- **Config:** An active `policy.template` grants `reject_ok` to the actor's group.
+- **Access:** User is registered as an approver on the approval level that is currently
+  pending.
+
+## Flow
+
+1. Open the **School > Student Activities > Graduation Batches** menu.
+2. Open the record to reject.
+3. Click the **Reject** button.
+4. Click **OK** on the confirmation dialog.
+
+## Post-Condition
+
+- Status changes to **Rejected**.

--- a/ssi_school_student_graduation/docs/school_student_graduation_batch/10-cancel.md
+++ b/ssi_school_student_graduation/docs/school_student_graduation_batch/10-cancel.md
@@ -1,0 +1,29 @@
+# Cancel Graduation Batch
+
+> **Module:** ssi*school_student_graduation\
+> **Model:** `school_student_graduation_batch`\
+> **Menu:** School > Student Activities > Graduation Batches\
+> **Actor:** user in group \_School Student Graduation Batch — Validator*\
+> **State:** `draft` | `confirm` | `reject` → `cancel`\
+> **Requires:** `01-create`
+
+## Pre-Condition
+
+- **Record:** Status is **Draft**, **Waiting for Approval**, or **Rejected**. Once the
+  batch reaches **Done**, it is terminal and can no longer be cancelled.
+- **Config:** An active `policy.template` grants `cancel_ok` for that state to the
+  actor's group.
+- **Access:** User is in group _School Student Graduation Batch — Validator_.
+
+## Flow
+
+1. Open the **School > Student Activities > Graduation Batches** menu.
+2. Open the record to cancel.
+3. Click the **Cancel** button.
+4. In the wizard that appears, select the **Cancellation Reason**.
+5. Click **Confirm**.
+6. Click **OK** on the confirmation dialog.
+
+## Post-Condition
+
+- Status changes to **Cancelled**.

--- a/ssi_school_student_graduation/docs/school_student_graduation_batch/12-restart.md
+++ b/ssi_school_student_graduation/docs/school_student_graduation_batch/12-restart.md
@@ -1,0 +1,28 @@
+# Restart Graduation Batch
+
+> **Module:** ssi*school_student_graduation\
+> **Model:** `school_student_graduation_batch`\
+> **Menu:** School > Student Activities > Graduation Batches\
+> **Actor:** user in group \_School Student Graduation Batch — Validator*\
+> **State:** `cancel` | `reject` → `draft`\
+> **Requires:** `10-cancel`
+
+## Pre-Condition
+
+- **Record:** Status is **Cancelled** or **Rejected**.
+- **Config:** An active `policy.template` grants `restart_ok` for that state to the
+  actor's group.
+- **Access:** User is in group _School Student Graduation Batch — Validator_.
+
+## Flow
+
+1. Open the **School > Student Activities > Graduation Batches** menu.
+2. Open the record to restart.
+3. Click the **Restart** button.
+4. Click **OK** on the confirmation dialog.
+
+## Post-Condition
+
+- Status returns to **Draft**.
+- All approval records are removed and the approval template is cleared. A later Confirm
+  starts the approval process from the beginning.

--- a/ssi_school_student_graduation/docs/school_student_graduation_batch/13-reset-number.md
+++ b/ssi_school_student_graduation/docs/school_student_graduation_batch/13-reset-number.md
@@ -1,0 +1,29 @@
+# Reset Document Number — Graduation Batch
+
+> **Module:** ssi*school_student_graduation\
+> **Model:** `school_student_graduation_batch`\
+> **Menu:** School > Student Activities > Graduation Batches\
+> **Actor:** user in group \_School Student Graduation Batch — Validator*\
+> **Requires:** `01-create`
+
+## Pre-Condition
+
+- **Record:** Status is **Draft**.
+- **Config:** An active `sequence.template` exists for this model.
+- **Config:** An active `policy.template` grants `manual_number_ok` for state `draft` to
+  the actor's group.
+- **Access:** User is in group _School Student Graduation Batch — Validator_.
+
+## Flow
+
+1. Open the **School > Student Activities > Graduation Batches** menu.
+2. Open the record whose document number will be reset.
+3. Click the **Reset Document Number** button (or edit the **# Document** field directly
+   and change it to **/**).
+4. Click **OK** on the confirmation dialog (only when the button was used).
+
+## Post-Condition
+
+- Document number returns to **/**.
+- The record will receive an automatic number when it transitions to **Done**, according
+  to the configured sequence.

--- a/ssi_school_student_graduation/docs/school_student_graduation_batch/14-restart-approval.md
+++ b/ssi_school_student_graduation/docs/school_student_graduation_batch/14-restart-approval.md
@@ -1,0 +1,32 @@
+# Restart Approval Process — Graduation Batch
+
+> **Module:** ssi*school_student_graduation\
+> **Model:** `school_student_graduation_batch`\
+> **Menu:** School > Student Activities > Graduation Batches\
+> **Actor:** user in group \_School Student Graduation Batch — User*\
+> **Requires:** `04-confirm`
+
+## Pre-Condition
+
+- **Record:** Status is **Waiting for Approval**, and the approval process is stalled
+  (for example, the record currently has no approval template assigned, or the assigned
+  template no longer matches).
+- **Config:** An active `policy.template` for this model grants `restart_approval_ok`
+  for state `confirm` to the actor's group.
+- **Config:** An active `approval.template` for this model matches this record, with an
+  approver group configured for its approval level, so the process can be rebuilt once
+  restarted.
+- **Access:** User is in group _School Student Graduation Batch — User_.
+
+## Flow
+
+1. Open the **School > Student Activities > Graduation Batches** menu.
+2. Open the record whose approval process is stalled.
+3. Click the **Restart Approval Process** button.
+4. Click **OK** on the confirmation dialog.
+
+## Post-Condition
+
+- Status remains **Waiting for Approval**.
+- The existing approval records are discarded and a new approval process is created from
+  the approval template that now matches the record.

--- a/ssi_school_student_graduation/docs/school_student_graduation_batch/15-print.md
+++ b/ssi_school_student_graduation/docs/school_student_graduation_batch/15-print.md
@@ -1,0 +1,27 @@
+# Print Graduation Batch
+
+> **Module:** ssi*school_student_graduation\
+> **Model:** `school_student_graduation_batch`\
+> **Menu:** School > Student Activities > Graduation Batches\
+> **Actor:** user in group \_School Student Graduation Batch — Viewer*\
+> **Requires:** `01-create`
+
+## Pre-Condition
+
+- **Config:** At least one `print_document_type` (with a linked report for
+  `school_student_graduation_batch`) is configured, so a report is available to select
+  in step 4.
+- **Access:** User is in group _School Student Graduation Batch — Viewer_.
+
+## Flow
+
+1. Open the **School > Student Activities > Graduation Batches** menu.
+2. Open the record to print.
+3. Click **Print** in the header.
+4. In the **Select Report To Print** wizard, select a **Type** (optional filter) and the
+   **Report Template** to generate.
+5. Click **Print**.
+
+## Post-Condition
+
+- The selected report is generated and opened/downloaded.

--- a/ssi_school_student_graduation/docs/school_student_graduation_batch/16-reload-template-policy.md
+++ b/ssi_school_student_graduation/docs/school_student_graduation_batch/16-reload-template-policy.md
@@ -1,0 +1,28 @@
+# Reload Template Policy — Graduation Batch
+
+> **Module:** ssi*school_student_graduation\
+> **Model:** `school_student_graduation_batch`\
+> **Menu:** School > Student Activities > Graduation Batches\
+> **Actor:** administrator in group \_Settings / Technical Settings*\
+> **Requires:** `01-create`
+
+## Pre-Condition
+
+- **Record:** None — usable regardless of status.
+- **Config:** At least one active `policy.template` exists for this model, so a matching
+  template can be found.
+- **Access:** User is in group _Settings / Technical Settings_ (`base.group_system`).
+  The **Policies** tab that contains this button is only visible to this group.
+
+## Flow
+
+1. Open the **School > Student Activities > Graduation Batches** menu.
+2. Open the record whose assigned policy template should be re-evaluated.
+3. On the **Policies** tab, click **Reload Template Policy**.
+
+## Post-Condition
+
+- **Policy Template** is recomputed and re-assigned to the highest-sequence
+  `policy.template` for this model whose condition currently matches the record. This
+  may change which action buttons and policy fields (`confirm_ok`,
+  `restart_approval_ok`, etc.) are granted, without changing the record's status.


### PR DESCRIPTION
## Ringkasan

Menambahkan Instruksi Kerja (IK) lengkap untuk kedua model modul `ssi_school_student_graduation`:

- `school_student_graduation`: `01`-`03` (create/edit/delete), `04-confirm`, `05-approve`, `06-reject`, `10-cancel`, `12-restart`, `13-reset-number`, `14-restart-approval`, `15-print`, `16-reload-template-policy`.
- `school_student_graduation_batch`: set kanonik yang sama, dengan `action_populate_lines` didokumentasikan sebagai langkah inline pada `01-create` dan `02-edit` (bukan file IK sendiri) sesuai vonis tangga penempatan aksi.

`README.rst` diperbarui dengan bagian `Work Instruction` untuk kedua model.

Tidak ada perubahan kode model/view — item ini murni dokumentasi (`type:docs`).

## Test plan

- [x] `assets/validate-ik.sh ssi_school_student_graduation` keluar dengan 0 ERROR
- [x] pre-commit (termasuk `oca-gen-addon-readme` & `prettier`) hijau
- [ ] CI hijau

Closes #215