### PR TITLE
[UPD] IK delta 8 modul *_operating_unit (admission, incident, graduation, leave, withdrawal, admission_lead, 2x invoice export)

### DIFF
--- a/ssi_school_admission_customer_invoice_export_operating_unit/README.rst
+++ b/ssi_school_admission_customer_invoice_export_operating_unit/README.rst
@@ -11,6 +11,15 @@ Create Invoice Export wizard for school admissions, so the exported
 invoices and the resulting document are scoped to one operating unit.
 
 
+Work Instruction
+=================
+
+Admission
+----------
+
+* `Create Invoice Export - Admission <docs/school_admission/20-create-invoice-export.html>`_
+
+
 Bug Tracker
 ===========
 

--- a/ssi_school_admission_customer_invoice_export_operating_unit/docs/school_admission/20-create-invoice-export.md
+++ b/ssi_school_admission_customer_invoice_export_operating_unit/docs/school_admission/20-create-invoice-export.md
@@ -1,0 +1,26 @@
+# Create Invoice Export — Admission
+
+> **Module:** ssi_school_admission_customer_invoice_export_operating_unit\
+> **Extends:** ssi_school_admission_customer_invoice_export — model `school_admission`, action
+> `20-create-invoice-export`
+
+## Modified Flow
+
+- Anchor: on the base Flow's step 5 (fill in the **Create Invoice Export** wizard), one
+  field is added before **Type**:
+  - **Operating Unit** _(required)_: Automatically filled with the acting user's default
+    operating unit. Change if needed. Restricts which of the collected invoice moves are
+    actually exported to this operating unit, and is copied onto the resulting Customer
+    Invoice Export document.
+
+## Modified Validation
+
+- Clicking **Create Invoice Export** in the wizard footer fails if none of the collected
+  invoice moves belong to the selected **Operating Unit** — even when the base "no
+  exportable move" check already passed.
+
+## Additional Post-Condition
+
+- The created **Customer Invoice Export** document's **Invoices**/**Invoice Lines** are
+  further restricted to moves of the wizard's **Operating Unit**, and the document's own
+  **Operating Unit** is set to that value.

--- a/ssi_school_admission_lead_operating_unit/README.rst
+++ b/ssi_school_admission_lead_operating_unit/README.rst
@@ -10,6 +10,16 @@ Glue module that propagates the operating unit from a CRM lead to the
 school admission form created via the lead's action buttons.
 
 
+Work Instruction
+=================
+
+CRM Lead
+---------
+
+* `Create Admission from CRM Lead <docs/crm_lead/02-create-admission.html>`_
+* `Create Admission Form from CRM Lead <docs/crm_lead/02-create-admission-form.html>`_
+
+
 Bug Tracker
 ===========
 

--- a/ssi_school_admission_lead_operating_unit/docs/crm_lead/02-create-admission-form.md
+++ b/ssi_school_admission_lead_operating_unit/docs/crm_lead/02-create-admission-form.md
@@ -1,0 +1,16 @@
+# Create Admission Form from CRM Lead
+
+> **Module:** ssi_school_admission_lead_operating_unit\
+> **Extends:** ssi_school_admission_lead — model `crm.lead`, action `02-create-admission-form`
+
+## Modified Flow
+
+- Anchor: on the base Flow's step 4 (fill in the **Create Admission Form** wizard), the
+  wizard gains one field:
+  - **Operating Unit**: Pre-filled from the lead's own **Operating Unit**, if set (via
+    the button's context); otherwise left empty. Change if needed.
+
+## Additional Post-Condition
+
+- The new `school_admission_form` document is created with its **Operating Unit** set to
+  the wizard's **Operating Unit**, when one was selected.

