### PR TITLE
[UPD] ssi_school_operating_unit - IK delta operating unit

### DIFF
--- a/ssi_school_operating_unit/README.rst
+++ b/ssi_school_operating_unit/README.rst
@@ -11,3 +11,61 @@ Adds operating unit access control for transactional (school_enrollment, school_
 and master data models (school, grade types, grades, classes, academic periods, students, teachers).
 The operating unit selected on a Homeroom batch is automatically propagated to every
 enrollment generated from it.
+
+Work Instruction
+=================
+
+School
+------
+
+* `Create School <docs/school/01-create.html>`_
+
+Student
+-------
+
+* `Create Student <docs/school_student/01-create.html>`_
+
+Teacher
+-------
+
+* `Create Teacher <docs/school_teacher/01-create.html>`_
+
+Grade
+-----
+
+* `Create Grade <docs/school_grade/01-create.html>`_
+
+Grade Type
+----------
+
+* `Create Grade Type <docs/school_grade_type/01-create.html>`_
+
+Grade Class
+-----------
+
+* `Create Grade Class <docs/school_grade_class/01-create.html>`_
+
+Academic Year
+-------------
+
+* `Create Academic Year <docs/school_academic_year/01-create.html>`_
+
+School Academic Term
+--------------------
+
+* `Create School Academic Term <docs/school_academic_term/01-create.html>`_
+
+Homeroom
+--------
+
+* `Create Homeroom <docs/school_homeroom/01-create.html>`_
+
+Student Class Mutation
+-----------------------
+
+* `Create Student Class Mutation <docs/school_student_mutation/01-create.html>`_
+
+Enrollment
+----------
+
+* `Create Enrollment <docs/school_enrollment/01-create.html>`_

--- a/ssi_school_operating_unit/docs/school/01-create.md
+++ b/ssi_school_operating_unit/docs/school/01-create.md
@@ -1,0 +1,19 @@
+# Create School
+
+> **Module:** ssi_school_operating_unit\
+> **Extends:** ssi_school — model `school`, action `01-create`
+
+## Additional Fields
+
+When this module is installed, the create form gains one optional field:
+
+- **Operating Unit**: Select the operating unit(s) this School belongs to. Leave empty
+  to make the record visible to every operating unit. Only visible to users in the
+  _Multiple Operating Unit_ group.
+
+## Modified — Record Visibility
+
+- The School list is filtered by a record rule: a user only sees records that have no
+  Operating Unit set, or that share at least one Operating Unit with their own Operating
+  Units. This rule only restricts what a user can see — it does not restrict who can
+  create, edit, or delete records.

--- a/ssi_school_operating_unit/docs/school_academic_term/01-create.md
+++ b/ssi_school_operating_unit/docs/school_academic_term/01-create.md
@@ -1,0 +1,19 @@
+# Create School Academic Term
+
+> **Module:** ssi_school_operating_unit\
+> **Extends:** ssi_school — model `school_academic_term`, action `01-create`
+
+## Additional Fields
+
+When this module is installed, the create form gains one optional field:
+
+- **Operating Unit**: Select the operating unit(s) this Academic Term belongs to. Leave
+  empty to make the record visible to every operating unit. Only visible to users in the
+  _Multiple Operating Unit_ group.
+
+## Modified — Record Visibility
+
+- The Academic Term list is filtered by a record rule: a user only sees records that
+  have no Operating Unit set, or that share at least one Operating Unit with their own
+  Operating Units. This rule only restricts what a user can see — it does not restrict
+  who can create, edit, or delete records.

--- a/ssi_school_operating_unit/docs/school_academic_year/01-create.md
+++ b/ssi_school_operating_unit/docs/school_academic_year/01-create.md
@@ -1,0 +1,19 @@
+# Create Academic Year
+
+> **Module:** ssi_school_operating_unit\
+> **Extends:** ssi_school — model `school_academic_year`, action `01-create`
+
+## Additional Fields
+
+When this module is installed, the create form gains one optional field:
+
+- **Operating Unit**: Select the operating unit(s) this Academic Year belongs to. Leave
+  empty to make the record visible to every operating unit. Only visible to users in the
+  _Multiple Operating Unit_ group.
+
+## Modified — Record Visibility
+
+- The Academic Year list is filtered by a record rule: a user only sees records that
+  have no Operating Unit set, or that share at least one Operating Unit with their own
+  Operating Units. This rule only restricts what a user can see — it does not restrict
+  who can create, edit, or delete records.

--- a/ssi_school_operating_unit/docs/school_enrollment/01-create.md
+++ b/ssi_school_operating_unit/docs/school_enrollment/01-create.md
@@ -1,0 +1,19 @@
+# Create Enrollment
+
+> **Module:** ssi_school_operating_unit\
+> **Extends:** ssi_school — model `school_enrollment`, action `01-create`
+
+## Additional Post-Condition
+
+- **Operating Unit** (added by this module, hidden unless the _Multiple Operating Unit_
+  group applies) is automatically set from the selected **School** whenever that school
+  belongs to exactly one operating unit. When the school belongs to zero or more than
+  one operating unit, **Operating Unit** keeps its previous value (initially the current
+  user's default operating unit) and is not overridden — it can still be changed
+  manually.
+
+## Modified — Record Visibility
+
+- Users in the _Operating Unit_ group only see, edit, and delete Enrollment records
+  whose Operating Unit matches one of their own Operating Units. Users outside this
+  group are not restricted by this rule.

--- a/ssi_school_operating_unit/docs/school_grade/01-create.md
+++ b/ssi_school_operating_unit/docs/school_grade/01-create.md
@@ -1,0 +1,19 @@
+# Create Grade
+
+> **Module:** ssi_school_operating_unit\
+> **Extends:** ssi_school — model `school_grade`, action `01-create`
+
+## Additional Fields
+
+When this module is installed, the create form gains one optional field:
+
+- **Operating Unit**: Select the operating unit(s) this Grade belongs to. Leave empty to
+  make the record visible to every operating unit. Only visible to users in the
+  _Multiple Operating Unit_ group.
+
+## Modified — Record Visibility
+
+- The Grade list is filtered by a record rule: a user only sees records that have no
+  Operating Unit set, or that share at least one Operating Unit with their own Operating
+  Units. This rule only restricts what a user can see — it does not restrict who can
+  create, edit, or delete records.

--- a/ssi_school_operating_unit/docs/school_grade_class/01-create.md
+++ b/ssi_school_operating_unit/docs/school_grade_class/01-create.md
@@ -1,0 +1,19 @@
+# Create Grade Class
+
+> **Module:** ssi_school_operating_unit\
+> **Extends:** ssi_school — model `school_grade_class`, action `01-create`
+
+## Additional Fields
+
+When this module is installed, the create form gains one optional field:
+
+- **Operating Unit**: Select the operating unit(s) this Grade Class belongs to. Leave
+  empty to make the record visible to every operating unit. Only visible to users in the
+  _Multiple Operating Unit_ group.
+
+## Modified — Record Visibility
+
+- The Grade Class list is filtered by a record rule: a user only sees records that have
+  no Operating Unit set, or that share at least one Operating Unit with their own
+  Operating Units. This rule only restricts what a user can see — it does not restrict
+  who can create, edit, or delete records.

--- a/ssi_school_operating_unit/docs/school_grade_type/01-create.md
+++ b/ssi_school_operating_unit/docs/school_grade_type/01-create.md
@@ -1,0 +1,19 @@
+# Create Grade Type
+
+> **Module:** ssi_school_operating_unit\
+> **Extends:** ssi_school — model `school_grade_type`, action `01-create`
+
+## Additional Fields
+
+When this module is installed, the create form gains one optional field:
+
+- **Operating Unit**: Select the operating unit(s) this Grade Type belongs to. Leave
+  empty to make the record visible to every operating unit. Only visible to users in the
+  _Multiple Operating Unit_ group.
+
+## Modified — Record Visibility
+
+- The Grade Type list is filtered by a record rule: a user only sees records that have
+  no Operating Unit set, or that share at least one Operating Unit with their own
+  Operating Units. This rule only restricts what a user can see — it does not restrict
+  who can create, edit, or delete records.

--- a/ssi_school_operating_unit/docs/school_homeroom/01-create.md
+++ b/ssi_school_operating_unit/docs/school_homeroom/01-create.md
@@ -1,0 +1,22 @@
+# Create Homeroom
+
+> **Module:** ssi_school_operating_unit\
+> **Extends:** ssi_school — model `school_homeroom`, action `01-create`
+
+## Additional Fields
+
+When this module is installed, the create form gains one field:
+
+- **Operating Unit**: Automatically filled from the current user's default operating
+  unit. Change if needed. Only visible to users in the _Multiple Operating Unit_ group.
+
+## Additional Post-Condition
+
+- Every Enrollment generated from this Homeroom batch (`16-generate-enrollments`) is
+  created with the same **Operating Unit** as the Homeroom.
+
+## Modified — Record Visibility
+
+- Users in the _Operating Unit_ group only see, edit, and delete Homeroom records whose
+  Operating Unit matches one of their own Operating Units. Users outside this group are
+  not restricted by this rule.

--- a/ssi_school_operating_unit/docs/school_student/01-create.md
+++ b/ssi_school_operating_unit/docs/school_student/01-create.md
@@ -1,0 +1,19 @@
+# Create Student
+
+> **Module:** ssi_school_operating_unit\
+> **Extends:** ssi_school — model `school_student`, action `01-create`
+
+## Additional Fields
+
+When this module is installed, the create form gains one optional field:
+
+- **Operating Unit**: Select the operating unit(s) this Student belongs to. Leave empty
+  to make the record visible to every operating unit. Only visible to users in the
+  _Multiple Operating Unit_ group.
+
+## Modified — Record Visibility
+
+- The Student list is filtered by a record rule: a user only sees records that have no
+  Operating Unit set, or that share at least one Operating Unit with their own Operating
+  Units. This rule only restricts what a user can see — it does not restrict who can
+  create, edit, or delete records.

--- a/ssi_school_operating_unit/docs/school_student_mutation/01-create.md
+++ b/ssi_school_operating_unit/docs/school_student_mutation/01-create.md
@@ -1,0 +1,17 @@
+# Create Student Class Mutation
+
+> **Module:** ssi_school_operating_unit\
+> **Extends:** ssi_school — model `school_student_mutation`, action `01-create`
+
+## Additional Fields
+
+When this module is installed, the create form gains one field:
+
+- **Operating Unit**: Automatically filled from the current user's default operating
+  unit. Change if needed. Only visible to users in the _Multiple Operating Unit_ group.
+
+## Modified — Record Visibility
+
+- Users in the _Operating Unit_ group only see, edit, and delete Student Class Mutation
+  records whose Operating Unit matches one of their own Operating Units. Users outside
+  this group are not restricted by this rule.

--- a/ssi_school_operating_unit/docs/school_teacher/01-create.md
+++ b/ssi_school_operating_unit/docs/school_teacher/01-create.md
@@ -1,0 +1,19 @@
+# Create Teacher
+
+> **Module:** ssi_school_operating_unit\
+> **Extends:** ssi_school — model `school_teacher`, action `01-create`
+
+## Additional Fields
+
+When this module is installed, the create form gains one optional field:
+
+- **Operating Unit**: Select the operating unit(s) this Teacher belongs to. Leave empty
+  to make the record visible to every operating unit. Only visible to users in the
+  _Multiple Operating Unit_ group.
+
+## Modified — Record Visibility
+
+- The Teacher list is filtered by a record rule: a user only sees records that have no
+  Operating Unit set, or that share at least one Operating Unit with their own Operating
+  Units. This rule only restricts what a user can see — it does not restrict who can
+  create, edit, or delete records.


### PR DESCRIPTION
## Summary

- Menambahkan Instruksi Kerja (IK) delta operating unit untuk sebelas model `ssi_school` yang di-inherit `ssi_school_operating_unit`: `school`, `school_student`, `school_teacher`, `school_academic_term`, `school_academic_year`, `school_grade`, `school_grade_type`, `school_grade_class`, `school_homeroom`, `school_student_mutation`, `school_enrollment`.
- Sepuluh model mendapat `## Additional Fields` (field `operating_unit_ids`/`operating_unit_id` yang benar-benar diisi/dipilih pengguna). `school_enrollment` dikecualikan dari `Additional Fields` karena `operating_unit_id`-nya diturunkan otomatis dari `school_id` — didokumentasikan sebagai `## Additional Post-Condition` (rincian keputusan ada di komentar issue).
- Seluruh sebelas model mendapat catatan `## Modified — Record Visibility` karena terkena record rule operating unit.
- `README.rst` diperbarui dengan bagian `Work Instruction` yang menaut ke IK baru.
- Item `type:docs` murni — **tidak ada perubahan kode**.

## Test plan

- [x] `assets/validate-ik.sh ssi_school_operating_unit` → 0 ERROR (11 berkas IK, semua punya blok metadata)
- [x] pre-commit (termasuk `oca-gen-addon-readme`, `prettier`) hijau saat commit
- [ ] CI GitHub hijau

Closes #224