### PR TITLE
[UPD] ssi_school_student_withdrawal - Instruksi Kerja

### DIFF
--- a/ssi_school_student_withdrawal/README.rst
+++ b/ssi_school_student_withdrawal/README.rst
@@ -14,6 +14,29 @@ and No News -> Dropped), and, when the student has an active
 enrollment, marks that enrollment's academic year result as Drop Out.
 
 
+Work Instruction
+================
+
+Student Withdrawal
+-------------------
+
+* `Create Student Withdrawal <docs/school_student_withdrawal/01-create.html>`_
+* `Edit Student Withdrawal <docs/school_student_withdrawal/02-edit.html>`_
+* `Delete Student Withdrawal <docs/school_student_withdrawal/03-delete.html>`_
+* `Confirm Student Withdrawal <docs/school_student_withdrawal/04-confirm.html>`_
+* `Approve Student Withdrawal <docs/school_student_withdrawal/05-approve.html>`_
+* `Reject Student Withdrawal <docs/school_student_withdrawal/06-reject.html>`_
+* `Cancel Student Withdrawal <docs/school_student_withdrawal/10-cancel.html>`_
+* `Restart Student Withdrawal <docs/school_student_withdrawal/12-restart.html>`_
+* `Reset Document Number - Student Withdrawal
+  <docs/school_student_withdrawal/13-reset-number.html>`_
+* `Restart Approval Process - Student Withdrawal
+  <docs/school_student_withdrawal/14-restart-approval.html>`_
+* `Print Student Withdrawal <docs/school_student_withdrawal/16-print.html>`_
+* `Reload Template Policy - Student Withdrawal
+  <docs/school_student_withdrawal/17-reload-template-policy.html>`_
+
+
 Installation
 ============
 

--- a/ssi_school_student_withdrawal/docs/school_student_withdrawal/01-create.md
+++ b/ssi_school_student_withdrawal/docs/school_student_withdrawal/01-create.md
@@ -1,0 +1,37 @@
+# Create Student Withdrawal
+
+> **Module:** ssi*school_student_withdrawal\
+> **Model:** `school_student_withdrawal`\
+> **Menu:** School > Student Activities > Student Withdrawals\
+> **Actor:** user in group \_School Student Withdrawal — User*\
+> **State:** `—` → `draft`
+
+## Pre-Condition
+
+- **Data:** The student to be withdrawn is currently in the **Enrolled**, **On Leave**,
+  or **Suspended** state (`school_student.state`). This is enforced by a model
+  constraint once the withdrawal reaches `confirm` or `done` (needed later by
+  `04-confirm` and `05-approve`), but it is not checked while still in Draft.
+- **Config:** An active `policy.template` for this model grants `confirm_ok` for state
+  `draft` to the actor's group (needed later by `04-confirm`).
+- **Access:** User is in group _School Student Withdrawal — User_.
+
+## Flow
+
+1. Open the **School > Student Activities > Student Withdrawals** menu.
+2. Click the **New** button. **(14.0: "Create")**
+3. Fill in the required fields:
+   - **Student** _(required)_: Select the student being withdrawn from the school.
+   - **Active Enrollment**: Automatically filled, read-only, from the student's
+     currently open enrollment (blank if the student has none).
+   - **Date**: Defaults to today's date. Change if needed.
+   - **Effective Date**: Optional. The date on which the withdrawal takes effect for the
+     student.
+   - **Reason Type** _(required)_: Select **Drop Out / Expelled**, **Resignation**, or
+     **No News / Whereabouts Unknown**.
+   - **Reason**: Optional additional explanation, on the **Withdrawal Details** tab.
+4. Click **Save**.
+
+## Post-Condition
+
+- A new record is created in **Draft** status.

