### PR TITLE
[UPD] ssi_school_health - IK delta school_student (health)

### DIFF
--- a/ssi_school_health/README.rst
+++ b/ssi_school_health/README.rst
@@ -17,6 +17,15 @@ without leaving the student form. No health data is duplicated: every field is
 related to the student's contact, which remains the single source of truth.
 
 
+Work Instruction
+=================
+
+Student
+-------
+
+* `Create Student <docs/school_student/01-create.html>`_
+* `Edit Student <docs/school_student/02-edit.html>`_
+
 Installation
 ============
 

--- a/ssi_school_health/docs/school_student/01-create.md
+++ b/ssi_school_health/docs/school_student/01-create.md
@@ -1,0 +1,36 @@
+# Create Student
+
+> **Module:** ssi_school_health\
+> **Extends:** ssi_school — model `school_student`, aksi `01-create`
+
+## Additional Fields
+
+When this module is installed, the create form gains a **Health** tab:
+
+- **Heights**: Record the student's height history. Repeat as many times as needed:
+  - Click **Add a line**.
+  - Fill in **Date** and **Value** (cm).
+- **Weights**: Record the student's weight history. Repeat as many times as needed:
+  - Click **Add a line**.
+  - Fill in **Date** and **Value** (kg).
+- **Head Circumferences**: Record the student's head circumference history. Repeat as
+  many times as needed:
+  - Click **Add a line**.
+  - Fill in **Date** and **Value** (cm).
+- **Allergies**: Record the student's allergies. Repeat as many times as needed:
+  - Click **Add a line**.
+  - Fill in **Allergen**, **Severity**, and **Note**.
+- **Disease History**: Record the student's disease history. Repeat as many times as
+  needed:
+  - Click **Add a line**.
+  - Fill in **Disease**, **Date Diagnosed**, **Date Recovered**, and **Note**.
+
+All five histories are related to the student's linked Contact and are shared with any
+other student record pointing to the same Contact; every line added here is written back
+to the Contact, which remains the single source of truth.
+
+## Additional Post-Condition
+
+- **Height (cm)**, **Weight (kg)**, and **Head Circumference (cm)** on the Health tab
+  show the latest recorded value from the histories above. Read-only, computed — not
+  editable directly.

--- a/ssi_school_health/docs/school_student/02-edit.md
+++ b/ssi_school_health/docs/school_student/02-edit.md
@@ -1,0 +1,18 @@
+# Edit Student
+
+> **Module:** ssi_school_health\
+> **Extends:** ssi_school — model `school_student`, aksi `02-edit`
+
+## Additional Fields
+
+The **Health** tab described in `01-create` remains available for editing:
+
+- **Heights**, **Weights**, **Head Circumferences**: Add, edit, or remove history lines
+  as needed.
+- **Allergies**: Add, edit, or remove lines as needed.
+- **Disease History**: Add, edit, or remove lines as needed.
+
+## Additional Post-Condition
+
+- **Height (cm)**, **Weight (kg)**, and **Head Circumference (cm)** are recomputed from
+  the latest history line whenever a line is added, edited, or removed.


### PR DESCRIPTION
## Ringkasan

Menambahkan Instruksi Kerja (IK) delta `school_student` di `ssi_school_health` untuk field kesehatan (Heights, Weights, Head Circumferences, Allergies, Disease History) yang benar-benar diisi pengguna pada aksi Create dan Edit. Field ringkasan computed (Height, Weight, Head Circumference) tidak didaftar sebagai field E1, hanya disebut sebagai `## Additional Post-Condition`.

`ssi_school_qr_code` divonis **nol IK** — halaman QR Code yang disisipkan `mixin.qr_code` hanya berisi field `qr_image` yang murni computed/read-only tanpa input pengguna. Alasan lengkap sudah dicatat di komentar issue.

## Perubahan

- `ssi_school_health/docs/school_student/01-create.md` (baru)
- `ssi_school_health/docs/school_student/02-edit.md` (baru)
- `ssi_school_health/README.rst` — entri `Work Instruction`

Closes #222