### PR TITLE
[UPD] ssi_school_incident - retrofit format IK (blok metadata, label tipe, Restart Approval/Print/Reload Template Policy)

### DIFF
--- a/ssi_school_incident/README.rst
+++ b/ssi_school_incident/README.rst
@@ -34,6 +34,7 @@ Incident Type
 * `Delete Incident Type <docs/school_incident_type/03-delete.html>`_
 * `Deactivate Incident Type <docs/school_incident_type/04-deactivate.html>`_
 * `Activate Incident Type <docs/school_incident_type/05-activate.html>`_
+* `Print Incident Type <docs/school_incident_type/06-print.html>`_
 
 Incident Escalation Criteria
 -----------------------------
@@ -43,6 +44,7 @@ Incident Escalation Criteria
 * `Delete Incident Escalation Criteria <docs/school_incident_escalation_criteria/03-delete.html>`_
 * `Deactivate Incident Escalation Criteria <docs/school_incident_escalation_criteria/04-deactivate.html>`_
 * `Activate Incident Escalation Criteria <docs/school_incident_escalation_criteria/05-activate.html>`_
+* `Print Incident Escalation Criteria <docs/school_incident_escalation_criteria/06-print.html>`_
 
 Academic Alert Level
 ---------------------
@@ -52,6 +54,7 @@ Academic Alert Level
 * `Delete Academic Alert Level <docs/school_academic_alert_level/03-delete.html>`_
 * `Deactivate Academic Alert Level <docs/school_academic_alert_level/04-deactivate.html>`_
 * `Activate Academic Alert Level <docs/school_academic_alert_level/05-activate.html>`_
+* `Print Academic Alert Level <docs/school_academic_alert_level/06-print.html>`_
 
 School Incident
 ----------------
@@ -67,6 +70,9 @@ School Incident
 * `Restart School Incident <docs/school_incident/12-restart.html>`_
 * `Reset Document Number - School Incident <docs/school_incident/13-reset-document-number.html>`_
 * `Escalate School Incident <docs/school_incident/14-escalate.html>`_
+* `Restart Approval Process - School Incident <docs/school_incident/15-restart-approval.html>`_
+* `Print School Incident <docs/school_incident/16-print.html>`_
+* `Reload Template Policy - School Incident <docs/school_incident/17-reload-template-policy.html>`_
 
 School Academic Alert
 -----------------------
@@ -83,6 +89,9 @@ School Academic Alert
 * `Reset Document Number - School Academic Alert <docs/school_academic_alert/13-reset-document-number.html>`_
 * `Evaluate School Academic Alert <docs/school_academic_alert/14-evaluate.html>`_
 * `Create Incident from School Academic Alert <docs/school_academic_alert/15-create-incident.html>`_
+* `Restart Approval Process - School Academic Alert <docs/school_academic_alert/16-restart-approval.html>`_
+* `Print School Academic Alert <docs/school_academic_alert/17-print.html>`_
+* `Reload Template Policy - School Academic Alert <docs/school_academic_alert/18-reload-template-policy.html>`_
 
 School Incident Weekly Review
 -------------------------------
@@ -98,6 +107,9 @@ School Incident Weekly Review
 * `Reset Document Number - School Incident Weekly Review <docs/school_incident_weekly_review/13-reset-document-number.html>`_
 * `Collect Incidents into School Incident Weekly Review <docs/school_incident_weekly_review/14-collect-incidents.html>`_
 * `Fill in the Weekly Case Review Checklist <docs/school_incident_weekly_review/15-checklist.html>`_
+* `Restart Approval Process - School Incident Weekly Review <docs/school_incident_weekly_review/16-restart-approval.html>`_
+* `Print School Incident Weekly Review <docs/school_incident_weekly_review/17-print.html>`_
+* `Reload Template Policy - School Incident Weekly Review <docs/school_incident_weekly_review/18-reload-template-policy.html>`_
 
 
 Installation

--- a/ssi_school_incident/docs/school_academic_alert/01-create.md
+++ b/ssi_school_incident/docs/school_academic_alert/01-create.md
@@ -1,5 +1,11 @@
 # Create School Academic Alert
 
+> **Module:** ssi*school_incident\
+> **Model:** `school_academic_alert`\
+> **Menu:** School > Incident > Academic Alerts\
+> **Actor:** user in group \_User (Homeroom Teacher)* or higher\
+> **State:** `—` → `draft`
+
 ## Pre-Condition
 
 - None.

--- a/ssi_school_incident/docs/school_academic_alert/02-edit.md
+++ b/ssi_school_incident/docs/school_academic_alert/02-edit.md
@@ -1,8 +1,14 @@
 # Edit School Academic Alert
 
+> **Module:** ssi*school_incident\
+> **Model:** `school_academic_alert`\
+> **Menu:** School > Incident > Academic Alerts\
+> **Actor:** user in group \_User (Homeroom Teacher)* or higher\
+> **Requires:** `01-create`
+
 ## Pre-Condition
 
-- Record is in **Draft** status.
+- **Record:** Status is **Draft**.
 
 ## Flow
 

--- a/ssi_school_incident/docs/school_academic_alert/03-delete.md
+++ b/ssi_school_incident/docs/school_academic_alert/03-delete.md
@@ -1,9 +1,15 @@
 # Delete School Academic Alert
 
+> **Module:** ssi*school_incident\
+> **Model:** `school_academic_alert`\
+> **Menu:** School > Incident > Academic Alerts\
+> **Actor:** user in group \_User (Homeroom Teacher)* or higher\
+> **Requires:** `01-create`
+
 ## Pre-Condition
 
-- Record is in **Draft** status.
-- Document number is still **/** (not yet generated).
+- **Record:** Status is **Draft**.
+- **Record:** Document number is still **/** (not yet generated).
 
 ## Flow
 

--- a/ssi_school_incident/docs/school_academic_alert/04-confirm.md
+++ b/ssi_school_incident/docs/school_academic_alert/04-confirm.md
@@ -1,10 +1,17 @@
 # Confirm School Academic Alert
 
+> **Module:** ssi*school_incident\
+> **Model:** `school_academic_alert`\
+> **Menu:** School > Incident > Academic Alerts\
+> **Actor:** user in group \_User (Homeroom Teacher)* or higher\
+> **State:** `draft` → `confirm`\
+> **Requires:** `01-create`
+
 ## Pre-Condition
 
-- Record is in **Draft** status.
-- User has _Can Confirm_ access right (belongs to the User (Homeroom Teacher) group or
-  higher).
+- **Record:** Status is **Draft**.
+- **Access:** User has _Can Confirm_ access right (belongs to the User (Homeroom
+  Teacher) group or higher).
 
 ## Flow
 

--- a/ssi_school_incident/docs/school_academic_alert/05-approve.md
+++ b/ssi_school_incident/docs/school_academic_alert/05-approve.md
@@ -1,11 +1,18 @@
 # Approve School Academic Alert
 
+> **Module:** ssi*school_incident\
+> **Model:** `school_academic_alert`\
+> **Menu:** School > Incident > Academic Alerts\
+> **Actor:** approver in group \_Officer (Counselor/Vice Principal)* or higher\
+> **State:** `confirm` → `open`\
+> **Requires:** `04-confirm`
+
 ## Pre-Condition
 
-- Record is in **Waiting for Approval** status.
-- User is registered as an approver on the active approval template (belongs to the
-  Officer (Counselor/Vice Principal) group or higher).
-- User has _Can Approve_ access right.
+- **Record:** Status is **Waiting for Approval**.
+- **Access:** User is registered as an approver on the active approval template (belongs
+  to the Officer (Counselor/Vice Principal) group or higher).
+- **Access:** User has _Can Approve_ access right.
 
 ## Flow
 

