### PR TITLE
[UPD] ssi_school_student_leave

### DIFF
--- a/ssi_school_student_leave/README.rst
+++ b/ssi_school_student_leave/README.rst
@@ -13,6 +13,30 @@ on_leave state. Once the leave period is over, the Return button
 re-enrolls the student directly, with no separate approval step.
 
 
+Work Instruction
+================
+
+Student Leave
+-------------
+
+* `Create Student Leave <docs/school_student_leave/01-create.html>`_
+* `Edit Student Leave <docs/school_student_leave/02-edit.html>`_
+* `Delete Student Leave <docs/school_student_leave/03-delete.html>`_
+* `Confirm Student Leave <docs/school_student_leave/04-confirm.html>`_
+* `Approve Student Leave <docs/school_student_leave/05-approve.html>`_
+* `Reject Student Leave <docs/school_student_leave/06-reject.html>`_
+* `Cancel Student Leave <docs/school_student_leave/10-cancel.html>`_
+* `Restart Student Leave <docs/school_student_leave/12-restart.html>`_
+* `Reset Document Number - Student Leave
+  <docs/school_student_leave/13-reset-number.html>`_
+* `Restart Approval Process - Student Leave
+  <docs/school_student_leave/14-restart-approval.html>`_
+* `Return Student Leave <docs/school_student_leave/15-return.html>`_
+* `Print Student Leave <docs/school_student_leave/16-print.html>`_
+* `Reload Template Policy - Student Leave
+  <docs/school_student_leave/17-reload-template-policy.html>`_
+
+
 Installation
 ============
 

--- a/ssi_school_student_leave/docs/school_student_leave/01-create.md
+++ b/ssi_school_student_leave/docs/school_student_leave/01-create.md
@@ -1,0 +1,36 @@
+# Create Student Leave
+
+> **Module:** ssi*school_student_leave\
+> **Model:** `school_student_leave`\
+> **Menu:** School > Student Activities > Student Leaves\
+> **Actor:** user in group \_School Student Leave — User*\
+> **State:** `—` → `draft`
+
+## Pre-Condition
+
+- **Data:** The student to be granted leave is currently in the **Enrolled** state
+  (`school_student.state = "enrol"`).
+- **Config:** An active `policy.template` for this model grants `confirm_ok` for state
+  `draft` to the actor's group (needed later by `04-confirm`).
+- **Access:** User is in group _School Student Leave — User_.
+
+## Flow
+
+1. Open the **School > Student Activities > Student Leaves** menu.
+2. Click the **New** button. **(14.0: "Create")**
+3. Fill in the required fields:
+   - **Student** _(required)_: Select the student requesting leave. Must currently be
+     **Enrolled**.
+   - **Active Enrollment**: Automatically filled, read-only, from the student's
+     currently open enrollment.
+   - **Academic Term** _(required)_: Select the single academic term this leave is valid
+     for.
+   - **Date**: Defaults to today's date. Change if needed.
+   - **Expected Return Date**: Optional. The date the student is expected to return from
+     leave.
+   - **Reason**: Optional explanation for the leave request, on the **Leave** tab.
+4. Click **Save**.
+
+## Post-Condition
+
+- A new record is created in **Draft** status.

--- a/ssi_school_student_leave/docs/school_student_leave/02-edit.md
+++ b/ssi_school_student_leave/docs/school_student_leave/02-edit.md
@@ -1,0 +1,23 @@
+# Edit Student Leave
+
+> **Module:** ssi*school_student_leave\
+> **Model:** `school_student_leave`\
+> **Menu:** School > Student Activities > Student Leaves\
+> **Actor:** user in group \_School Student Leave — User*\
+> **Requires:** `01-create`
+
+## Pre-Condition
+
+- **Record:** Status is **Draft**.
+- **Access:** User is in group _School Student Leave — User_.
+
+## Flow
+
+1. Open the **School > Student Activities > Student Leaves** menu.
+2. Find and open the record to edit.
+3. Change the required fields.
+4. Click **Save**.
+
+## Post-Condition
+
+- The record is updated with the new values.