--- a/ssi_school_admission_lead_operating_unit/docs/crm_lead/02-create-admission.md
+++ b/ssi_school_admission_lead_operating_unit/docs/crm_lead/02-create-admission.md
@@ -1,0 +1,16 @@
+# Create Admission from CRM Lead
+
+> **Module:** ssi_school_admission_lead_operating_unit\
+> **Extends:** ssi_school_lead — model `crm.lead`, action `02-create-admission`
+
+## Modified Flow
+
+- Anchor: on the base Flow's step 4 (fill in the **Create Admission** wizard), the
+  wizard gains one field:
+  - **Operating Unit**: Pre-filled from the lead's own **Operating Unit**, if set (via
+    the button's context); otherwise left empty. Change if needed.
+
+## Additional Post-Condition
+
+- The new `school_admission` document is created with its **Operating Unit** set to the
+  wizard's **Operating Unit**, when one was selected.

--- a/ssi_school_admission_operating_unit/README.rst
+++ b/ssi_school_admission_operating_unit/README.rst
@@ -11,6 +11,25 @@ Adds operating unit access control for transactional models:
 school_admission, school_admission_form, and school_admission_test.
 
 
+Work Instruction
+=================
+
+Admission
+----------
+
+* `Create School Admission <docs/school_admission/01-create.html>`_
+
+Admission Form
+---------------
+
+* `Create School Admission Form <docs/school_admission_form/01-create.html>`_
+
+Admission Test
+---------------
+
+* `Create School Admission Test <docs/school_admission_test/01-create.html>`_
+
+
 Bug Tracker
 ===========
 