--- a/ssi_school_student_withdrawal/docs/school_student_withdrawal/02-edit.md
+++ b/ssi_school_student_withdrawal/docs/school_student_withdrawal/02-edit.md
@@ -1,0 +1,23 @@
+# Edit Student Withdrawal
+
+> **Module:** ssi*school_student_withdrawal\
+> **Model:** `school_student_withdrawal`\
+> **Menu:** School > Student Activities > Student Withdrawals\
+> **Actor:** user in group \_School Student Withdrawal — User*\
+> **Requires:** `01-create`
+
+## Pre-Condition
+
+- **Record:** Status is **Draft**.
+- **Access:** User is in group _School Student Withdrawal — User_.
+
+## Flow
+
+1. Open the **School > Student Activities > Student Withdrawals** menu.
+2. Find and open the record to edit.
+3. Change the required fields.
+4. Click **Save**.
+
+## Post-Condition
+
+- The record is updated with the new values.

--- a/ssi_school_student_withdrawal/docs/school_student_withdrawal/03-delete.md
+++ b/ssi_school_student_withdrawal/docs/school_student_withdrawal/03-delete.md
@@ -1,0 +1,24 @@
+# Delete Student Withdrawal
+
+> **Module:** ssi*school_student_withdrawal\
+> **Model:** `school_student_withdrawal`\
+> **Menu:** School > Student Activities > Student Withdrawals\
+> **Actor:** user in group \_School Student Withdrawal — User*\
+> **Requires:** `01-create`
+
+## Pre-Condition
+
+- **Record:** Status is **Draft**.
+- **Record:** Document number is still **/** (not yet generated).
+- **Access:** User is in group _School Student Withdrawal — User_.
+
+## Flow
+
+1. Open the **School > Student Activities > Student Withdrawals** menu.
+2. Select one or more records to delete (check the checkbox).
+3. Click **Action** > **Delete**.
+4. Click **OK** to confirm.
+
+## Post-Condition
+
+- The selected records are permanently removed from the system.

--- a/ssi_school_student_withdrawal/docs/school_student_withdrawal/04-confirm.md
+++ b/ssi_school_student_withdrawal/docs/school_student_withdrawal/04-confirm.md
@@ -1,0 +1,34 @@
+# Confirm Student Withdrawal
+
+> **Module:** ssi*school_student_withdrawal\
+> **Model:** `school_student_withdrawal`\
+> **Menu:** School > Student Activities > Student Withdrawals\
+> **Actor:** user in group \_School Student Withdrawal — User*\
+> **State:** `draft` → `confirm`\
+> **Requires:** `01-create`
+
+## Pre-Condition
+
+- **Record:** Status is **Draft**.
+- **Record:** The student is currently in the **Enrolled**, **On Leave**, or
+  **Suspended** state.
+- **Record:** No other Draft or Waiting for Approval withdrawal already exists for the
+  same student.
+- **Config:** An active `policy.template` for this model grants `confirm_ok` for state
+  `draft` to the actor's group.
+- **Config:** An active `approval.template` for this model matches this record and has
+  at least one approver level.
+- **Config:** An active `sequence.template` exists for this model.
+- **Access:** User is in group _School Student Withdrawal — User_.
+
+## Flow
+
+1. Open the **School > Student Activities > Student Withdrawals** menu.
+2. Open the record to confirm.
+3. Click the **Confirm** button.
+4. Click **OK** on the confirmation dialog.
+
+## Post-Condition
+
+- Status changes to **Waiting for Approval**.
+- Approval records are created for each approver level defined by the approval template.

--- a/ssi_school_student_withdrawal/docs/school_student_withdrawal/05-approve.md
+++ b/ssi_school_student_withdrawal/docs/school_student_withdrawal/05-approve.md
@@ -1,0 +1,42 @@
+# Approve Student Withdrawal
+
+> **Module:** ssi_school_student_withdrawal\
+> **Model:** `school_student_withdrawal`\
+> **Menu:** School > Student Activities > Student Withdrawals\
+> **Actor:** approver on the pending approval level\
+> **State:** `confirm` → `done`\
+> **Requires:** `04-confirm`
+
+## Pre-Condition
+
+- **Record:** Status is **Waiting for Approval**.
+- **Record:** The student is still in the **Enrolled**, **On Leave**, or **Suspended**
+  state.
+- **Config:** An active `policy.template` grants `approve_ok` to the actor's group.
+- **Access:** User is registered as an approver on the approval level that is currently
+  **pending**. When the template uses sequential approval, only the first unapproved
+  level is pending.
+
+## Flow
+
+1. Open the **School > Student Activities > Student Withdrawals** menu.
+2. Open the record to approve.
+3. Click the **Approve** button.
+4. Click **OK** on the confirmation dialog.
+
+## Post-Condition
+
+- If all approval levels are fulfilled, status changes automatically to **Done**. The
+  student is transitioned depending on **Reason Type**: **Resignation** moves the
+  student to the **Resigned** state; **Drop Out / Expelled** and **No News / Whereabouts
+  Unknown** both move the student to the **Dropped** state. If the student had an active
+  enrollment, that enrollment's **Academic Year Result** is set to **Drop Out**. Both
+  `school_student`'s own state machine and this document's status are terminal at this
+  point — there is no action in this module to reverse a completed withdrawal.
+- If there are still pending approval levels, status remains **Waiting for Approval**
+  and the next level becomes pending.
+
+> **Note:** `school_student_withdrawal` does **not** have a manual Finish button
+> (`_automatically_insert_done_button` is disabled). The transition to **Done** always
+> happens automatically as soon as the last approval level is fulfilled — there is no
+> `07-start.md` or `09-finish.md` for this model.

--- a/ssi_school_student_withdrawal/docs/school_student_withdrawal/06-reject.md
+++ b/ssi_school_student_withdrawal/docs/school_student_withdrawal/06-reject.md
@@ -1,0 +1,26 @@
+# Reject Student Withdrawal
+
+> **Module:** ssi_school_student_withdrawal\
+> **Model:** `school_student_withdrawal`\
+> **Menu:** School > Student Activities > Student Withdrawals\
+> **Actor:** approver on the pending approval level\
+> **State:** `confirm` → `reject`\
+> **Requires:** `04-confirm`
+
+## Pre-Condition
+
+- **Record:** Status is **Waiting for Approval**.
+- **Config:** An active `policy.template` grants `reject_ok` to the actor's group.
+- **Access:** User is registered as an approver on the approval level that is currently
+  pending.
+
+## Flow
+
+1. Open the **School > Student Activities > Student Withdrawals** menu.
+2. Open the record to reject.
+3. Click the **Reject** button.
+4. Click **OK** on the confirmation dialog.
+
+## Post-Condition
+
+- Status changes to **Rejected**. The student's state is not changed.

--- a/ssi_school_student_withdrawal/docs/school_student_withdrawal/10-cancel.md
+++ b/ssi_school_student_withdrawal/docs/school_student_withdrawal/10-cancel.md
@@ -1,0 +1,29 @@
+# Cancel Student Withdrawal
+
+> **Module:** ssi*school_student_withdrawal\
+> **Model:** `school_student_withdrawal`\
+> **Menu:** School > Student Activities > Student Withdrawals\
+> **Actor:** user in group \_School Student Withdrawal — Validator*\
+> **State:** `draft` | `confirm` | `reject` → `cancel`\
+> **Requires:** `01-create`
+
+## Pre-Condition
+
+- **Record:** Status is **Draft**, **Waiting for Approval**, or **Rejected**. Once the
+  withdrawal reaches **Done**, it is terminal and can no longer be cancelled.
+- **Config:** An active `policy.template` grants `cancel_ok` for that state to the
+  actor's group.
+- **Access:** User is in group _School Student Withdrawal — Validator_.
+
+## Flow
+
+1. Open the **School > Student Activities > Student Withdrawals** menu.
+2. Open the record to cancel.
+3. Click the **Cancel** button.
+4. In the wizard that appears, select the **Cancellation Reason**.
+5. Click **Confirm**.
+6. Click **OK** on the confirmation dialog.
+
+## Post-Condition
+
+- Status changes to **Cancelled**.

--- a/ssi_school_student_withdrawal/docs/school_student_withdrawal/12-restart.md
+++ b/ssi_school_student_withdrawal/docs/school_student_withdrawal/12-restart.md
@@ -1,0 +1,28 @@
+# Restart Student Withdrawal
+
+> **Module:** ssi*school_student_withdrawal\
+> **Model:** `school_student_withdrawal`\
+> **Menu:** School > Student Activities > Student Withdrawals\
+> **Actor:** user in group \_School Student Withdrawal — Validator*\
+> **State:** `cancel` | `reject` → `draft`\
+> **Requires:** `10-cancel`
+
+## Pre-Condition
+
+- **Record:** Status is **Cancelled** or **Rejected**.
+- **Config:** An active `policy.template` grants `restart_ok` for that state to the
+  actor's group.
+- **Access:** User is in group _School Student Withdrawal — Validator_.
+
+## Flow
+
+1. Open the **School > Student Activities > Student Withdrawals** menu.
+2. Open the record to restart.
+3. Click the **Restart** button.
+4. Click **OK** on the confirmation dialog.
+
+## Post-Condition
+
+- Status returns to **Draft**.
+- All approval records are removed and the approval template is cleared. A later Confirm
+  starts the approval process from the beginning.

--- a/ssi_school_student_withdrawal/docs/school_student_withdrawal/13-reset-number.md
+++ b/ssi_school_student_withdrawal/docs/school_student_withdrawal/13-reset-number.md
@@ -1,0 +1,29 @@
+# Reset Document Number — Student Withdrawal
+
+> **Module:** ssi*school_student_withdrawal\
+> **Model:** `school_student_withdrawal`\
+> **Menu:** School > Student Activities > Student Withdrawals\
+> **Actor:** user in group \_School Student Withdrawal — Validator*\
+> **Requires:** `01-create`
+
+## Pre-Condition
+
+- **Record:** Status is **Draft**.
+- **Config:** An active `sequence.template` exists for this model.
+- **Config:** An active `policy.template` grants `manual_number_ok` for state `draft` to
+  the actor's group.
+- **Access:** User is in group _School Student Withdrawal — Validator_.
+
+## Flow
+
+1. Open the **School > Student Activities > Student Withdrawals** menu.
+2. Open the record whose document number will be reset.
+3. Click the **Reset Document Number** button (or edit the **# Document** field directly
+   and change it to **/**).
+4. Click **OK** on the confirmation dialog (only when the button was used).
+
+## Post-Condition
+
+- Document number returns to **/**.
+- The record will receive an automatic number when it transitions to **Done**, according
+  to the configured sequence.

--- a/ssi_school_student_withdrawal/docs/school_student_withdrawal/14-restart-approval.md
+++ b/ssi_school_student_withdrawal/docs/school_student_withdrawal/14-restart-approval.md
@@ -1,0 +1,32 @@
+# Restart Approval Process — Student Withdrawal
+
+> **Module:** ssi*school_student_withdrawal\
+> **Model:** `school_student_withdrawal`\
+> **Menu:** School > Student Activities > Student Withdrawals\
+> **Actor:** user in group \_School Student Withdrawal — User*\
+> **Requires:** `04-confirm`
+
+## Pre-Condition
+
+- **Record:** Status is **Waiting for Approval**, and the approval process is stalled
+  (for example, the record currently has no approval template assigned, or the assigned
+  template no longer matches).
+- **Config:** An active `policy.template` for this model grants `restart_approval_ok`
+  for state `confirm` to the actor's group.
+- **Config:** An active `approval.template` for this model matches this record, with an
+  approver group configured for its approval level, so the process can be rebuilt once
+  restarted.
+- **Access:** User is in group _School Student Withdrawal — User_.
+
+## Flow
+
+1. Open the **School > Student Activities > Student Withdrawals** menu.
+2. Open the record whose approval process is stalled.
+3. Click the **Restart Approval Process** button.
+4. Click **OK** on the confirmation dialog.
+
+## Post-Condition
+
+- Status remains **Waiting for Approval**.
+- The existing approval records are discarded and a new approval process is created from
+  the approval template that now matches the record.

--- a/ssi_school_student_withdrawal/docs/school_student_withdrawal/16-print.md
+++ b/ssi_school_student_withdrawal/docs/school_student_withdrawal/16-print.md
@@ -1,0 +1,27 @@
+# Print Student Withdrawal
+
+> **Module:** ssi*school_student_withdrawal\
+> **Model:** `school_student_withdrawal`\
+> **Menu:** School > Student Activities > Student Withdrawals\
+> **Actor:** user in group \_School Student Withdrawal — Viewer*\
+> **Requires:** `01-create`
+
+## Pre-Condition
+
+- **Config:** At least one `print_document_type` (with a linked report for
+  `school_student_withdrawal`) is configured, so a report is available to select in
+  step 4.
+- **Access:** User is in group _School Student Withdrawal — Viewer_.
+
+## Flow
+
+1. Open the **School > Student Activities > Student Withdrawals** menu.
+2. Open the record to print.
+3. Click **Print** in the header.
+4. In the **Select Report To Print** wizard, select a **Type** (optional filter) and the
+   **Report Template** to generate.
+5. Click **Print**.
+
+## Post-Condition
+
+- The selected report is generated and opened/downloaded.

--- a/ssi_school_student_withdrawal/docs/school_student_withdrawal/17-reload-template-policy.md
+++ b/ssi_school_student_withdrawal/docs/school_student_withdrawal/17-reload-template-policy.md
@@ -1,0 +1,28 @@
+# Reload Template Policy — Student Withdrawal
+
+> **Module:** ssi*school_student_withdrawal\
+> **Model:** `school_student_withdrawal`\
+> **Menu:** School > Student Activities > Student Withdrawals\
+> **Actor:** administrator in group \_Settings / Technical Settings*\
+> **Requires:** `01-create`
+
+## Pre-Condition
+
+- **Record:** None — usable regardless of status.
+- **Config:** At least one active `policy.template` exists for this model, so a matching
+  template can be found.
+- **Access:** User is in group _Settings / Technical Settings_ (`base.group_system`).
+  The **Policies** tab that contains this button is only visible to this group.
+
+## Flow
+
+1. Open the **School > Student Activities > Student Withdrawals** menu.
+2. Open the record whose assigned policy template should be re-evaluated.
+3. On the **Policies** tab, click **Reload Template Policy**.
+
+## Post-Condition
+
+- **Policy Template** is recomputed and re-assigned to the highest-sequence
+  `policy.template` for this model whose condition currently matches the record. This
+  may change which action buttons and policy fields (`confirm_ok`,
+  `restart_approval_ok`, etc.) are granted, without changing the record's status.


### PR DESCRIPTION
## Ringkasan

Menambahkan set Instruksi Kerja (IK) kanonik untuk `school_student_withdrawal` di
`ssi_school_student_withdrawal/docs/school_student_withdrawal/`, sesuai mixin yang
benar-benar terpasang (`mixin.transaction_confirm`, `mixin.transaction_done`,
`mixin.transaction_cancel`). Tidak ada perubahan kode model/view.

IK yang ditambahkan:

- `01-create.md`, `02-edit.md`, `03-delete.md`
- `04-confirm.md`, `05-approve.md`, `06-reject.md`
- `10-cancel.md`, `12-restart.md`, `13-reset-number.md`
- `14-restart-approval.md` (Restart Approval Process — tombolnya dirender tanpa syarat
  karena `school_student_withdrawal` tidak meng-override
  `_automatically_insert_restart_approval_button`)
- `16-print.md`, `17-reload-template-policy.md`

Tidak ada IK `07-start`/`08-ready`/`09-finish` karena model tidak memakai
`mixin.transaction_open`/`mixin.transaction_ready`, dan transisi ke Done bersifat
otomatis setelah approval selesai (`_automatically_insert_done_button = False`). Tidak
ada aksi khas modul (tidak ada `action_*` tambahan di form view selain bawaan mixin),
sehingga tidak ada IK bernomor `15`.

`README.rst` diperbarui dengan bagian `Work Instruction` yang menautkan seluruh IK di
atas.

Tour (UI test) pasangan IK ini dicatat terpisah di #228 dan dikerjakan setelah issue ini
`closed:completed`.

## Verifikasi

- `assets/validate-ik.sh ssi_school_student_withdrawal` → 0 ERROR (12 berkas IK, 12
  peringatan tour — diharapkan, ditangani #228)
- pre-commit (termasuk `oca-gen-addon-readme`, `prettier`) hijau

Closes #217