--- a/ssi_school_incident/docs/school_academic_alert/06-reject.md
+++ b/ssi_school_incident/docs/school_academic_alert/06-reject.md
@@ -1,11 +1,18 @@
 # Reject School Academic Alert
 
+> **Module:** ssi*school_incident\
+> **Model:** `school_academic_alert`\
+> **Menu:** School > Incident > Academic Alerts\
+> **Actor:** approver in group \_Officer (Counselor/Vice Principal)* or higher\
+> **State:** `confirm` → `reject`\
+> **Requires:** `04-confirm`
+
 ## Pre-Condition
 
-- Record is in **Waiting for Approval** status.
-- User is registered as an approver on the active approval template (belongs to the
-  Officer (Counselor/Vice Principal) group or higher).
-- User has _Can Reject_ access right.
+- **Record:** Status is **Waiting for Approval**.
+- **Access:** User is registered as an approver on the active approval template (belongs
+  to the Officer (Counselor/Vice Principal) group or higher).
+- **Access:** User has _Can Reject_ access right.
 
 ## Flow
 

--- a/ssi_school_incident/docs/school_academic_alert/09-finish.md
+++ b/ssi_school_incident/docs/school_academic_alert/09-finish.md
@@ -1,10 +1,17 @@
 # Finish School Academic Alert
 
+> **Module:** ssi*school_incident\
+> **Model:** `school_academic_alert`\
+> **Menu:** School > Incident > Academic Alerts\
+> **Actor:** user in group \_User (Homeroom Teacher)* or higher\
+> **State:** `open` → `done`\
+> **Requires:** `05-approve`
+
 ## Pre-Condition
 
-- Record is in **Open** status.
-- User has _Can Finish_ access right (belongs to the User (Homeroom Teacher) group or
-  higher).
+- **Record:** Status is **Open**.
+- **Access:** User has _Can Finish_ access right (belongs to the User (Homeroom Teacher)
+  group or higher).
 
 ## Flow
 

--- a/ssi_school_incident/docs/school_academic_alert/10-cancel.md
+++ b/ssi_school_incident/docs/school_academic_alert/10-cancel.md
@@ -1,10 +1,17 @@
 # Cancel School Academic Alert
 
+> **Module:** ssi*school_incident\
+> **Model:** `school_academic_alert`\
+> **Menu:** School > Incident > Academic Alerts\
+> **Actor:** user in group \_Officer (Counselor/Vice Principal)* or higher\
+> **State:** `draft` | `confirm` | `open` → `cancel`\
+> **Requires:** `01-create`
+
 ## Pre-Condition
 
-- Record is in **Draft**, **Waiting for Approval**, or **Open** status.
-- User has _Can Cancel_ access right (belongs to the Officer (Counselor/Vice Principal)
-  group or higher).
+- **Record:** Status is **Draft**, **Waiting for Approval**, or **Open**.
+- **Access:** User has _Can Cancel_ access right (belongs to the Officer (Counselor/Vice
+  Principal) group or higher).
 
 ## Flow
 

--- a/ssi_school_incident/docs/school_academic_alert/12-restart.md
+++ b/ssi_school_incident/docs/school_academic_alert/12-restart.md
@@ -1,10 +1,17 @@
 # Restart School Academic Alert
 
+> **Module:** ssi*school_incident\
+> **Model:** `school_academic_alert`\
+> **Menu:** School > Incident > Academic Alerts\
+> **Actor:** user in group \_Officer (Counselor/Vice Principal)* or higher\
+> **State:** `cancel` | `reject` → `draft`\
+> **Requires:** `10-cancel`
+
 ## Pre-Condition
 
-- Record is in **Cancelled** or **Rejected** status.
-- User has _Can Restart_ access right (belongs to the Officer (Counselor/Vice Principal)
-  group or higher).
+- **Record:** Status is **Cancelled** or **Rejected**.
+- **Access:** User has _Can Restart_ access right (belongs to the Officer
+  (Counselor/Vice Principal) group or higher).
 
 ## Flow
 

--- a/ssi_school_incident/docs/school_academic_alert/13-reset-document-number.md
+++ b/ssi_school_incident/docs/school_academic_alert/13-reset-document-number.md
@@ -1,10 +1,16 @@
 # Reset Document Number — School Academic Alert
 
+> **Module:** ssi*school_incident\
+> **Model:** `school_academic_alert`\
+> **Menu:** School > Incident > Academic Alerts\
+> **Actor:** user in group \_Officer (Counselor/Vice Principal)* or higher\
+> **Requires:** `01-create`
+
 ## Pre-Condition
 
-- Record is in **Draft** status.
-- User has _Can Input Manual Document Number_ access right (belongs to the Officer
-  (Counselor/Vice Principal) group or higher).
+- **Record:** Status is **Draft**.
+- **Access:** User has _Can Input Manual Document Number_ access right (belongs to the
+  Officer (Counselor/Vice Principal) group or higher).
 
 ## Flow
 

--- a/ssi_school_incident/docs/school_academic_alert/14-evaluate.md
+++ b/ssi_school_incident/docs/school_academic_alert/14-evaluate.md
@@ -1,9 +1,16 @@
 # Evaluate School Academic Alert
 
+> **Module:** ssi*school_incident\
+> **Model:** `school_academic_alert`\
+> **Menu:** School > Incident > Academic Alerts\
+> **Actor:** user in group \_User (Homeroom Teacher)* or higher\
+> **Requires:** `01-create`
+
 ## Pre-Condition
 
-- Record is in a status where _Can Evaluate_ access right applies (Draft), and the user
-  belongs to the User (Homeroom Teacher) group or higher.
+- **Record:** Status is **Draft** (the status where the _Can Evaluate_ access right
+  applies).
+- **Access:** User belongs to the User (Homeroom Teacher) group or higher.
 
 ## Flow
 
@@ -11,7 +18,7 @@
 2. Open the School Academic Alert record to evaluate.
 3. Optionally fill in the **Evaluation Context** field with plain Python assignments to
    seed extra local variables (e.g. `trigger_count = 3`).
-4. Click the **Evaluate** button.
+4. Click the **Evaluate** button (`action_evaluate`).
 
 The system checks every configured Academic Alert Level from most severe (highest
 Sequence, e.g. Red) to least severe (lowest Sequence, e.g. Yellow), running each level's

--- a/ssi_school_incident/docs/school_academic_alert/15-create-incident.md
+++ b/ssi_school_incident/docs/school_academic_alert/15-create-incident.md
@@ -1,17 +1,24 @@
 # Create Incident from School Academic Alert
 
+> **Module:** ssi*school_incident\
+> **Model:** `school_academic_alert`\
+> **Menu:** School > Incident > Academic Alerts\
+> **Actor:** user in group \_Officer (Counselor/Vice Principal)* or higher\
+> **Requires:** `14-evaluate`
+
 ## Pre-Condition
 
-- Record is in **Open** status.
-- **Alert Level** is set to an Orange or Red level (from a previous **Evaluate** run).
-- User has _Can Create Incident_ access right (belongs to the Officer (Counselor/Vice
-  Principal) group or higher).
+- **Record:** Status is **Open**.
+- **Record:** **Alert Level** is set to an Orange or Red level (from a previous
+  **Evaluate** run).
+- **Access:** User has _Can Create Incident_ access right (belongs to the Officer
+  (Counselor/Vice Principal) group or higher).
 
 ## Flow
 
 1. Open the **School > Incident > Academic Alerts** menu.
 2. Open the School Academic Alert record whose Alert Level is Orange or Red.
-3. Click the **Create Incident** button.
+3. Click the **Create Incident** button (`action_create_incident`).
 
 ## Post-Condition
 