--- a/ssi_school_student_leave/docs/school_student_leave/03-delete.md
+++ b/ssi_school_student_leave/docs/school_student_leave/03-delete.md
@@ -1,0 +1,24 @@
+# Delete Student Leave
+
+> **Module:** ssi*school_student_leave\
+> **Model:** `school_student_leave`\
+> **Menu:** School > Student Activities > Student Leaves\
+> **Actor:** user in group \_School Student Leave — User*\
+> **Requires:** `01-create`
+
+## Pre-Condition
+
+- **Record:** Status is **Draft**.
+- **Record:** Document number is still **/** (not yet generated).
+- **Access:** User is in group _School Student Leave — User_.
+
+## Flow
+
+1. Open the **School > Student Activities > Student Leaves** menu.
+2. Select one or more records to delete (check the checkbox).
+3. Click **Action** > **Delete**.
+4. Click **OK** to confirm.
+
+## Post-Condition
+
+- The selected records are permanently removed from the system.

--- a/ssi_school_student_leave/docs/school_student_leave/04-confirm.md
+++ b/ssi_school_student_leave/docs/school_student_leave/04-confirm.md
@@ -1,0 +1,33 @@
+# Confirm Student Leave
+
+> **Module:** ssi*school_student_leave\
+> **Model:** `school_student_leave`\
+> **Menu:** School > Student Activities > Student Leaves\
+> **Actor:** user in group \_School Student Leave — User*\
+> **State:** `draft` → `confirm`\
+> **Requires:** `01-create`
+
+## Pre-Condition
+
+- **Record:** Status is **Draft**.
+- **Record:** The student is still in the **Enrolled** state.
+- **Record:** No other Draft or Waiting for Approval leave already exists for the same
+  student.
+- **Config:** An active `policy.template` for this model grants `confirm_ok` for state
+  `draft` to the actor's group.
+- **Config:** An active `approval.template` for this model matches this record and has
+  at least one approver level.
+- **Config:** An active `sequence.template` exists for this model.
+- **Access:** User is in group _School Student Leave — User_.
+
+## Flow
+
+1. Open the **School > Student Activities > Student Leaves** menu.
+2. Open the record to confirm.
+3. Click the **Confirm** button.
+4. Click **OK** on the confirmation dialog.
+
+## Post-Condition
+
+- Status changes to **Waiting for Approval**.
+- Approval records are created for each approver level defined by the approval template.

--- a/ssi_school_student_leave/docs/school_student_leave/05-approve.md
+++ b/ssi_school_student_leave/docs/school_student_leave/05-approve.md
@@ -1,0 +1,38 @@
+# Approve Student Leave
+
+> **Module:** ssi_school_student_leave\
+> **Model:** `school_student_leave`\
+> **Menu:** School > Student Activities > Student Leaves\
+> **Actor:** approver on the pending approval level\
+> **State:** `confirm` → `done`\
+> **Requires:** `04-confirm`
+
+## Pre-Condition
+
+- **Record:** Status is **Waiting for Approval**.
+- **Record:** The student is still in the **Enrolled** state.
+- **Config:** An active `policy.template` grants `approve_ok` to the actor's group.
+- **Access:** User is registered as an approver on the approval level that is currently
+  **pending**. When the template uses sequential approval, only the first unapproved
+  level is pending.
+
+## Flow
+
+1. Open the **School > Student Activities > Student Leaves** menu.
+2. Open the record to approve.
+3. Click the **Approve** button.
+4. Click **OK** on the confirmation dialog.
+
+## Post-Condition
+
+- If all approval levels are fulfilled, status changes automatically to **Done**, and
+  the student is moved to the **On Leave** state. Once Done, the leave document itself
+  is not reverted through the workflow — the student's return is handled by the separate
+  **Return** action (`15-return`), which does not change this document's status.
+- If there are still pending approval levels, status remains **Waiting for Approval**
+  and the next level becomes pending.
+
+> **Note:** `school_student_leave` does **not** have a manual Finish button
+> (`_automatically_insert_done_button` is disabled). The transition to **Done** always
+> happens automatically as soon as the last approval level is fulfilled — there is no
+> `07-start.md` or `09-finish.md` for this model.

--- a/ssi_school_student_leave/docs/school_student_leave/06-reject.md
+++ b/ssi_school_student_leave/docs/school_student_leave/06-reject.md
@@ -1,0 +1,26 @@
+# Reject Student Leave
+
+> **Module:** ssi_school_student_leave\
+> **Model:** `school_student_leave`\
+> **Menu:** School > Student Activities > Student Leaves\
+> **Actor:** approver on the pending approval level\
+> **State:** `confirm` → `reject`\
+> **Requires:** `04-confirm`
+
+## Pre-Condition
+
+- **Record:** Status is **Waiting for Approval**.
+- **Config:** An active `policy.template` grants `reject_ok` to the actor's group.
+- **Access:** User is registered as an approver on the approval level that is currently
+  pending.
+
+## Flow
+
+1. Open the **School > Student Activities > Student Leaves** menu.
+2. Open the record to reject.
+3. Click the **Reject** button.
+4. Click **OK** on the confirmation dialog.
+
+## Post-Condition
+
+- Status changes to **Rejected**.

--- a/ssi_school_student_leave/docs/school_student_leave/10-cancel.md
+++ b/ssi_school_student_leave/docs/school_student_leave/10-cancel.md
@@ -1,0 +1,29 @@
+# Cancel Student Leave
+
+> **Module:** ssi*school_student_leave\
+> **Model:** `school_student_leave`\
+> **Menu:** School > Student Activities > Student Leaves\
+> **Actor:** user in group \_School Student Leave — Validator*\
+> **State:** `draft` | `confirm` | `reject` → `cancel`\
+> **Requires:** `01-create`
+
+## Pre-Condition
+
+- **Record:** Status is **Draft**, **Waiting for Approval**, or **Rejected**. Once the
+  leave reaches **Done**, it is terminal and can no longer be cancelled.
+- **Config:** An active `policy.template` grants `cancel_ok` for that state to the
+  actor's group.
+- **Access:** User is in group _School Student Leave — Validator_.
+
+## Flow
+
+1. Open the **School > Student Activities > Student Leaves** menu.
+2. Open the record to cancel.
+3. Click the **Cancel** button.
+4. In the wizard that appears, select the **Cancellation Reason**.
+5. Click **Confirm**.
+6. Click **OK** on the confirmation dialog.
+
+## Post-Condition
+
+- Status changes to **Cancelled**.

--- a/ssi_school_student_leave/docs/school_student_leave/12-restart.md
+++ b/ssi_school_student_leave/docs/school_student_leave/12-restart.md
@@ -1,0 +1,28 @@
+# Restart Student Leave
+
+> **Module:** ssi*school_student_leave\
+> **Model:** `school_student_leave`\
+> **Menu:** School > Student Activities > Student Leaves\
+> **Actor:** user in group \_School Student Leave — Validator*\
+> **State:** `cancel` | `reject` → `draft`\
+> **Requires:** `10-cancel`
+
+## Pre-Condition
+
+- **Record:** Status is **Cancelled** or **Rejected**.
+- **Config:** An active `policy.template` grants `restart_ok` for that state to the
+  actor's group.
+- **Access:** User is in group _School Student Leave — Validator_.
+
+## Flow
+
+1. Open the **School > Student Activities > Student Leaves** menu.
+2. Open the record to restart.
+3. Click the **Restart** button.
+4. Click **OK** on the confirmation dialog.
+
+## Post-Condition
+
+- Status returns to **Draft**.
+- All approval records are removed and the approval template is cleared. A later Confirm
+  starts the approval process from the beginning.

--- a/ssi_school_student_leave/docs/school_student_leave/13-reset-number.md
+++ b/ssi_school_student_leave/docs/school_student_leave/13-reset-number.md
@@ -1,0 +1,29 @@
+# Reset Document Number — Student Leave
+
+> **Module:** ssi*school_student_leave\
+> **Model:** `school_student_leave`\
+> **Menu:** School > Student Activities > Student Leaves\
+> **Actor:** user in group \_School Student Leave — Validator*\
+> **Requires:** `01-create`
+
+## Pre-Condition
+
+- **Record:** Status is **Draft**.
+- **Config:** An active `sequence.template` exists for this model.
+- **Config:** An active `policy.template` grants `manual_number_ok` for state `draft` to
+  the actor's group.
+- **Access:** User is in group _School Student Leave — Validator_.
+
+## Flow
+
+1. Open the **School > Student Activities > Student Leaves** menu.
+2. Open the record whose document number will be reset.
+3. Click the **Reset Document Number** button (or edit the **# Document** field directly
+   and change it to **/**).
+4. Click **OK** on the confirmation dialog (only when the button was used).
+
+## Post-Condition
+
+- Document number returns to **/**.
+- The record will receive an automatic number when it transitions to **Done**, according
+  to the configured sequence.

--- a/ssi_school_student_leave/docs/school_student_leave/14-restart-approval.md
+++ b/ssi_school_student_leave/docs/school_student_leave/14-restart-approval.md
@@ -1,0 +1,32 @@
+# Restart Approval Process — Student Leave
+
+> **Module:** ssi*school_student_leave\
+> **Model:** `school_student_leave`\
+> **Menu:** School > Student Activities > Student Leaves\
+> **Actor:** user in group \_School Student Leave — User*\
+> **Requires:** `04-confirm`
+
+## Pre-Condition
+
+- **Record:** Status is **Waiting for Approval**, and the approval process is stalled
+  (for example, the record currently has no approval template assigned, or the assigned
+  template no longer matches).
+- **Config:** An active `policy.template` for this model grants `restart_approval_ok`
+  for state `confirm` to the actor's group.
+- **Config:** An active `approval.template` for this model matches this record, with an
+  approver group configured for its approval level, so the process can be rebuilt once
+  restarted.
+- **Access:** User is in group _School Student Leave — User_.
+
+## Flow
+
+1. Open the **School > Student Activities > Student Leaves** menu.
+2. Open the record whose approval process is stalled.
+3. Click the **Restart Approval Process** button.
+4. Click **OK** on the confirmation dialog.
+
+## Post-Condition
+
+- Status remains **Waiting for Approval**.
+- The existing approval records are discarded and a new approval process is created from
+  the approval template that now matches the record.

--- a/ssi_school_student_leave/docs/school_student_leave/15-return.md
+++ b/ssi_school_student_leave/docs/school_student_leave/15-return.md
@@ -1,0 +1,39 @@
+# Return Student Leave
+
+> **Module:** ssi*school_student_leave\
+> **Model:** `school_student_leave`\
+> **Menu:** School > Student Activities > Student Leaves\
+> **Actor:** user in group \_School Student Leave — Viewer*\
+> **Requires:** `05-approve`
+
+This IK documents the `action_return` button.
+
+## Pre-Condition
+
+- **Record:** Status is **Done**.
+- **Record:** The student is currently in the **On Leave** state
+  (`school_student.state = "on_leave"`). Attempting this action when the student is not
+  on leave raises an error.
+- **Access:** User is in group _School Student Leave — Viewer_ (the minimum group with
+  access to the menu). The **Return** button carries no additional group or policy
+  restriction — it is gated only by the record's status.
+
+## Flow
+
+1. Open the **School > Student Activities > Student Leaves** menu.
+2. Open the record whose status is **Done** and whose student is currently **On Leave**.
+3. Click the **Return** button.
+
+## Post-Condition
+
+- The linked student's status changes from **On Leave** to **Enrolled**
+  (`school_student.state` = `"enrol"`, via `action_set_to_enroll()`).
+- This leave document's own status is **not** changed by this action — it remains
+  **Done**. The leave document itself is not reverted through the workflow; only the
+  student's status is updated.
+- The student's active enrollment record (`school_enrollment`) is not modified by this
+  action.
+
+> **Note:** Unlike `04-confirm` / `05-approve` / `06-reject` / `10-cancel` /
+> `12-restart` / `14-restart-approval`, clicking **Return** does **not** show a
+> confirmation dialog — the button has no `confirm` attribute in the view.

--- a/ssi_school_student_leave/docs/school_student_leave/16-print.md
+++ b/ssi_school_student_leave/docs/school_student_leave/16-print.md
@@ -1,0 +1,26 @@
+# Print Student Leave
+
+> **Module:** ssi*school_student_leave\
+> **Model:** `school_student_leave`\
+> **Menu:** School > Student Activities > Student Leaves\
+> **Actor:** user in group \_School Student Leave — Viewer*\
+> **Requires:** `01-create`
+
+## Pre-Condition
+
+- **Config:** At least one `print_document_type` (with a linked report for
+  `school_student_leave`) is configured, so a report is available to select in step 4.
+- **Access:** User is in group _School Student Leave — Viewer_.
+
+## Flow
+
+1. Open the **School > Student Activities > Student Leaves** menu.
+2. Open the record to print.
+3. Click **Print** in the header.
+4. In the **Select Report To Print** wizard, select a **Type** (optional filter) and the
+   **Report Template** to generate.
+5. Click **Print**.
+
+## Post-Condition
+
+- The selected report is generated and opened/downloaded.

--- a/ssi_school_student_leave/docs/school_student_leave/17-reload-template-policy.md
+++ b/ssi_school_student_leave/docs/school_student_leave/17-reload-template-policy.md
@@ -1,0 +1,28 @@
+# Reload Template Policy — Student Leave
+
+> **Module:** ssi*school_student_leave\
+> **Model:** `school_student_leave`\
+> **Menu:** School > Student Activities > Student Leaves\
+> **Actor:** administrator in group \_Settings / Technical Settings*\
+> **Requires:** `01-create`
+
+## Pre-Condition
+
+- **Record:** None — usable regardless of status.
+- **Config:** At least one active `policy.template` exists for this model, so a matching
+  template can be found.
+- **Access:** User is in group _Settings / Technical Settings_ (`base.group_system`).
+  The **Policies** tab that contains this button is only visible to this group.
+
+## Flow
+
+1. Open the **School > Student Activities > Student Leaves** menu.
+2. Open the record whose assigned policy template should be re-evaluated.
+3. On the **Policies** tab, click **Reload Template Policy**.
+
+## Post-Condition
+
+- **Policy Template** is recomputed and re-assigned to the highest-sequence
+  `policy.template` for this model whose condition currently matches the record. This
+  may change which action buttons and policy fields (`confirm_ok`,
+  `restart_approval_ok`, etc.) are granted, without changing the record's status.


### PR DESCRIPTION
## Ringkasan

Menambahkan set Instruksi Kerja (IK) lengkap untuk `school_student_leave` di `docs/school_student_leave/`, sesuai mixin yang terpasang (`mixin.transaction_confirm` / `mixin.transaction_done` / `mixin.transaction_cancel`):

- `01-create`, `02-edit`, `03-delete`
- `04-confirm`, `05-approve`, `06-reject`
- `10-cancel`, `12-restart`, `13-reset-number`
- `14-restart-approval` (tombol Restart Approval Process, disuntikkan `ssi_transaction_confirm_mixin`, dirender tanpa syarat karena `_automatically_insert_restart_approval_button` tidak di-override)
- `15-return` (aksi `action_return` — Post-Condition diverifikasi dari kode: hanya mengubah status siswa dari On Leave ke Enrolled via `action_set_to_enroll()`; status dokumen leave sendiri TIDAK berubah, tetap Done; tidak menyentuh record enrollment)
- `16-print`, `17-reload-template-policy`

Entri `Work Instruction` ditambahkan ke `README.rst`. Tidak ada perubahan kode model/view — permukaan perubahan hanya `docs/` dan `README.rst`.

Tour (UI test) sengaja TIDAK termasuk di item ini — dicatat terpisah di #228 yang `Depends on:` item ini.

Closes #216