--- a/ssi_school_admission_operating_unit/docs/school_admission/01-create.md
+++ b/ssi_school_admission_operating_unit/docs/school_admission/01-create.md
@@ -1,0 +1,15 @@
+# Create School Admission
+
+> **Module:** ssi_school_admission_operating_unit\
+> **Extends:** ssi_school_admission — model `school_admission`, action `01-create`
+
+## Modified — Record Visibility
+
+- The admission list is now filtered by operating unit (record rule): a user only sees
+  admissions belonging to operating units they are assigned to (group _Operating Unit_
+  under _School Admission_'s data ownership category). This is not a Flow step.
+- **Operating Unit** is not a field the user fills directly. It is derived automatically
+  from the selected **School**'s own operating unit whenever the school has exactly one.
+  When the school has more than one operating unit (or none), the field is left as-is
+  and can be set manually — it is visible on the form only when the _Multi Operating
+  Unit_ feature is enabled (Settings > Operating Unit).

--- a/ssi_school_admission_operating_unit/docs/school_admission_form/01-create.md
+++ b/ssi_school_admission_operating_unit/docs/school_admission_form/01-create.md
@@ -1,0 +1,16 @@
+# Create School Admission Form
+
+> **Module:** ssi_school_admission_operating_unit\
+> **Extends:** ssi_school_admission — model `school_admission_form`, action `01-create`
+
+## Modified — Record Visibility
+
+- The admission form list is now filtered by operating unit (record rule): a user only
+  sees admission forms belonging to operating units they are assigned to (group
+  _Operating Unit_ under _School Admission Form_'s data ownership category). This is not
+  a Flow step.
+- **Operating Unit** is not a field the user fills directly. It is derived automatically
+  from the selected **School**'s own operating unit whenever the school has exactly one.
+  When the school has more than one operating unit (or none), the field is left as-is
+  and can be set manually — it is visible on the form only when the _Multi Operating
+  Unit_ feature is enabled (Settings > Operating Unit).

--- a/ssi_school_admission_operating_unit/docs/school_admission_test/01-create.md
+++ b/ssi_school_admission_operating_unit/docs/school_admission_test/01-create.md
@@ -1,0 +1,16 @@
+# Create School Admission Test
+
+> **Module:** ssi_school_admission_operating_unit\
+> **Extends:** ssi_school_admission — model `school_admission_test`, action `01-create`
+
+## Modified — Record Visibility
+
+- The admission test list is now filtered by operating unit (record rule): a user only
+  sees admission tests belonging to operating units they are assigned to (group
+  _Operating Unit_ under _School Admission Test_'s data ownership category). This is not
+  a Flow step.
+- **Operating Unit** is not a field the user fills directly. It is derived automatically
+  from the selected **School**'s own operating unit whenever the school has exactly one.
+  When the school has more than one operating unit (or none), the field is left as-is
+  and can be set manually — it is visible on the form only when the _Multi Operating
+  Unit_ feature is enabled (Settings > Operating Unit).

--- a/ssi_school_customer_invoice_export_operating_unit/README.rst
+++ b/ssi_school_customer_invoice_export_operating_unit/README.rst
@@ -11,6 +11,15 @@ Create Invoice Export wizard for school enrollments, so the exported
 invoices and the resulting document are scoped to one operating unit.
 
 
+Work Instruction
+=================
+
+Enrollment
+-----------
+
+* `Create Invoice Export - Enrollment <docs/school_enrollment/23-create-invoice-export.html>`_
+
+
 Bug Tracker
 ===========
 

--- a/ssi_school_customer_invoice_export_operating_unit/docs/school_enrollment/23-create-invoice-export.md
+++ b/ssi_school_customer_invoice_export_operating_unit/docs/school_enrollment/23-create-invoice-export.md
@@ -1,0 +1,25 @@
+# Create Invoice Export — Enrollment
+
+> **Module:** ssi_school_customer_invoice_export_operating_unit\
+> **Extends:** ssi_school_customer_invoice_export — model `school_enrollment`, action `23-create-invoice-export`
+
+## Modified Flow
+
+- Anchor: on the base Flow's step 5 (fill in the **Create Invoice Export** wizard), one
+  field is added before **Type**:
+  - **Operating Unit** _(required)_: Automatically filled with the acting user's default
+    operating unit. Change if needed. Restricts which of the collected invoice moves are
+    actually exported to this operating unit, and is copied onto the resulting Customer
+    Invoice Export document.
+
+## Modified Validation
+
+- Clicking **Create Invoice Export** in the wizard footer fails if none of the collected
+  invoice moves belong to the selected **Operating Unit** — even when the base "no
+  exportable move" check already passed.
+
+## Additional Post-Condition
+
+- The created **Customer Invoice Export** document's **Invoices**/**Invoice Lines** are
+  further restricted to moves of the wizard's **Operating Unit**, and the document's own
+  **Operating Unit** is set to that value.

--- a/ssi_school_incident_operating_unit/README.rst
+++ b/ssi_school_incident_operating_unit/README.rst
@@ -11,6 +11,20 @@ Adds operating unit access control for the transactional models
 school_incident and school_incident_weekly_review.
 
 
+Work Instruction
+=================
+
+Incident
+---------
+
+* `Create School Incident <docs/school_incident/01-create.html>`_
+
+Incident Weekly Review
+------------------------
+
+* `Create School Incident Weekly Review <docs/school_incident_weekly_review/01-create.html>`_
+
+
 Bug Tracker
 ===========
 

--- a/ssi_school_incident_operating_unit/docs/school_incident/01-create.md
+++ b/ssi_school_incident_operating_unit/docs/school_incident/01-create.md
@@ -1,0 +1,18 @@
+# Create School Incident
+
+> **Module:** ssi_school_incident_operating_unit\
+> **Extends:** ssi_school_incident — model `school_incident`, action `01-create`
+
+## Additional Fields
+
+When this module is installed, the create form gains one field, visible only when the
+_Multi Operating Unit_ feature is enabled (Settings > Operating Unit):
+
+- **Operating Unit**: Automatically filled with the acting user's default operating
+  unit. Change if needed.
+
+## Modified — Record Visibility
+
+- The incident list is now filtered by operating unit (record rule): a user only sees
+  incidents belonging to operating units they are assigned to. Manager (Principal) is
+  also evaluated against this rule. This is not a Flow step.

--- a/ssi_school_incident_operating_unit/docs/school_incident_weekly_review/01-create.md
+++ b/ssi_school_incident_operating_unit/docs/school_incident_weekly_review/01-create.md
@@ -1,0 +1,18 @@
+# Create School Incident Weekly Review
+
+> **Module:** ssi_school_incident_operating_unit\
+> **Extends:** ssi_school_incident — model `school_incident_weekly_review`, action `01-create`
+
+## Additional Fields
+
+When this module is installed, the create form gains one field, visible only when the
+_Multi Operating Unit_ feature is enabled (Settings > Operating Unit):
+
+- **Operating Unit**: Automatically filled with the acting user's default operating
+  unit. Change if needed.
+
+## Modified — Record Visibility
+
+- The weekly review list is now filtered by operating unit (record rule): a user only
+  sees weekly reviews belonging to operating units they are assigned to. Manager
+  (Principal) is also evaluated against this rule. This is not a Flow step.

--- a/ssi_school_student_graduation_operating_unit/README.rst
+++ b/ssi_school_student_graduation_operating_unit/README.rst
@@ -11,6 +11,20 @@ Adds operating unit access control for the transactional model
 school_student_graduation.
 
 
+Work Instruction
+=================
+
+Student Graduation
+--------------------
+
+* `Create School Student Graduation <docs/school_student_graduation/01-create.html>`_
+
+Student Graduation Batch
+---------------------------
+
+* `Create School Student Graduation Batch <docs/school_student_graduation_batch/01-create.html>`_
+
+
 Bug Tracker
 ===========
 

--- a/ssi_school_student_graduation_operating_unit/docs/school_student_graduation/01-create.md
+++ b/ssi_school_student_graduation_operating_unit/docs/school_student_graduation/01-create.md
@@ -1,0 +1,19 @@
+# Create School Student Graduation
+
+> **Module:** ssi_school_student_graduation_operating_unit\
+> **Extends:** ssi_school_student_graduation — model `school_student_graduation`, action
+> `01-create`
+
+## Additional Fields
+
+When this module is installed, the create form gains one field, visible only when the
+_Multi Operating Unit_ feature is enabled (Settings > Operating Unit):
+
+- **Operating Unit**: Automatically filled with the acting user's default operating
+  unit. Change if needed.
+
+## Modified — Record Visibility
+
+- The graduation list is now filtered by operating unit (record rule): a user only sees
+  graduation records belonging to operating units they are assigned to. This is not a
+  Flow step.

--- a/ssi_school_student_graduation_operating_unit/docs/school_student_graduation_batch/01-create.md
+++ b/ssi_school_student_graduation_operating_unit/docs/school_student_graduation_batch/01-create.md
@@ -1,0 +1,18 @@
+# Create School Student Graduation Batch
+
+> **Module:** ssi_school_student_graduation_operating_unit\
+> **Extends:** ssi_school_student_graduation — model `school_student_graduation_batch`, action
+> `01-create`
+
+## Additional Fields
+
+When this module is installed, the create form gains one field, visible only when the
+_Multi Operating Unit_ feature is enabled (Settings > Operating Unit):
+
+- **Operating Unit**: Automatically filled with the acting user's default operating
+  unit. Change if needed.
+
+## Modified — Record Visibility
+
+- The batch list is now filtered by operating unit (record rule): a user only sees batch
+  records belonging to operating units they are assigned to. This is not a Flow step.

--- a/ssi_school_student_leave_operating_unit/README.rst
+++ b/ssi_school_student_leave_operating_unit/README.rst
@@ -11,6 +11,15 @@ Adds operating unit access control for the transactional model
 school_student_leave.
 
 
+Work Instruction
+=================
+
+Student Leave
+---------------
+
+* `Create School Student Leave <docs/school_student_leave/01-create.html>`_
+
+
 Bug Tracker
 ===========
 

--- a/ssi_school_student_leave_operating_unit/docs/school_student_leave/01-create.md
+++ b/ssi_school_student_leave_operating_unit/docs/school_student_leave/01-create.md
@@ -1,0 +1,17 @@
+# Create School Student Leave
+
+> **Module:** ssi_school_student_leave_operating_unit\
+> **Extends:** ssi_school_student_leave — model `school_student_leave`, action `01-create`
+
+## Additional Fields
+
+When this module is installed, the create form gains one field, visible only when the
+_Multi Operating Unit_ feature is enabled (Settings > Operating Unit):
+
+- **Operating Unit**: Automatically filled with the acting user's default operating
+  unit. Change if needed.
+
+## Modified — Record Visibility
+
+- The leave list is now filtered by operating unit (record rule): a user only sees leave
+  records belonging to operating units they are assigned to. This is not a Flow step.

--- a/ssi_school_student_withdrawal_operating_unit/README.rst
+++ b/ssi_school_student_withdrawal_operating_unit/README.rst
@@ -11,6 +11,15 @@ Adds operating unit access control to the school_student_withdrawal
 transactional model.
 
 
+Work Instruction
+=================
+
+Student Withdrawal
+--------------------
+
+* `Create School Student Withdrawal <docs/school_student_withdrawal/01-create.html>`_
+
+
 Bug Tracker
 ===========
 

--- a/ssi_school_student_withdrawal_operating_unit/docs/school_student_withdrawal/01-create.md
+++ b/ssi_school_student_withdrawal_operating_unit/docs/school_student_withdrawal/01-create.md
@@ -1,0 +1,19 @@
+# Create School Student Withdrawal
+
+> **Module:** ssi_school_student_withdrawal_operating_unit\
+> **Extends:** ssi_school_student_withdrawal — model `school_student_withdrawal`, action
+> `01-create`
+
+## Additional Fields
+
+When this module is installed, the create form gains one field, visible only when the
+_Multi Operating Unit_ feature is enabled (Settings > Operating Unit):
+
+- **Operating Unit**: Automatically filled with the acting user's default operating
+  unit. Change if needed.
+
+## Modified — Record Visibility
+
+- The withdrawal list is now filtered by operating unit (record rule): a user only sees
+  withdrawal records belonging to operating units they are assigned to. This is not a
+  Flow step.


### PR DESCRIPTION
## Ringkasan

Menambahkan Instruksi Kerja (IK) delta beserta catatan visibility untuk delapan modul
`*_operating_unit` di repo ini — murni dokumentasi (`docs/`, `README.rst`), tanpa
perubahan kode model/view:

- `ssi_school_admission_operating_unit` — `school_admission`, `school_admission_form`,
  `school_admission_test`: `operating_unit_id` diturunkan otomatis dari `school_id`
  (bukan diisi pengguna) → catatan `Modified — Record Visibility` saja, tanpa `E1`.
- `ssi_school_incident_operating_unit` — `school_incident`,
  `school_incident_weekly_review`: `operating_unit_id` diisi pengguna (mixin
  `mixin.single_operating_unit`) → `Additional Fields` + `Modified — Record Visibility`.
- `ssi_school_student_graduation_operating_unit` — `school_student_graduation`,
  `school_student_graduation_batch`: sama seperti di atas.
- `ssi_school_student_leave_operating_unit` — `school_student_leave`: sama.
- `ssi_school_student_withdrawal_operating_unit` — `school_student_withdrawal`: sama.
- `ssi_school_admission_lead_operating_unit` — wizard `crm.lead.create_admission` &
  `crm.lead.create_admission_form` mendapat field `operating_unit_id` baru → delta
  `Modified Flow` menempel pada IK aksi Create Admission / Create Admission Form
  (`ssi_school_lead`/`ssi_school_admission_lead`).
- `ssi_school_customer_invoice_export_operating_unit` &
  `ssi_school_admission_customer_invoice_export_operating_unit` — wizard Create Invoice
  Export mendapat field Operating Unit wajib → delta `Modified Flow` + `Modified
  Validation` + `Additional Post-Condition` menempel pada IK aksi Create Invoice Export.

## Model tanpa IK (dicatat, sesuai Keputusan Desain)

- `school_admission_payment_term` (`ssi_school_admission_operating_unit`) — tidak
  menambah field maupun record rule OU sendiri; hanya mempropagasi `operating_unit_id`
  dari admission induk ke invoice yang dibuat. Tidak dibuat IK.
- `school_admission_operating_unit_mixin.py` — modul helper murni fungsi Python, bukan
  model Odoo. Tidak dibuat IK.

## Verifikasi

- `assets/validate-ik.sh` pada kedelapan modul: **0 ERROR** (hanya peringatan "tak ada
  tour" yang memang di luar cakupan issue ini — tour didelegasikan ke item terpisah).
- `pre-commit` (prettier, dsb.) hijau di seluruh commit.
- `README.rst` tiap modul yang menghasilkan berkas memuat entri `Work Instruction`.

Closes #225