--- a/ssi_school_incident/docs/school_academic_alert/16-restart-approval.md
+++ b/ssi_school_incident/docs/school_academic_alert/16-restart-approval.md
@@ -1,0 +1,32 @@
+# Restart Approval Process — School Academic Alert
+
+> **Module:** ssi*school_incident\
+> **Model:** `school_academic_alert`\
+> **Menu:** School > Incident > Academic Alerts\
+> **Actor:** user in group \_User (Homeroom Teacher)* or higher\
+> **Requires:** `04-confirm`
+
+## Pre-Condition
+
+- **Record:** Status is **Waiting for Approval**, and the approval process is stalled
+  (for example, the record currently has no approval template assigned, or the assigned
+  template no longer matches).
+- **Config:** An active `policy.template` for this model grants `restart_approval_ok`
+  for state `confirm` to the actor's group.
+- **Config:** An active `approval.template` for this model matches this record, with an
+  approver group configured for its approval level, so the process can be rebuilt once
+  restarted.
+- **Access:** User is in group _User (Homeroom Teacher)_ or higher.
+
+## Flow
+
+1. Open the **School > Incident > Academic Alerts** menu.
+2. Open the record whose approval process is stalled.
+3. Click the **Restart Approval Process** button.
+4. Click **OK** on the confirmation dialog.
+
+## Post-Condition
+
+- Status remains **Waiting for Approval**.
+- The existing approval records are discarded and a new approval process is created from
+  the approval template that now matches the record.

--- a/ssi_school_incident/docs/school_academic_alert/17-print.md
+++ b/ssi_school_incident/docs/school_academic_alert/17-print.md
@@ -1,0 +1,27 @@
+# Print School Academic Alert
+
+> **Module:** ssi_school_incident\
+> **Model:** `school_academic_alert`\
+> **Menu:** School > Incident > Academic Alerts\
+> **Actor:** any authenticated user\
+> **Requires:** `01-create`
+
+## Pre-Condition
+
+- **Config:** At least one `print_document_type` (with a linked report for
+  `school_academic_alert`) is configured, so a report is available to select in step 4.
+- **Access:** User has read access to School Academic Alert (granted to every
+  authenticated user by the model's global access rule).
+
+## Flow
+
+1. Open the **School > Incident > Academic Alerts** menu.
+2. Open the record to print.
+3. Click **Print** in the header.
+4. In the **Select Report To Print** wizard, select a **Type** (optional filter) and the
+   **Report Template** to generate.
+5. Click **Print**.
+
+## Post-Condition
+
+- The selected report is generated and opened/downloaded.

--- a/ssi_school_incident/docs/school_academic_alert/18-reload-template-policy.md
+++ b/ssi_school_incident/docs/school_academic_alert/18-reload-template-policy.md
@@ -1,0 +1,28 @@
+# Reload Template Policy — School Academic Alert
+
+> **Module:** ssi*school_incident\
+> **Model:** `school_academic_alert`\
+> **Menu:** School > Incident > Academic Alerts\
+> **Actor:** administrator in group \_Settings / Technical Settings*\
+> **Requires:** `01-create`
+
+## Pre-Condition
+
+- **Record:** None — usable regardless of status.
+- **Config:** At least one active `policy.template` exists for this model, so a matching
+  template can be found.
+- **Access:** User is in group _Settings / Technical Settings_ (`base.group_system`).
+  The **Policies** tab that contains this button is only visible to this group.
+
+## Flow
+
+1. Open the **School > Incident > Academic Alerts** menu.
+2. Open the record whose assigned policy template should be re-evaluated.
+3. On the **Policies** tab, click **Reload Template Policy**.
+
+## Post-Condition
+
+- **Policy Template** is recomputed and re-assigned to the highest-sequence
+  `policy.template` for this model whose condition currently matches the record. This
+  may change which action buttons and policy fields (`confirm_ok`,
+  `restart_approval_ok`, etc.) are granted, without changing the record's status.

--- a/ssi_school_incident/docs/school_academic_alert_level/01-create.md
+++ b/ssi_school_incident/docs/school_academic_alert_level/01-create.md
@@ -1,5 +1,10 @@
 # Create Academic Alert Level
 
+> **Module:** ssi*school_incident\
+> **Model:** `school_academic_alert_level`\
+> **Menu:** School > Configuration > Configuration > Academic Alert Levels\
+> **Actor:** user in group \_Manager (Principal)*
+
 ## Pre-Condition
 
 - None.

--- a/ssi_school_incident/docs/school_academic_alert_level/02-edit.md
+++ b/ssi_school_incident/docs/school_academic_alert_level/02-edit.md
@@ -1,5 +1,11 @@
 # Edit Academic Alert Level
 
+> **Module:** ssi*school_incident\
+> **Model:** `school_academic_alert_level`\
+> **Menu:** School > Configuration > Configuration > Academic Alert Levels\
+> **Actor:** user in group \_Manager (Principal)*\
+> **Requires:** `01-create`
+
 ## Pre-Condition
 
 - None.

--- a/ssi_school_incident/docs/school_academic_alert_level/03-delete.md
+++ b/ssi_school_incident/docs/school_academic_alert_level/03-delete.md
@@ -1,8 +1,15 @@
 # Delete Academic Alert Level
 
+> **Module:** ssi*school_incident\
+> **Model:** `school_academic_alert_level`\
+> **Menu:** School > Configuration > Configuration > Academic Alert Levels\
+> **Actor:** user in group \_Manager (Principal)*\
+> **Requires:** `01-create`
+
 ## Pre-Condition
 
-- The Academic Alert Level is not referenced by any School Academic Alert record.
+- **Data:** The Academic Alert Level is not referenced by any School Academic Alert
+  record.
 
 ## Flow
 

--- a/ssi_school_incident/docs/school_academic_alert_level/04-deactivate.md
+++ b/ssi_school_incident/docs/school_academic_alert_level/04-deactivate.md
@@ -1,5 +1,12 @@
 # Deactivate Academic Alert Level
 
+> **Module:** ssi*school_incident\
+> **Model:** `school_academic_alert_level`\
+> **Menu:** School > Configuration > Configuration > Academic Alert Levels\
+> **Actor:** user in group \_Manager (Principal)*\
+> **Active:** `true` → `false`\
+> **Requires:** `01-create`
+
 ## Pre-Condition
 
 - None.

--- a/ssi_school_incident/docs/school_academic_alert_level/05-activate.md
+++ b/ssi_school_incident/docs/school_academic_alert_level/05-activate.md
@@ -1,5 +1,12 @@
 # Activate Academic Alert Level
 
+> **Module:** ssi*school_incident\
+> **Model:** `school_academic_alert_level`\
+> **Menu:** School > Configuration > Configuration > Academic Alert Levels\
+> **Actor:** user in group \_Manager (Principal)*\
+> **Active:** `false` → `true`\
+> **Requires:** `01-create`
+
 ## Pre-Condition
 
 - None.

--- a/ssi_school_incident/docs/school_academic_alert_level/06-print.md
+++ b/ssi_school_incident/docs/school_academic_alert_level/06-print.md
@@ -1,0 +1,28 @@
+# Print Academic Alert Level
+
+> **Module:** ssi_school_incident\
+> **Model:** `school_academic_alert_level`\
+> **Menu:** School > Configuration > Configuration > Academic Alert Levels\
+> **Actor:** any authenticated user\
+> **Requires:** `01-create`
+
+## Pre-Condition
+
+- **Config:** At least one `print_document_type` (with a linked report for
+  `school_academic_alert_level`) is configured, so a report is available to select in
+  step 4.
+- **Access:** User has read access to Academic Alert Level (granted to every
+  authenticated user by the model's global access rule).
+
+## Flow
+
+1. Open the **School > Configuration > Configuration > Academic Alert Levels** menu.
+2. Open the record to print.
+3. Click **Print** in the header.
+4. In the **Select Report To Print** wizard, select a **Type** (optional filter) and the
+   **Report Template** to generate.
+5. Click **Print**.
+
+## Post-Condition
+
+- The selected report is generated and opened/downloaded.

--- a/ssi_school_incident/docs/school_incident/01-create.md
+++ b/ssi_school_incident/docs/school_incident/01-create.md
@@ -1,5 +1,11 @@
 # Create School Incident
 
+> **Module:** ssi*school_incident\
+> **Model:** `school_incident`\
+> **Menu:** School > Incident > Incidents\
+> **Actor:** user in group \_User (Homeroom Teacher)* or higher\
+> **State:** `—` → `draft`
+
 ## Pre-Condition
 
 - None.

--- a/ssi_school_incident/docs/school_incident/02-edit.md
+++ b/ssi_school_incident/docs/school_incident/02-edit.md
@@ -1,8 +1,14 @@
 # Edit School Incident
 
+> **Module:** ssi*school_incident\
+> **Model:** `school_incident`\
+> **Menu:** School > Incident > Incidents\
+> **Actor:** user in group \_User (Homeroom Teacher)* or higher\
+> **Requires:** `01-create`
+
 ## Pre-Condition
 
-- Record is in **Draft** status.
+- **Record:** Status is **Draft**.
 
 ## Flow
 

--- a/ssi_school_incident/docs/school_incident/03-delete.md
+++ b/ssi_school_incident/docs/school_incident/03-delete.md
@@ -1,9 +1,15 @@
 # Delete School Incident
 
+> **Module:** ssi*school_incident\
+> **Model:** `school_incident`\
+> **Menu:** School > Incident > Incidents\
+> **Actor:** user in group \_User (Homeroom Teacher)* or higher\
+> **Requires:** `01-create`
+
 ## Pre-Condition
 
-- Record is in **Draft** status.
-- Document number is still **/** (not yet generated).
+- **Record:** Status is **Draft**.
+- **Record:** Document number is still **/** (not yet generated).
 
 ## Flow
 

--- a/ssi_school_incident/docs/school_incident/04-confirm.md
+++ b/ssi_school_incident/docs/school_incident/04-confirm.md
@@ -1,10 +1,17 @@
 # Confirm School Incident
 
+> **Module:** ssi*school_incident\
+> **Model:** `school_incident`\
+> **Menu:** School > Incident > Incidents\
+> **Actor:** user in group \_User (Homeroom Teacher)* or higher\
+> **State:** `draft` → `confirm`\
+> **Requires:** `01-create`
+
 ## Pre-Condition
 
-- Record is in **Draft** status.
-- User has _Can Confirm_ access right (belongs to the User (Homeroom Teacher) group or
-  higher).
+- **Record:** Status is **Draft**.
+- **Access:** User has _Can Confirm_ access right (belongs to the User (Homeroom
+  Teacher) group or higher).
 
 ## Flow
 

--- a/ssi_school_incident/docs/school_incident/05-approve.md
+++ b/ssi_school_incident/docs/school_incident/05-approve.md
@@ -1,11 +1,18 @@
 # Approve School Incident
 
+> **Module:** ssi*school_incident\
+> **Model:** `school_incident`\
+> **Menu:** School > Incident > Incidents\
+> **Actor:** approver in group \_Officer (Counselor/Vice Principal)* or higher\
+> **State:** `confirm` → `open`\
+> **Requires:** `04-confirm`
+
 ## Pre-Condition
 
-- Record is in **Waiting for Approval** status.
-- User is registered as an approver on the active approval template (belongs to the
-  Officer (Counselor/Vice Principal) group or higher).
-- User has _Can Approve_ access right.
+- **Record:** Status is **Waiting for Approval**.
+- **Access:** User is registered as an approver on the active approval template (belongs
+  to the Officer (Counselor/Vice Principal) group or higher).
+- **Access:** User has _Can Approve_ access right.
 
 ## Flow
 

--- a/ssi_school_incident/docs/school_incident/06-reject.md
+++ b/ssi_school_incident/docs/school_incident/06-reject.md
@@ -1,11 +1,18 @@
 # Reject School Incident
 
+> **Module:** ssi*school_incident\
+> **Model:** `school_incident`\
+> **Menu:** School > Incident > Incidents\
+> **Actor:** approver in group \_Officer (Counselor/Vice Principal)* or higher\
+> **State:** `confirm` → `reject`\
+> **Requires:** `04-confirm`
+
 ## Pre-Condition
 
-- Record is in **Waiting for Approval** status.
-- User is registered as an approver on the active approval template (belongs to the
-  Officer (Counselor/Vice Principal) group or higher).
-- User has _Can Reject_ access right.
+- **Record:** Status is **Waiting for Approval**.
+- **Access:** User is registered as an approver on the active approval template (belongs
+  to the Officer (Counselor/Vice Principal) group or higher).
+- **Access:** User has _Can Reject_ access right.
 
 ## Flow
 

--- a/ssi_school_incident/docs/school_incident/09-finish.md
+++ b/ssi_school_incident/docs/school_incident/09-finish.md
@@ -1,10 +1,17 @@
 # Finish School Incident
 
+> **Module:** ssi*school_incident\
+> **Model:** `school_incident`\
+> **Menu:** School > Incident > Incidents\
+> **Actor:** user in group \_User (Homeroom Teacher)* or higher\
+> **State:** `open` → `done`\
+> **Requires:** `05-approve`
+
 ## Pre-Condition
 
-- Record is in **Open** status.
-- User has _Can Finish_ access right (belongs to the User (Homeroom Teacher) group or
-  higher).
+- **Record:** Status is **Open**.
+- **Access:** User has _Can Finish_ access right (belongs to the User (Homeroom Teacher)
+  group or higher).
 
 ## Flow
 

--- a/ssi_school_incident/docs/school_incident/10-cancel.md
+++ b/ssi_school_incident/docs/school_incident/10-cancel.md
@@ -1,10 +1,17 @@
 # Cancel School Incident
 
+> **Module:** ssi*school_incident\
+> **Model:** `school_incident`\
+> **Menu:** School > Incident > Incidents\
+> **Actor:** user in group \_Officer (Counselor/Vice Principal)* or higher\
+> **State:** `draft` | `confirm` | `open` → `cancel`\
+> **Requires:** `01-create`
+
 ## Pre-Condition
 
-- Record is in **Draft**, **Waiting for Approval**, or **Open** status.
-- User has _Can Cancel_ access right (belongs to the Officer (Counselor/Vice Principal)
-  group or higher).
+- **Record:** Status is **Draft**, **Waiting for Approval**, or **Open**.
+- **Access:** User has _Can Cancel_ access right (belongs to the Officer (Counselor/Vice
+  Principal) group or higher).
 
 ## Flow
 

--- a/ssi_school_incident/docs/school_incident/12-restart.md
+++ b/ssi_school_incident/docs/school_incident/12-restart.md
@@ -1,10 +1,17 @@
 # Restart School Incident
 
+> **Module:** ssi*school_incident\
+> **Model:** `school_incident`\
+> **Menu:** School > Incident > Incidents\
+> **Actor:** user in group \_Officer (Counselor/Vice Principal)* or higher\
+> **State:** `cancel` | `reject` → `draft`\
+> **Requires:** `10-cancel`
+
 ## Pre-Condition
 
-- Record is in **Cancelled** or **Rejected** status.
-- User has _Can Restart_ access right (belongs to the Officer (Counselor/Vice Principal)
-  group or higher).
+- **Record:** Status is **Cancelled** or **Rejected**.
+- **Access:** User has _Can Restart_ access right (belongs to the Officer
+  (Counselor/Vice Principal) group or higher).
 
 ## Flow
 

--- a/ssi_school_incident/docs/school_incident/13-reset-document-number.md
+++ b/ssi_school_incident/docs/school_incident/13-reset-document-number.md
@@ -1,10 +1,16 @@
 # Reset Document Number — School Incident
 
+> **Module:** ssi*school_incident\
+> **Model:** `school_incident`\
+> **Menu:** School > Incident > Incidents\
+> **Actor:** user in group \_Officer (Counselor/Vice Principal)* or higher\
+> **Requires:** `01-create`
+
 ## Pre-Condition
 
-- Record is in **Draft** status.
-- User has _Can Input Manual Document Number_ access right (belongs to the Officer
-  (Counselor/Vice Principal) group or higher).
+- **Record:** Status is **Draft**.
+- **Access:** User has _Can Input Manual Document Number_ access right (belongs to the
+  Officer (Counselor/Vice Principal) group or higher).
 
 ## Flow
 

--- a/ssi_school_incident/docs/school_incident/14-escalate.md
+++ b/ssi_school_incident/docs/school_incident/14-escalate.md
@@ -1,12 +1,18 @@
 # Escalate School Incident
 
+> **Module:** ssi*school_incident\
+> **Model:** `school_incident`\
+> **Menu:** School > Incident > Incidents\
+> **Actor:** user in group \_Officer (Counselor/Vice Principal)* or higher\
+> **Requires:** `05-approve`
+
 ## Pre-Condition
 
-- Record is in **Open** status.
-- At least one active **Incident Escalation Criteria** record exists whose Target Level
-  matches the handling tier being escalated to.
-- User has _Can Escalate_ access right (belongs to the Officer (Counselor/Vice
-  Principal) group or higher).
+- **Record:** Status is **Open**.
+- **Data:** At least one active **Incident Escalation Criteria** record exists whose
+  Target Level matches the handling tier being escalated to.
+- **Access:** User has _Can Escalate_ access right (belongs to the Officer
+  (Counselor/Vice Principal) group or higher).
 
 ## Flow
 
@@ -20,7 +26,7 @@
      matches the selected Target Level above, justifying this escalation.
    - **Escalation Reason**: Enter the narrative/chronology explaining why this case is
      being escalated.
-5. Click **Escalate** in the wizard footer.
+5. Click **Escalate** in the wizard footer (`action_escalate_wizard`).
 
 ## Post-Condition
 

--- a/ssi_school_incident/docs/school_incident/15-restart-approval.md
+++ b/ssi_school_incident/docs/school_incident/15-restart-approval.md
@@ -1,0 +1,32 @@
+# Restart Approval Process — School Incident
+
+> **Module:** ssi*school_incident\
+> **Model:** `school_incident`\
+> **Menu:** School > Incident > Incidents\
+> **Actor:** user in group \_User (Homeroom Teacher)* or higher\
+> **Requires:** `04-confirm`
+
+## Pre-Condition
+
+- **Record:** Status is **Waiting for Approval**, and the approval process is stalled
+  (for example, the record currently has no approval template assigned, or the assigned
+  template no longer matches).
+- **Config:** An active `policy.template` for this model grants `restart_approval_ok`
+  for state `confirm` to the actor's group.
+- **Config:** An active `approval.template` for this model matches this record, with an
+  approver group configured for its approval level, so the process can be rebuilt once
+  restarted.
+- **Access:** User is in group _User (Homeroom Teacher)_ or higher.
+
+## Flow
+
+1. Open the **School > Incident > Incidents** menu.
+2. Open the record whose approval process is stalled.
+3. Click the **Restart Approval Process** button.
+4. Click **OK** on the confirmation dialog.
+
+## Post-Condition
+
+- Status remains **Waiting for Approval**.
+- The existing approval records are discarded and a new approval process is created from
+  the approval template that now matches the record.

--- a/ssi_school_incident/docs/school_incident/16-print.md
+++ b/ssi_school_incident/docs/school_incident/16-print.md
@@ -1,0 +1,27 @@
+# Print School Incident
+
+> **Module:** ssi_school_incident\
+> **Model:** `school_incident`\
+> **Menu:** School > Incident > Incidents\
+> **Actor:** any authenticated user\
+> **Requires:** `01-create`
+
+## Pre-Condition
+
+- **Config:** At least one `print_document_type` (with a linked report for
+  `school_incident`) is configured, so a report is available to select in step 4.
+- **Access:** User has read access to School Incident (granted to every authenticated
+  user by the model's global access rule).
+
+## Flow
+
+1. Open the **School > Incident > Incidents** menu.
+2. Open the record to print.
+3. Click **Print** in the header.
+4. In the **Select Report To Print** wizard, select a **Type** (optional filter) and the
+   **Report Template** to generate.
+5. Click **Print**.
+
+## Post-Condition
+
+- The selected report is generated and opened/downloaded.

--- a/ssi_school_incident/docs/school_incident/17-reload-template-policy.md
+++ b/ssi_school_incident/docs/school_incident/17-reload-template-policy.md
@@ -1,0 +1,29 @@
+# Reload Template Policy — School Incident
+
+> **Module:** ssi*school_incident\
+> **Model:** `school_incident`\
+> **Menu:** School > Incident > Incidents\
+> **Actor:** administrator in group \_Settings / Technical Settings*\
+> **Requires:** `01-create`
+
+## Pre-Condition
+
+- **Record:** None — usable regardless of status.
+- **Config:** At least one active `policy.template` exists for this model, so a matching
+  template can be found.
+- **Access:** User is in group _Settings / Technical Settings_ (`base.group_system`).
+  The **Policies** tab that contains this button is only visible to this group.
+
+## Flow
+
+1. Open the **School > Incident > Incidents** menu.
+2. Open the record whose assigned policy template should be re-evaluated.
+3. On the **Policies** tab, click **Reload Template Policy**.
+
+## Post-Condition
+
+- **Policy Template** is recomputed and re-assigned to the highest-sequence
+  `policy.template` for this model whose condition currently matches the record. This
+  may change which action buttons and policy fields (`confirm_ok`,
+  `restart_approval_ok`, `escalate_ok`, etc.) are granted, without changing the record's
+  status.

--- a/ssi_school_incident/docs/school_incident_escalation_criteria/01-create.md
+++ b/ssi_school_incident/docs/school_incident_escalation_criteria/01-create.md
@@ -1,5 +1,10 @@
 # Create Incident Escalation Criteria
 
+> **Module:** ssi*school_incident\
+> **Model:** `school_incident_escalation_criteria`\
+> **Menu:** School > Configuration > Configuration > Escalation Criteria\
+> **Actor:** user in group \_Manager (Principal)*
+
 ## Pre-Condition
 
 - None.

--- a/ssi_school_incident/docs/school_incident_escalation_criteria/02-edit.md
+++ b/ssi_school_incident/docs/school_incident_escalation_criteria/02-edit.md
@@ -1,5 +1,11 @@
 # Edit Incident Escalation Criteria
 
+> **Module:** ssi*school_incident\
+> **Model:** `school_incident_escalation_criteria`\
+> **Menu:** School > Configuration > Configuration > Escalation Criteria\
+> **Actor:** user in group \_Manager (Principal)*\
+> **Requires:** `01-create`
+
 ## Pre-Condition
 
 - None.

--- a/ssi_school_incident/docs/school_incident_escalation_criteria/03-delete.md
+++ b/ssi_school_incident/docs/school_incident_escalation_criteria/03-delete.md
@@ -1,9 +1,15 @@
 # Delete Incident Escalation Criteria
 
+> **Module:** ssi*school_incident\
+> **Model:** `school_incident_escalation_criteria`\
+> **Menu:** School > Configuration > Configuration > Escalation Criteria\
+> **Actor:** user in group \_Manager (Principal)*\
+> **Requires:** `01-create`
+
 ## Pre-Condition
 
-- The Escalation Criteria record is not referenced by any School Incident escalation
-  history.
+- **Data:** The Escalation Criteria record is not referenced by any School Incident
+  escalation history.
 
 ## Flow
 

--- a/ssi_school_incident/docs/school_incident_escalation_criteria/04-deactivate.md
+++ b/ssi_school_incident/docs/school_incident_escalation_criteria/04-deactivate.md
@@ -1,5 +1,12 @@
 # Deactivate Incident Escalation Criteria
 
+> **Module:** ssi*school_incident\
+> **Model:** `school_incident_escalation_criteria`\
+> **Menu:** School > Configuration > Configuration > Escalation Criteria\
+> **Actor:** user in group \_Manager (Principal)*\
+> **Active:** `true` → `false`\
+> **Requires:** `01-create`
+
 ## Pre-Condition
 
 - None.

--- a/ssi_school_incident/docs/school_incident_escalation_criteria/05-activate.md
+++ b/ssi_school_incident/docs/school_incident_escalation_criteria/05-activate.md
@@ -1,5 +1,12 @@
 # Activate Incident Escalation Criteria
 
+> **Module:** ssi*school_incident\
+> **Model:** `school_incident_escalation_criteria`\
+> **Menu:** School > Configuration > Configuration > Escalation Criteria\
+> **Actor:** user in group \_Manager (Principal)*\
+> **Active:** `false` → `true`\
+> **Requires:** `01-create`
+
 ## Pre-Condition
 
 - None.

--- a/ssi_school_incident/docs/school_incident_escalation_criteria/06-print.md
+++ b/ssi_school_incident/docs/school_incident_escalation_criteria/06-print.md
@@ -1,0 +1,28 @@
+# Print Incident Escalation Criteria
+
+> **Module:** ssi_school_incident\
+> **Model:** `school_incident_escalation_criteria`\
+> **Menu:** School > Configuration > Configuration > Escalation Criteria\
+> **Actor:** any authenticated user\
+> **Requires:** `01-create`
+
+## Pre-Condition
+
+- **Config:** At least one `print_document_type` (with a linked report for
+  `school_incident_escalation_criteria`) is configured, so a report is available to
+  select in step 4.
+- **Access:** User has read access to Incident Escalation Criteria (granted to every
+  authenticated user by the model's global access rule).
+
+## Flow
+
+1. Open the **School > Configuration > Configuration > Escalation Criteria** menu.
+2. Open the record to print.
+3. Click **Print** in the header.
+4. In the **Select Report To Print** wizard, select a **Type** (optional filter) and the
+   **Report Template** to generate.
+5. Click **Print**.
+
+## Post-Condition
+
+- The selected report is generated and opened/downloaded.

--- a/ssi_school_incident/docs/school_incident_type/01-create.md
+++ b/ssi_school_incident/docs/school_incident_type/01-create.md
@@ -1,5 +1,10 @@
 # Create Incident Type
 
+> **Module:** ssi*school_incident\
+> **Model:** `school_incident_type`\
+> **Menu:** School > Configuration > Configuration > Incident Types\
+> **Actor:** user in group \_Manager (Principal)*
+
 ## Pre-Condition
 
 - None.

--- a/ssi_school_incident/docs/school_incident_type/02-edit.md
+++ b/ssi_school_incident/docs/school_incident_type/02-edit.md
@@ -1,5 +1,11 @@
 # Edit Incident Type
 
+> **Module:** ssi*school_incident\
+> **Model:** `school_incident_type`\
+> **Menu:** School > Configuration > Configuration > Incident Types\
+> **Actor:** user in group \_Manager (Principal)*\
+> **Requires:** `01-create`
+
 ## Pre-Condition
 
 - None.

--- a/ssi_school_incident/docs/school_incident_type/03-delete.md
+++ b/ssi_school_incident/docs/school_incident_type/03-delete.md
@@ -1,8 +1,14 @@
 # Delete Incident Type
 
+> **Module:** ssi*school_incident\
+> **Model:** `school_incident_type`\
+> **Menu:** School > Configuration > Configuration > Incident Types\
+> **Actor:** user in group \_Manager (Principal)*\
+> **Requires:** `01-create`
+
 ## Pre-Condition
 
-- The Incident Type is not referenced by any School Incident record.
+- **Data:** The Incident Type is not referenced by any School Incident record.
 
 ## Flow
 

--- a/ssi_school_incident/docs/school_incident_type/04-deactivate.md
+++ b/ssi_school_incident/docs/school_incident_type/04-deactivate.md
@@ -1,5 +1,12 @@
 # Deactivate Incident Type
 
+> **Module:** ssi*school_incident\
+> **Model:** `school_incident_type`\
+> **Menu:** School > Configuration > Configuration > Incident Types\
+> **Actor:** user in group \_Manager (Principal)*\
+> **Active:** `true` → `false`\
+> **Requires:** `01-create`
+
 ## Pre-Condition
 
 - None.

--- a/ssi_school_incident/docs/school_incident_type/05-activate.md
+++ b/ssi_school_incident/docs/school_incident_type/05-activate.md
@@ -1,5 +1,12 @@
 # Activate Incident Type
 
+> **Module:** ssi*school_incident\
+> **Model:** `school_incident_type`\
+> **Menu:** School > Configuration > Configuration > Incident Types\
+> **Actor:** user in group \_Manager (Principal)*\
+> **Active:** `false` → `true`\
+> **Requires:** `01-create`
+
 ## Pre-Condition
 
 - None.

--- a/ssi_school_incident/docs/school_incident_type/06-print.md
+++ b/ssi_school_incident/docs/school_incident_type/06-print.md
@@ -1,0 +1,27 @@
+# Print Incident Type
+
+> **Module:** ssi_school_incident\
+> **Model:** `school_incident_type`\
+> **Menu:** School > Configuration > Configuration > Incident Types\
+> **Actor:** any authenticated user\
+> **Requires:** `01-create`
+
+## Pre-Condition
+
+- **Config:** At least one `print_document_type` (with a linked report for
+  `school_incident_type`) is configured, so a report is available to select in step 4.
+- **Access:** User has read access to Incident Type (granted to every authenticated user
+  by the model's global access rule).
+
+## Flow
+
+1. Open the **School > Configuration > Configuration > Incident Types** menu.
+2. Open the record to print.
+3. Click **Print** in the header.
+4. In the **Select Report To Print** wizard, select a **Type** (optional filter) and the
+   **Report Template** to generate.
+5. Click **Print**.
+
+## Post-Condition
+
+- The selected report is generated and opened/downloaded.

--- a/ssi_school_incident/docs/school_incident_weekly_review/01-create.md
+++ b/ssi_school_incident/docs/school_incident_weekly_review/01-create.md
@@ -1,5 +1,11 @@
 # Create School Incident Weekly Review
 
+> **Module:** ssi*school_incident\
+> **Model:** `school_incident_weekly_review`\
+> **Menu:** School > Incident > Weekly Case Reviews\
+> **Actor:** user in group \_Officer (Counselor/Vice Principal)* or higher\
+> **State:** `—` → `draft`
+
 ## Pre-Condition
 
 - None.
@@ -23,3 +29,13 @@
 - A new Weekly Case Review record is created in **Draft** status.
 - The Incidents list is still empty; use the **Collect Incidents** button to pull in
   eligible School Incident cases.
+
+## Related Views
+
+- The **Total**, **Overdue**, **Not Resolved > 7d**, and **Escalated** stat buttons in
+  the form's button box (`action_view_total_incidents`, `action_view_overdue_incidents`,
+  `action_view_unresolved_over_7d_incidents`, `action_view_escalated_incidents`) open
+  the School Incident list, pre-filtered to the corresponding subset of the incidents
+  collected into this review. Each one only returns an `act_window` and writes no field,
+  so they are pure navigation: informational only, not documented as IK steps or tours
+  of their own.

--- a/ssi_school_incident/docs/school_incident_weekly_review/02-edit.md
+++ b/ssi_school_incident/docs/school_incident_weekly_review/02-edit.md
@@ -1,8 +1,14 @@
 # Edit School Incident Weekly Review
 
+> **Module:** ssi*school_incident\
+> **Model:** `school_incident_weekly_review`\
+> **Menu:** School > Incident > Weekly Case Reviews\
+> **Actor:** user in group \_Officer (Counselor/Vice Principal)* or higher\
+> **Requires:** `01-create`
+
 ## Pre-Condition
 
-- Record is in **Draft** status.
+- **Record:** Status is **Draft**.
 
 ## Flow
 

--- a/ssi_school_incident/docs/school_incident_weekly_review/03-delete.md
+++ b/ssi_school_incident/docs/school_incident_weekly_review/03-delete.md
@@ -1,9 +1,15 @@
 # Delete School Incident Weekly Review
 
+> **Module:** ssi*school_incident\
+> **Model:** `school_incident_weekly_review`\
+> **Menu:** School > Incident > Weekly Case Reviews\
+> **Actor:** user in group \_Officer (Counselor/Vice Principal)* or higher\
+> **Requires:** `01-create`
+
 ## Pre-Condition
 
-- Record is in **Draft** status.
-- Document number is still **/** (not yet generated).
+- **Record:** Status is **Draft**.
+- **Record:** Document number is still **/** (not yet generated).
 
 ## Flow
 

--- a/ssi_school_incident/docs/school_incident_weekly_review/04-confirm.md
+++ b/ssi_school_incident/docs/school_incident_weekly_review/04-confirm.md
@@ -1,10 +1,17 @@
 # Confirm School Incident Weekly Review
 
+> **Module:** ssi*school_incident\
+> **Model:** `school_incident_weekly_review`\
+> **Menu:** School > Incident > Weekly Case Reviews\
+> **Actor:** user in group \_Officer (Counselor/Vice Principal)* or higher\
+> **State:** `draft` → `confirm`\
+> **Requires:** `01-create`
+
 ## Pre-Condition
 
-- Record is in **Draft** status.
-- User has _Can Confirm_ access right (belongs to the Officer (Counselor/Vice Principal)
-  group or higher).
+- **Record:** Status is **Draft**.
+- **Access:** User has _Can Confirm_ access right (belongs to the Officer
+  (Counselor/Vice Principal) group or higher).
 
 ## Flow
 

--- a/ssi_school_incident/docs/school_incident_weekly_review/05-approve.md
+++ b/ssi_school_incident/docs/school_incident_weekly_review/05-approve.md
@@ -1,11 +1,18 @@
 # Approve School Incident Weekly Review
 
+> **Module:** ssi*school_incident\
+> **Model:** `school_incident_weekly_review`\
+> **Menu:** School > Incident > Weekly Case Reviews\
+> **Actor:** approver in group \_Manager (Principal)*\
+> **State:** `confirm` → `done`\
+> **Requires:** `04-confirm`
+
 ## Pre-Condition
 
-- Record is in **Waiting for Approval** status.
-- User is registered as an approver on the active approval template (belongs to the
-  Manager (Principal) group).
-- User has _Can Approve_ access right.
+- **Record:** Status is **Waiting for Approval**.
+- **Access:** User is registered as an approver on the active approval template (belongs
+  to the Manager (Principal) group).
+- **Access:** User has _Can Approve_ access right.
 
 ## Flow
 

--- a/ssi_school_incident/docs/school_incident_weekly_review/06-reject.md
+++ b/ssi_school_incident/docs/school_incident_weekly_review/06-reject.md
@@ -1,11 +1,18 @@
 # Reject School Incident Weekly Review
 
+> **Module:** ssi*school_incident\
+> **Model:** `school_incident_weekly_review`\
+> **Menu:** School > Incident > Weekly Case Reviews\
+> **Actor:** approver in group \_Manager (Principal)*\
+> **State:** `confirm` → `reject`\
+> **Requires:** `04-confirm`
+
 ## Pre-Condition
 
-- Record is in **Waiting for Approval** status.
-- User is registered as an approver on the active approval template (belongs to the
-  Manager (Principal) group).
-- User has _Can Reject_ access right.
+- **Record:** Status is **Waiting for Approval**.
+- **Access:** User is registered as an approver on the active approval template (belongs
+  to the Manager (Principal) group).
+- **Access:** User has _Can Reject_ access right.
 
 ## Flow
 

--- a/ssi_school_incident/docs/school_incident_weekly_review/10-cancel.md
+++ b/ssi_school_incident/docs/school_incident_weekly_review/10-cancel.md
@@ -1,9 +1,17 @@
 # Cancel School Incident Weekly Review
 
+> **Module:** ssi*school_incident\
+> **Model:** `school_incident_weekly_review`\
+> **Menu:** School > Incident > Weekly Case Reviews\
+> **Actor:** user in group \_Manager (Principal)*\
+> **State:** `draft` | `confirm` | `reject` → `cancel`\
+> **Requires:** `01-create`
+
 ## Pre-Condition
 
-- Record is in **Draft**, **Waiting for Approval**, or **Rejected** status.
-- User has _Can Cancel_ access right (belongs to the Manager (Principal) group).
+- **Record:** Status is **Draft**, **Waiting for Approval**, or **Rejected**.
+- **Access:** User has _Can Cancel_ access right (belongs to the Manager (Principal)
+  group).
 
 ## Flow
 

--- a/ssi_school_incident/docs/school_incident_weekly_review/12-restart.md
+++ b/ssi_school_incident/docs/school_incident_weekly_review/12-restart.md
@@ -1,10 +1,17 @@
 # Restart School Incident Weekly Review
 
+> **Module:** ssi*school_incident\
+> **Model:** `school_incident_weekly_review`\
+> **Menu:** School > Incident > Weekly Case Reviews\
+> **Actor:** user in group \_Officer (Counselor/Vice Principal)* or higher\
+> **State:** `cancel` | `reject` → `draft`\
+> **Requires:** `10-cancel`
+
 ## Pre-Condition
 
-- Record is in **Cancelled** or **Rejected** status.
-- User has _Can Restart_ access right (belongs to the Officer (Counselor/Vice Principal)
-  group or higher).
+- **Record:** Status is **Cancelled** or **Rejected**.
+- **Access:** User has _Can Restart_ access right (belongs to the Officer
+  (Counselor/Vice Principal) group or higher).
 
 ## Flow
 

--- a/ssi_school_incident/docs/school_incident_weekly_review/13-reset-document-number.md
+++ b/ssi_school_incident/docs/school_incident_weekly_review/13-reset-document-number.md
@@ -1,10 +1,16 @@
 # Reset Document Number — School Incident Weekly Review
 
+> **Module:** ssi*school_incident\
+> **Model:** `school_incident_weekly_review`\
+> **Menu:** School > Incident > Weekly Case Reviews\
+> **Actor:** user in group \_Officer (Counselor/Vice Principal)* or higher\
+> **Requires:** `01-create`
+
 ## Pre-Condition
 
-- Record is in **Draft** status.
-- User has _Can Input Manual Document Number_ access right (belongs to the Officer
-  (Counselor/Vice Principal) group or higher).
+- **Record:** Status is **Draft**.
+- **Access:** User has _Can Input Manual Document Number_ access right (belongs to the
+  Officer (Counselor/Vice Principal) group or higher).
 
 ## Flow
 

--- a/ssi_school_incident/docs/school_incident_weekly_review/14-collect-incidents.md
+++ b/ssi_school_incident/docs/school_incident_weekly_review/14-collect-incidents.md
@@ -1,18 +1,24 @@
 # Collect Incidents into School Incident Weekly Review
 
+> **Module:** ssi*school_incident\
+> **Model:** `school_incident_weekly_review`\
+> **Menu:** School > Incident > Weekly Case Reviews\
+> **Actor:** user in group \_Officer (Counselor/Vice Principal)* or higher\
+> **Requires:** `01-create`
+
 ## Pre-Condition
 
-- Record is in **Draft** status.
-- **Date Start** and **Date End** are filled in.
-- User has _Can Collect_ access right (belongs to the Officer (Counselor/Vice Principal)
-  group or higher).
+- **Record:** Status is **Draft**.
+- **Record:** **Date Start** and **Date End** are filled in.
+- **Access:** User has _Can Collect_ access right (belongs to the Officer
+  (Counselor/Vice Principal) group or higher).
 
 ## Flow
 
 1. Open the **School > Incident > Weekly Case Reviews** menu.
 2. Open the Weekly Case Review record.
 3. Fill in (or confirm) **Date Start**, **Date End**, and optionally **School**.
-4. Click the **Collect Incidents** button.
+4. Click the **Collect Incidents** button (`action_collect_incidents`).
 
 ## Post-Condition
 

--- a/ssi_school_incident/docs/school_incident_weekly_review/15-checklist.md
+++ b/ssi_school_incident/docs/school_incident_weekly_review/15-checklist.md
@@ -1,9 +1,15 @@
 # Fill in the Weekly Case Review Checklist
 
+> **Module:** ssi*school_incident\
+> **Model:** `school_incident_weekly_review`\
+> **Menu:** School > Incident > Weekly Case Reviews\
+> **Actor:** user in group \_Officer (Counselor/Vice Principal)* or higher\
+> **Requires:** `01-create`
+
 ## Pre-Condition
 
-- Record is accessible in an editable state (**Draft**, or **Waiting for
-  Approval**/**Rejected** if the checklist still needs correction before re-confirming).
+- **Record:** Status is **Draft**, or **Waiting for Approval**/**Rejected** if the
+  checklist still needs correction before re-confirming.
 
 ## Flow
 

--- a/ssi_school_incident/docs/school_incident_weekly_review/16-restart-approval.md
+++ b/ssi_school_incident/docs/school_incident_weekly_review/16-restart-approval.md
@@ -1,0 +1,32 @@
+# Restart Approval Process — School Incident Weekly Review
+
+> **Module:** ssi*school_incident\
+> **Model:** `school_incident_weekly_review`\
+> **Menu:** School > Incident > Weekly Case Reviews\
+> **Actor:** user in group \_Officer (Counselor/Vice Principal)* or higher\
+> **Requires:** `04-confirm`
+
+## Pre-Condition
+
+- **Record:** Status is **Waiting for Approval**, and the approval process is stalled
+  (for example, the record currently has no approval template assigned, or the assigned
+  template no longer matches).
+- **Config:** An active `policy.template` for this model grants `restart_approval_ok`
+  for state `confirm` to the actor's group.
+- **Config:** An active `approval.template` for this model matches this record, with an
+  approver group configured for its approval level, so the process can be rebuilt once
+  restarted.
+- **Access:** User is in group _Officer (Counselor/Vice Principal)_ or higher.
+
+## Flow
+
+1. Open the **School > Incident > Weekly Case Reviews** menu.
+2. Open the record whose approval process is stalled.
+3. Click the **Restart Approval Process** button.
+4. Click **OK** on the confirmation dialog.
+
+## Post-Condition
+
+- Status remains **Waiting for Approval**.
+- The existing approval records are discarded and a new approval process is created from
+  the approval template that now matches the record.

--- a/ssi_school_incident/docs/school_incident_weekly_review/17-print.md
+++ b/ssi_school_incident/docs/school_incident_weekly_review/17-print.md
@@ -1,0 +1,28 @@
+# Print School Incident Weekly Review
+
+> **Module:** ssi_school_incident\
+> **Model:** `school_incident_weekly_review`\
+> **Menu:** School > Incident > Weekly Case Reviews\
+> **Actor:** any authenticated user\
+> **Requires:** `01-create`
+
+## Pre-Condition
+
+- **Config:** At least one `print_document_type` (with a linked report for
+  `school_incident_weekly_review`) is configured, so a report is available to select in
+  step 4.
+- **Access:** User has read access to School Incident Weekly Review (granted to every
+  authenticated user by the model's global access rule).
+
+## Flow
+
+1. Open the **School > Incident > Weekly Case Reviews** menu.
+2. Open the record to print.
+3. Click **Print** in the header.
+4. In the **Select Report To Print** wizard, select a **Type** (optional filter) and the
+   **Report Template** to generate.
+5. Click **Print**.
+
+## Post-Condition
+
+- The selected report is generated and opened/downloaded.

--- a/ssi_school_incident/docs/school_incident_weekly_review/18-reload-template-policy.md
+++ b/ssi_school_incident/docs/school_incident_weekly_review/18-reload-template-policy.md
@@ -1,0 +1,29 @@
+# Reload Template Policy — School Incident Weekly Review
+
+> **Module:** ssi*school_incident\
+> **Model:** `school_incident_weekly_review`\
+> **Menu:** School > Incident > Weekly Case Reviews\
+> **Actor:** administrator in group \_Settings / Technical Settings*\
+> **Requires:** `01-create`
+
+## Pre-Condition
+
+- **Record:** None — usable regardless of status.
+- **Config:** At least one active `policy.template` exists for this model, so a matching
+  template can be found.
+- **Access:** User is in group _Settings / Technical Settings_ (`base.group_system`).
+  The **Policies** tab that contains this button is only visible to this group.
+
+## Flow
+
+1. Open the **School > Incident > Weekly Case Reviews** menu.
+2. Open the record whose assigned policy template should be re-evaluated.
+3. On the **Policies** tab, click **Reload Template Policy**.
+
+## Post-Condition
+
+- **Policy Template** is recomputed and re-assigned to the highest-sequence
+  `policy.template` for this model whose condition currently matches the record. This
+  may change which action buttons and policy fields (`confirm_ok`,
+  `restart_approval_ok`, `collect_ok`, etc.) are granted, without changing the record's
+  status.


### PR DESCRIPTION
## Ringkasan

Retrofit 49 berkas Instruksi Kerja (IK) lama `ssi_school_incident` ke format terbaru skill `odoo-development-instruksi-kerja`, plus 12 berkas IK baru:

- Blok metadata (Module/Model/Menu/Actor/State/Active/Requires) ditambahkan ke seluruh 49 berkas IK lama.
- Label tipe (Record/Data/Config/Access) ditambahkan ke setiap butir Pre-Condition.
- Delapan aksi bertombol yang sebelumnya tanpa rumah kini punya rumah:
  - `action_view_total_incidents`, `action_view_overdue_incidents`, `action_view_unresolved_over_7d_incidents`, `action_view_escalated_incidents` — divonis **N** (nol IK), dicatat sebagai `## Related Views` informational di `school_incident_weekly_review/01-create.md`.
  - `action_collect_incidents`, `action_create_incident`, `action_escalate_wizard`, `action_evaluate` — dilengkapi ke berkas IK yang sudah ada (bukan berkas baru).
- Berkas IK baru **Restart Approval Process** (`action_reload_approval_template`) untuk `school_incident` (15), `school_academic_alert` (16), `school_incident_weekly_review` (16) — nomor melanjutkan tertinggi karena slot kanonik `14` sudah dipakai file lama di ketiga model.
- Berkas IK baru **Print** dan **Reload Template Policy** pada model yang benar-benar memiliki tombolnya (diverifikasi ke `_automatically_insert_print_button`/`_automatically_insert_restart_approval_button` di kode & mixin) — tiga model transaksional plus Print pada tiga model master data (`mixin.master_data` juga mengaktifkan Print secara default).
- `README.rst` diperbarui dengan entri `Work Instruction` untuk seluruh berkas baru.

Item `type:docs` — tidak ada perubahan kode. Verifikasi lewat `assets/validate-ik.sh ssi_school_incident --strict` (0 ERROR, 61/61 berkas punya blok metadata) dan pre-commit.

Pasangan tour (UI test) dicatat terpisah di #233, dikerjakan setelah item ini closed.

Closes #218