### PR TITLE
[UPD] Tour UI kelulusan, cuti, dan pengunduran diri siswa

### DIFF
--- a/ssi_school_student_graduation/__manifest__.py
+++ b/ssi_school_student_graduation/__manifest__.py
@@ -37,5 +37,6 @@
         "approval_template/school_student_graduation_batch.xml",
         "views/school_student_graduation.xml",
         "views/school_student_graduation_batch.xml",
+        "views/assets.xml",
     ],
 }

--- a/ssi_school_student_graduation/static/tests/tours/school_student_graduation_batch_tour.js
+++ b/ssi_school_student_graduation/static/tests/tours/school_student_graduation_batch_tour.js
@@ -201,17 +201,48 @@ odoo.define(
                 // setUpClass's 02-edit.md comment.
                 populateEligibleStudents("TOUR SGB Edit Student"),
                 [
-                    // Flow 5 -- Click Save.
+                    // Flow 5 -- Click Save. By this point the record is
+                    // already persisted -- action_populate_lines is a
+                    // type="object" button that implicit-auto-saves before
+                    // its RPC runs, and its own write() already landed the
+                    // refreshed Lines list, so the form carries no further
+                    // dirty state. Confirmed pattern (patterns.md skill
+                    // odoo-development-ui-test §P covers the "reload race"
+                    // case; this is the sibling "nothing left to save"
+                    // case, already fixed the same way in
+                    // ssi_school_admission's school_admission_form_tour.js
+                    // test_create/test_edit): clicking .o_form_button_save
+                    // here fires zero write calls, and 14.0 core does not
+                    // transition an already-clean form to .o_form_readonly
+                    // -- so that class is NOT a valid gate here. IK
+                    // Post-Condition ("The record is updated with the new
+                    // values") does not require readonly mode either.
                     {
                         content: "Save the record",
                         trigger: ".o_form_button_save",
                     },
-
-                    // Post-Condition -- the record is updated with the new
-                    // values.
+                ],
+                // Post-Condition -- the record is updated with the new
+                // values. Verified by navigating away and re-opening the
+                // record (same technique as school_admission_form_tour.js
+                // test_edit): the form stayed in edit mode after Save (see
+                // note above), and re-opening an EXISTING record always
+                // renders it read-only in 14.0, where the Lines list is a
+                // reliable, mode-independent kasatmata proof the Populate
+                // change actually persisted.
+                [
                     {
-                        content: "Record is saved",
-                        trigger: ".o_form_view.o_form_readonly",
+                        content: "Click the Graduation Batches breadcrumb",
+                        trigger:
+                            ".breadcrumb-item.o_back_button a:contains(Graduation Batches)",
+                    },
+                ],
+                openRecordByYear("TOUR SGB Edit Year"),
+                [
+                    {
+                        content: "The populated student is still on the record",
+                        trigger:
+                            ".o_field_widget[name='line_ids'] .o_data_row:contains(TOUR SGB Edit Student)",
                         run: function () {
                             // Assertion only.
                         },

--- a/ssi_school_student_graduation/static/tests/tours/school_student_graduation_batch_tour.js
+++ b/ssi_school_student_graduation/static/tests/tours/school_student_graduation_batch_tour.js
@@ -1,0 +1,694 @@
+// Copyright 2026 OpenSynergy Indonesia
+// Copyright 2026 PT. Simetri Sinergi Indonesia
+// License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl).
+
+odoo.define(
+    "ssi_school_student_graduation.school_student_graduation_batch_tour",
+    function (require) {
+        "use strict";
+
+        var tour = require("web_tour.tour");
+
+        // Shared navigation block reused by every tour below -- corresponds
+        // to Flow 1 of every school_student_graduation_batch IK: "Open the
+        // School > Student Activities > Graduation Batches menu."
+        function openBatchList() {
+            return [
+                tour.stepUtils.showAppsMenuItem(),
+                {
+                    content: "Open the School app",
+                    trigger: '.o_app[data-menu-xmlid="ssi_school.menu_school_root"]',
+                },
+                {
+                    content: "Open the Student Activities menu",
+                    trigger:
+                        '.o_menu_sections [data-menu-xmlid="ssi_school.menu_school_student_activity"]',
+                },
+                {
+                    content: "Open the Graduation Batches menu",
+                    trigger:
+                        '.o_menu_sections [data-menu-xmlid="ssi_school_student_graduation.school_student_graduation_batch_menu"]',
+                },
+                {
+                    // Gerbang: tunggu action TUJUAN benar-benar terpasang,
+                    // bukan sekadar "ada list di layar" (patterns.md skill
+                    // odoo-development-ui-test §A).
+                    content: "Graduation Batches list is displayed",
+                    trigger:
+                        ".o_control_panel .breadcrumb-item.active:contains(Graduation Batches)",
+                    extra_trigger: ".o_list_view",
+                    run: function () {
+                        // Assertion only; do not trigger the default click
+                        // action.
+                    },
+                },
+            ];
+        }
+
+        // Opens the record identified by the unique Academic Year name
+        // shown on the list row (used as Pre-Condition test data marker,
+        // since school_student_graduation_batch has no per-record free
+        // text field of its own).
+        function openRecordByYear(yearName) {
+            return [
+                {
+                    content: "Open the record",
+                    trigger:
+                        ".o_data_row:contains(" + yearName + ") .o_data_cell:first",
+                    extra_trigger: ".o_list_view",
+                },
+                {
+                    content: "Form is open",
+                    trigger: ".o_form_view",
+                    run: function () {
+                        // Assertion only.
+                    },
+                },
+            ];
+        }
+
+        // Opens the Students tab and clicks Populate Eligible Students
+        // (Inline Action documented on 01-create.md / 02-edit.md), then
+        // waits for the eligible student to appear in the Lines list.
+        function populateEligibleStudents(eligibleStudentName) {
+            return [
+                {
+                    content: "Open the Students tab",
+                    trigger: ".o_notebook .nav-link:contains(Students)",
+                },
+                {
+                    content: "Click Populate Eligible Students",
+                    trigger:
+                        ".o_form_view button[name='action_populate_lines']:enabled",
+                },
+                {
+                    content: "The eligible student appears in the Lines list",
+                    trigger:
+                        ".o_field_widget[name='line_ids'] .o_data_row:contains(" +
+                        eligibleStudentName +
+                        ")",
+                    run: function () {
+                        // Assertion only.
+                    },
+                },
+            ];
+        }
+
+        // IK: docs/school_student_graduation_batch/01-create.md
+        //
+        // Inline Actions: action_populate_lines (Populate Eligible
+        // Students) is exercised as a step here, not as its own tour.
+        tour.register(
+            "ssi_school_student_graduation_school_student_graduation_batch_create",
+            {
+                test: true,
+                url: "/web",
+            },
+            [].concat(
+                // Flow 1 -- Open the Graduation Batches menu.
+                openBatchList(),
+                [
+                    // Flow 2 -- Click the New button. (14.0: "Create")
+                    {
+                        content: "Click New",
+                        trigger: ".o_list_button_add",
+                        extra_trigger: ".o_list_view",
+                    },
+                    {
+                        content: "Form is open in edit mode",
+                        trigger: ".o_form_view.o_form_editable",
+                        run: function () {
+                            // Assertion only.
+                        },
+                    },
+                ],
+                // Flow 3 -- Date/Academic Year/Academic Term/Grade are all
+                // optional (Date defaults to today), so no field needs to
+                // be filled before populating.
+                //
+                // Flow 4 -- On the Students tab, click Populate Eligible
+                // Students to fill the Lines list.
+                populateEligibleStudents("TOUR SGB Create Eligible Student"),
+                [
+                    // Flow 5 -- Click Save.
+                    {
+                        content: "Save the record",
+                        trigger: ".o_form_button_save",
+                    },
+
+                    // Post-Condition -- a new record is created in Draft
+                    // status.
+                    {
+                        content: "Record is saved",
+                        trigger: ".o_form_view.o_form_readonly",
+                        run: function () {
+                            // Assertion only.
+                        },
+                    },
+                    {
+                        content: "Status is Draft",
+                        trigger:
+                            ".o_statusbar_status .o_arrow_button[data-value='draft'].btn-primary",
+                        run: function () {
+                            // Assertion only.
+                        },
+                    },
+                ]
+            )
+        );
+
+        // IK: docs/school_student_graduation_batch/02-edit.md
+        //
+        // Inline Actions: action_populate_lines (Populate Eligible
+        // Students) is exercised as a step here too.
+        tour.register(
+            "ssi_school_student_graduation_school_student_graduation_batch_edit",
+            {
+                test: true,
+                url: "/web",
+            },
+            [].concat(
+                // Flow 1 -- Open the Graduation Batches menu.
+                openBatchList(),
+                // Flow 2 -- Find and open the record to edit.
+                openRecordByYear("TOUR SGB Edit Year"),
+                [
+                    // 14.0: a just-opened record is displayed read-only; an
+                    // explicit Edit click is required before its fields
+                    // become editable. Not itemized in 02-edit.md's Flow --
+                    // same documented 14.0 platform mechanic as
+                    // school_student_graduation_tour.js test_edit.
+                    {
+                        content: "Click the Edit button",
+                        trigger: ".o_form_button_edit",
+                    },
+                    {
+                        content: "Form is now editable",
+                        trigger: ".o_form_view.o_form_editable",
+                        run: function () {
+                            // Assertion only.
+                        },
+                    },
+                ],
+                // Flow 3/4 -- Refill the Lines list from the current
+                // filters via Populate Eligible Students.
+                populateEligibleStudents("TOUR SGB Edit Eligible Student"),
+                [
+                    // Flow 5 -- Click Save.
+                    {
+                        content: "Save the record",
+                        trigger: ".o_form_button_save",
+                    },
+
+                    // Post-Condition -- the record is updated with the new
+                    // values.
+                    {
+                        content: "Record is saved",
+                        trigger: ".o_form_view.o_form_readonly",
+                        run: function () {
+                            // Assertion only.
+                        },
+                    },
+                ]
+            )
+        );
+
+        // IK: docs/school_student_graduation_batch/03-delete.md
+        tour.register(
+            "ssi_school_student_graduation_school_student_graduation_batch_delete",
+            {
+                test: true,
+                url: "/web",
+            },
+            [].concat(
+                // Flow 1 -- Open the Graduation Batches menu.
+                openBatchList(),
+                [
+                    // Flow 2 -- Select the record to delete (check the
+                    // checkbox).
+                    {
+                        content: "Check the record's selector checkbox",
+                        trigger:
+                            ".o_data_row:contains(TOUR SGB Delete Year) .o_list_record_selector input",
+                    },
+
+                    // Flow 3 -- Click Action > Delete.
+                    {
+                        content: "Open the Action menu",
+                        trigger: ".o_cp_action_menus button:contains(Action)",
+                    },
+                    {
+                        content: "Click Delete",
+                        trigger: ".o_cp_action_menus .o_menu_item a",
+                        run: function () {
+                            var $delete = $(".o_cp_action_menus .o_menu_item a").filter(
+                                function () {
+                                    return $(this).text().trim() === "Delete";
+                                }
+                            );
+                            $delete[0].click();
+                        },
+                    },
+
+                    // Flow 4 -- Click OK to confirm.
+                    {
+                        content: "Confirm deletion",
+                        trigger: ".modal-footer button.btn-primary",
+                        in_modal: true,
+                    },
+
+                    // Post-Condition -- the selected records are
+                    // permanently removed from the system.
+                    {
+                        content: "Record no longer in the list",
+                        trigger:
+                            ".o_list_view:not(:has(.o_data_row:contains(TOUR SGB Delete Year)))",
+                        run: function () {
+                            // Assertion only.
+                        },
+                    },
+                ]
+            )
+        );
+
+        // IK: docs/school_student_graduation_batch/04-confirm.md
+        tour.register(
+            "ssi_school_student_graduation_school_student_graduation_batch_confirm",
+            {
+                test: true,
+                url: "/web",
+            },
+            [].concat(
+                // Flow 1 -- Open the Graduation Batches menu.
+                openBatchList(),
+                // Flow 2 -- Open the record to confirm.
+                openRecordByYear("TOUR SGB Confirm Year"),
+                [
+                    // Flow 3 -- Click the Confirm button.
+                    {
+                        content: "Click the Confirm button",
+                        trigger: ".o_statusbar_buttons button[name='action_confirm']",
+                        extra_trigger: ".o_form_view",
+                    },
+
+                    // Flow 4 -- Click OK on the confirmation dialog.
+                    {
+                        content: "Confirm the dialog",
+                        trigger: ".modal-footer button.btn-primary",
+                        in_modal: true,
+                    },
+
+                    // Post-Condition -- status changes to Waiting for
+                    // Approval.
+                    {
+                        content: "Status is Waiting for Approval",
+                        trigger:
+                            ".o_statusbar_status .o_arrow_button[data-value='confirm'].btn-primary",
+                        run: function () {
+                            // Assertion only.
+                        },
+                    },
+                ]
+            )
+        );
+
+        // IK: docs/school_student_graduation_batch/05-approve.md
+        tour.register(
+            "ssi_school_student_graduation_school_student_graduation_batch_approve",
+            {
+                test: true,
+                url: "/web",
+            },
+            [].concat(
+                // Flow 1 -- Open the Graduation Batches menu.
+                openBatchList(),
+                // Flow 2 -- Open the record to approve.
+                openRecordByYear("TOUR SGB Approve Year"),
+                [
+                    // Flow 3 -- Click the Approve button.
+                    {
+                        content: "Click the Approve button",
+                        trigger:
+                            ".o_statusbar_buttons button[name='action_approve_approval']",
+                        extra_trigger: ".o_form_view",
+                    },
+
+                    // Flow 4 -- Click OK on the confirmation dialog.
+                    {
+                        content: "Confirm the dialog",
+                        trigger: ".modal-footer button.btn-primary",
+                        in_modal: true,
+                    },
+
+                    // Post-Condition -- the single approval level is
+                    // fulfilled, so status changes automatically to Done
+                    // (there is no separate manual Finish step for this
+                    // model).
+                    {
+                        content: "Status is Done",
+                        trigger:
+                            ".o_statusbar_status .o_arrow_button[data-value='done'].btn-primary",
+                        run: function () {
+                            // Assertion only.
+                        },
+                    },
+                ]
+            )
+        );
+
+        // IK: docs/school_student_graduation_batch/06-reject.md
+        tour.register(
+            "ssi_school_student_graduation_school_student_graduation_batch_reject",
+            {
+                test: true,
+                url: "/web",
+            },
+            [].concat(
+                // Flow 1 -- Open the Graduation Batches menu.
+                openBatchList(),
+                // Flow 2 -- Open the record to reject.
+                openRecordByYear("TOUR SGB Reject Year"),
+                [
+                    // Flow 3 -- Click the Reject button.
+                    {
+                        content: "Click the Reject button",
+                        trigger:
+                            ".o_statusbar_buttons button[name='action_reject_approval']",
+                        extra_trigger: ".o_form_view",
+                    },
+
+                    // Flow 4 -- Click OK on the confirmation dialog.
+                    {
+                        content: "Confirm the dialog",
+                        trigger: ".modal-footer button.btn-primary",
+                        in_modal: true,
+                    },
+
+                    // Post-Condition -- status changes to Rejected.
+                    {
+                        content: "Status is Rejected",
+                        trigger:
+                            ".o_statusbar_status .o_arrow_button[data-value='reject'].btn-primary",
+                        run: function () {
+                            // Assertion only.
+                        },
+                    },
+                ]
+            )
+        );
+
+        // IK: docs/school_student_graduation_batch/10-cancel.md
+        tour.register(
+            "ssi_school_student_graduation_school_student_graduation_batch_cancel",
+            {
+                test: true,
+                url: "/web",
+            },
+            [].concat(
+                // Flow 1 -- Open the Graduation Batches menu.
+                openBatchList(),
+                // Flow 2 -- Open the record to cancel.
+                openRecordByYear("TOUR SGB Cancel Year"),
+                [
+                    // Flow 3 -- Click the Cancel button.
+                    {
+                        content: "Click the Cancel button",
+                        trigger:
+                            ".o_statusbar_buttons button:enabled:contains('Cancel')",
+                        extra_trigger: ".o_form_view",
+                    },
+                    {
+                        content: "Wizard is open",
+                        trigger: ".o_form_view",
+                        run: function () {
+                            // Assertion only.
+                        },
+                    },
+
+                    // Flow 4 -- In the wizard, select the Cancellation
+                    // Reason (radio widget).
+                    {
+                        content: "Select the cancellation reason",
+                        trigger:
+                            ".o_field_widget[name='cancel_reason_id'] " +
+                            ".o_radio_item:contains(TOUR SGB Cancel Reason) input",
+                        run: "click",
+                    },
+
+                    // Flow 5 -- Click Confirm.
+                    {
+                        content: "Confirm the wizard",
+                        trigger: ".modal-footer button[name='action_confirm']",
+                    },
+
+                    // Flow 6 -- Click OK on the confirmation dialog.
+                    {
+                        content: "Confirm the Are you sure? dialog",
+                        trigger: ".modal-footer button.btn-primary",
+                        in_modal: true,
+                    },
+
+                    // Post-Condition -- status changes to Cancelled.
+                    {
+                        content: "Status is Cancelled",
+                        trigger:
+                            ".o_statusbar_status .o_arrow_button[data-value='cancel'].btn-primary",
+                        run: function () {
+                            // Assertion only.
+                        },
+                    },
+                ]
+            )
+        );
+
+        // IK: docs/school_student_graduation_batch/12-restart.md
+        tour.register(
+            "ssi_school_student_graduation_school_student_graduation_batch_restart",
+            {
+                test: true,
+                url: "/web",
+            },
+            [].concat(
+                // Flow 1 -- Open the Graduation Batches menu.
+                openBatchList(),
+                // Flow 2 -- Open the record to restart.
+                openRecordByYear("TOUR SGB Restart Year"),
+                [
+                    // Flow 3 -- Click the Restart button.
+                    {
+                        content: "Click the Restart button",
+                        trigger: ".o_statusbar_buttons button[name='action_restart']",
+                        extra_trigger: ".o_form_view",
+                    },
+
+                    // Flow 4 -- Click OK on the confirmation dialog.
+                    {
+                        content: "Confirm the dialog",
+                        trigger: ".modal-footer button.btn-primary",
+                        in_modal: true,
+                    },
+
+                    // Post-Condition -- status returns to Draft.
+                    {
+                        content: "Status is Draft",
+                        trigger:
+                            ".o_statusbar_status .o_arrow_button[data-value='draft'].btn-primary",
+                        run: function () {
+                            // Assertion only.
+                        },
+                    },
+                ]
+            )
+        );
+
+        // IK: docs/school_student_graduation_batch/13-reset-number.md
+        tour.register(
+            "ssi_school_student_graduation_school_student_graduation_batch_reset_number",
+            {
+                test: true,
+                url: "/web",
+            },
+            [].concat(
+                // Flow 1 -- Open the Graduation Batches menu.
+                openBatchList(),
+                // Flow 2 -- Open the record whose document number will be
+                // reset.
+                openRecordByYear("TOUR SGB Reset Number Year"),
+                [
+                    // Flow 3 -- Click the Reset Document Number button.
+                    {
+                        content: "Click the Reset Document Number button",
+                        trigger:
+                            ".o_statusbar_buttons button[name='action_reset_document_number']",
+                        extra_trigger: ".o_form_view",
+                    },
+
+                    // Flow 4 -- Click OK on the confirmation dialog.
+                    {
+                        content: "Confirm the dialog",
+                        trigger: ".modal-footer button.btn-primary",
+                        in_modal: true,
+                    },
+
+                    // Post-Condition -- document number returns to "/".
+                    {
+                        content: "Document number is reset (display name shows *)",
+                        trigger:
+                            ".oe_title .o_field_widget[name='display_name']:contains(*)",
+                        run: function () {
+                            // Assertion only.
+                        },
+                    },
+                ]
+            )
+        );
+
+        // IK: docs/school_student_graduation_batch/14-restart-approval.md
+        //
+        // Config Pre-Condition note: same shape as
+        // school_student_graduation -- policy_template/school_student_
+        // graduation_batch.xml does not ship a policy.template_detail
+        // granting restart_approval_ok, so the test file's setUpClass
+        // supplies it directly.
+        tour.register(
+            "ssi_school_student_graduation_school_student_graduation_batch_restart_approval",
+            {
+                test: true,
+                url: "/web",
+            },
+            [].concat(
+                // Flow 1 -- Open the Graduation Batches menu.
+                openBatchList(),
+                // Flow 2 -- Open the record whose approval process is
+                // stalled.
+                openRecordByYear("TOUR SGB Restart Approval Year"),
+                [
+                    // Flow 3 -- Click the Restart Approval Process button.
+                    {
+                        content: "Click the Restart Approval Process button",
+                        trigger:
+                            ".o_statusbar_buttons button[name='action_reload_approval_template']",
+                        extra_trigger: ".o_form_view",
+                    },
+
+                    // Flow 4 -- Click OK on the confirmation dialog.
+                    {
+                        content: "Confirm the dialog",
+                        trigger: ".modal-footer button.btn-primary",
+                        in_modal: true,
+                    },
+
+                    // Post-Condition -- status remains Waiting for
+                    // Approval.
+                    {
+                        content: "Status is still Waiting for Approval",
+                        trigger:
+                            ".o_statusbar_status .o_arrow_button[data-value='confirm'].btn-primary",
+                        run: function () {
+                            // Assertion only.
+                        },
+                    },
+                ]
+            )
+        );
+
+        // IK: docs/school_student_graduation_batch/15-print.md
+        //
+        // Boundary (patterns.md §Q): see school_student_graduation_tour.js
+        // test_print for the same reasoning -- the tour only proves the
+        // wizard opens then closes it, without printing.
+        tour.register(
+            "ssi_school_student_graduation_school_student_graduation_batch_print",
+            {
+                test: true,
+                url: "/web",
+            },
+            [].concat(
+                // Flow 1 -- Open the Graduation Batches menu.
+                openBatchList(),
+                // Flow 2 -- Open the record to print.
+                openRecordByYear("TOUR SGB Print Year"),
+                [
+                    // Flow 3 -- Click Print in the header.
+                    {
+                        content: "Click the Print button",
+                        trigger:
+                            ".o_statusbar_buttons button:enabled:contains('Print')",
+                        extra_trigger: ".o_form_view",
+                    },
+
+                    // Flow 4/5 boundary -- the wizard is proven open, then
+                    // closed.
+                    {
+                        content: "The Select Report To Print wizard is displayed",
+                        trigger: ".modal-title:contains('Select Report To Print')",
+                        run: function () {
+                            // Assertion only.
+                        },
+                    },
+                    {
+                        content: "Close the wizard",
+                        trigger: ".modal-footer button[special='cancel']",
+                        in_modal: true,
+                    },
+
+                    // Post-Condition (tour boundary) -- the wizard is
+                    // closed and the record form is displayed again.
+                    {
+                        content: "Wizard is closed and the form is displayed again",
+                        trigger: ".o_form_view",
+                        extra_trigger: "body:not(:has(.modal))",
+                        run: function () {
+                            // Assertion only.
+                        },
+                    },
+                ]
+            )
+        );
+
+        // IK: docs/school_student_graduation_batch/16-reload-template-policy.md
+        //
+        // Boundary: same reasoning as school_student_graduation_tour.js
+        // test_reload_template_policy -- no dialog/notification signal;
+        // the tour only proves the button is reachable and clickable.
+        tour.register(
+            "ssi_school_student_graduation_school_student_graduation_batch_reload_template_policy",
+            {
+                test: true,
+                url: "/web",
+            },
+            [].concat(
+                // Flow 1 -- Open the Graduation Batches menu.
+                openBatchList(),
+                // Flow 2 -- Open the record whose assigned policy template
+                // should be re-evaluated.
+                openRecordByYear("TOUR SGB Reload Policy Year"),
+                [
+                    // Flow 3 -- On the Policies tab, click Reload Template
+                    // Policy.
+                    {
+                        content: "Open the Policies tab",
+                        trigger: ".o_notebook .nav-link:contains(Policies)",
+                    },
+                    {
+                        content: "Click the Reload Template Policy button",
+                        trigger:
+                            ".o_form_view button[name='action_reload_policy_template']:enabled",
+                    },
+
+                    // Post-Condition (tour boundary) -- the form survives
+                    // the click.
+                    {
+                        content: "Form is intact after the reload",
+                        trigger: "body:not(.o_ui_blocked)",
+                        extra_trigger:
+                            ".o_form_view button[name='action_reload_policy_template']:enabled",
+                        run: function () {
+                            // Assertion only.
+                        },
+                    },
+                ]
+            )
+        );
+    }
+);

--- a/ssi_school_student_graduation/static/tests/tours/school_student_graduation_batch_tour.js
+++ b/ssi_school_student_graduation/static/tests/tours/school_student_graduation_batch_tour.js
@@ -191,8 +191,15 @@ odoo.define(
                     },
                 ],
                 // Flow 3/4 -- Refill the Lines list from the current
-                // filters via Populate Eligible Students.
-                populateEligibleStudents("TOUR SGB Edit Eligible Student"),
+                // filters via Populate Eligible Students. The batch's
+                // Academic Year filter matches only "TOUR SGB Edit
+                // Student" (the one line student _create_batch built
+                // this record with in Python) -- a differently-scoped
+                // "eligible" student would never satisfy this
+                // batch's own Populate filter regardless of naming,
+                // see test_ui_school_student_graduation_batch.py
+                // setUpClass's 02-edit.md comment.
+                populateEligibleStudents("TOUR SGB Edit Student"),
                 [
                     // Flow 5 -- Click Save.
                     {

--- a/ssi_school_student_graduation/static/tests/tours/school_student_graduation_tour.js
+++ b/ssi_school_student_graduation/static/tests/tours/school_student_graduation_tour.js
@@ -1,0 +1,709 @@
+// Copyright 2026 OpenSynergy Indonesia
+// Copyright 2026 PT. Simetri Sinergi Indonesia
+// License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl).
+
+odoo.define("ssi_school_student_graduation.school_student_graduation_tour", function (
+    require
+) {
+    "use strict";
+
+    var tour = require("web_tour.tour");
+
+    // Shared navigation block reused by every tour below -- corresponds to
+    // Flow 1 of every school_student_graduation IK: "Open the School >
+    // Student Activities > Student Graduations menu."
+    function openGraduationList() {
+        return [
+            tour.stepUtils.showAppsMenuItem(),
+            {
+                content: "Open the School app",
+                trigger: '.o_app[data-menu-xmlid="ssi_school.menu_school_root"]',
+            },
+            {
+                content: "Open the Student Activities menu",
+                trigger:
+                    '.o_menu_sections [data-menu-xmlid="ssi_school.menu_school_student_activity"]',
+            },
+            {
+                content: "Open the Student Graduations menu",
+                trigger:
+                    '.o_menu_sections [data-menu-xmlid="ssi_school_student_graduation.school_student_graduation_menu"]',
+            },
+            {
+                // Gerbang: tunggu action TUJUAN benar-benar terpasang, bukan
+                // sekadar "ada list di layar" (patterns.md skill
+                // odoo-development-ui-test §A).
+                content: "Student Graduations list is displayed",
+                trigger:
+                    ".o_control_panel .breadcrumb-item.active:contains(Student Graduations)",
+                extra_trigger: ".o_list_view",
+                run: function () {
+                    // Assertion only; do not trigger the default click action.
+                },
+            },
+        ];
+    }
+
+    // Selects an option from an open many2one autocomplete dropdown.
+    function pickMany2one(fieldName, label) {
+        return [
+            {
+                content: "Select the " + fieldName + " field value",
+                trigger: ".o_field_many2one[name='" + fieldName + "'] input",
+                run: "text " + label,
+            },
+            {
+                content: "Pick " + label + " from the dropdown",
+                trigger: ".ui-autocomplete .ui-menu-item a:contains(" + label + ")",
+                in_modal: false,
+            },
+        ];
+    }
+
+    // Opens the record identified by the unique Student name shown on the
+    // list row (used as Pre-Condition test data marker).
+    function openRecordByStudent(studentName) {
+        return [
+            {
+                content: "Open the record",
+                trigger: ".o_data_row:contains(" + studentName + ") .o_data_cell:first",
+                extra_trigger: ".o_list_view",
+            },
+            {
+                content: "Form is open",
+                trigger: ".o_form_view",
+                run: function () {
+                    // Assertion only.
+                },
+            },
+        ];
+    }
+
+    // IK: docs/school_student_graduation/01-create.md
+    tour.register(
+        "ssi_school_student_graduation_school_student_graduation_create",
+        {
+            test: true,
+            url: "/web",
+        },
+        [].concat(
+            // Flow 1 -- Open the Student Graduations menu.
+            openGraduationList(),
+            [
+                // Flow 2 -- Click the New button. (14.0: "Create")
+                {
+                    content: "Click New",
+                    trigger: ".o_list_button_add",
+                    extra_trigger: ".o_list_view",
+                },
+                {
+                    content: "Form is open in edit mode",
+                    trigger: ".o_form_view.o_form_editable",
+                    run: function () {
+                        // Assertion only.
+                    },
+                },
+            ],
+            // Flow 3 -- Fill in the required field: Student. Active
+            // Enrollment / Academic Year / Academic Term are auto-filled,
+            // read-only, from the student -- not exercised by clicks here
+            // (their auto-fill value is unit test territory).
+            pickMany2one("student_id", "TOUR SG Create Student"),
+            [
+                // Flow 4 -- Click Save.
+                {
+                    content: "Save the record",
+                    trigger: ".o_form_button_save",
+                },
+
+                // Post-Condition -- a new record is created in Draft
+                // status.
+                {
+                    content: "Record is saved",
+                    trigger: ".o_form_view.o_form_readonly",
+                    run: function () {
+                        // Assertion only.
+                    },
+                },
+                {
+                    content: "Status is Draft",
+                    trigger:
+                        ".o_statusbar_status .o_arrow_button[data-value='draft'].btn-primary",
+                    run: function () {
+                        // Assertion only.
+                    },
+                },
+            ]
+        )
+    );
+
+    // IK: docs/school_student_graduation/02-edit.md
+    tour.register(
+        "ssi_school_student_graduation_school_student_graduation_edit",
+        {
+            test: true,
+            url: "/web",
+        },
+        [].concat(
+            // Flow 1 -- Open the Student Graduations menu.
+            openGraduationList(),
+            // Flow 2 -- Find and open the record to edit.
+            openRecordByStudent("TOUR SG Edit Student"),
+            [
+                // 14.0: a just-opened record is displayed read-only; an
+                // explicit Edit click is required before its fields become
+                // editable. This step is not itemized in 02-edit.md's Flow
+                // -- flagged as a minor IK gap in the task report (compare
+                // e.g. ssi_school school_student_mutation_tour.js, which
+                // documents the same 14.0 platform mechanic).
+                {
+                    content: "Click the Edit button",
+                    trigger: ".o_form_button_edit",
+                },
+                {
+                    content: "Form is now editable",
+                    trigger: ".o_form_view.o_form_editable",
+                    run: function () {
+                        // Assertion only.
+                    },
+                },
+            ],
+            // Flow 3 -- Change the required field (Student, from the
+            // initial student to a second eligible student).
+            pickMany2one("student_id", "TOUR SG Edit Target Student"),
+            [
+                // Flow 4 -- Click Save.
+                {
+                    content: "Save the record",
+                    trigger: ".o_form_button_save",
+                },
+
+                // Post-Condition -- the record is updated with the new
+                // values.
+                {
+                    content: "Record is saved",
+                    trigger: ".o_form_view.o_form_readonly",
+                    run: function () {
+                        // Assertion only.
+                    },
+                },
+            ]
+        )
+    );
+
+    // IK: docs/school_student_graduation/03-delete.md
+    tour.register(
+        "ssi_school_student_graduation_school_student_graduation_delete",
+        {
+            test: true,
+            url: "/web",
+        },
+        [].concat(
+            // Flow 1 -- Open the Student Graduations menu.
+            openGraduationList(),
+            [
+                // Flow 2 -- Select the record to delete (check the
+                // checkbox).
+                {
+                    content: "Check the record's selector checkbox",
+                    trigger:
+                        ".o_data_row:contains(TOUR SG Delete Student) .o_list_record_selector input",
+                },
+
+                // Flow 3 -- Click Action > Delete.
+                {
+                    content: "Open the Action menu",
+                    trigger: ".o_cp_action_menus button:contains(Action)",
+                },
+                {
+                    content: "Click Delete",
+                    // Item Action menu adalah komponen Owl; cocokkan LABEL
+                    // PERSIS -- :contains(Delete) sebagai substring bisa
+                    // keliru menunjuk item lain. Lihat patterns.md skill
+                    // odoo-development-ui-test §I.
+                    trigger: ".o_cp_action_menus .o_menu_item a",
+                    run: function () {
+                        var $delete = $(".o_cp_action_menus .o_menu_item a").filter(
+                            function () {
+                                return $(this).text().trim() === "Delete";
+                            }
+                        );
+                        $delete[0].click();
+                    },
+                },
+
+                // Flow 4 -- Click OK to confirm.
+                {
+                    content: "Confirm deletion",
+                    trigger: ".modal-footer button.btn-primary",
+                    in_modal: true,
+                },
+
+                // Post-Condition -- the selected records are permanently
+                // removed from the system.
+                {
+                    content: "Record no longer in the list",
+                    trigger:
+                        ".o_list_view:not(:has(.o_data_row:contains(TOUR SG Delete Student)))",
+                    run: function () {
+                        // Assertion only.
+                    },
+                },
+            ]
+        )
+    );
+
+    // IK: docs/school_student_graduation/04-confirm.md
+    tour.register(
+        "ssi_school_student_graduation_school_student_graduation_confirm",
+        {
+            test: true,
+            url: "/web",
+        },
+        [].concat(
+            // Flow 1 -- Open the Student Graduations menu.
+            openGraduationList(),
+            // Flow 2 -- Open the record to confirm.
+            openRecordByStudent("TOUR SG Confirm Student"),
+            [
+                // Flow 3 -- Click the Confirm button.
+                {
+                    content: "Click the Confirm button",
+                    trigger: ".o_statusbar_buttons button[name='action_confirm']",
+                    extra_trigger: ".o_form_view",
+                },
+
+                // Flow 4 -- Click OK on the confirmation dialog.
+                {
+                    content: "Confirm the dialog",
+                    trigger: ".modal-footer button.btn-primary",
+                    in_modal: true,
+                },
+
+                // Post-Condition -- status changes to Waiting for
+                // Approval.
+                {
+                    content: "Status is Waiting for Approval",
+                    trigger:
+                        ".o_statusbar_status .o_arrow_button[data-value='confirm'].btn-primary",
+                    run: function () {
+                        // Assertion only.
+                    },
+                },
+            ]
+        )
+    );
+
+    // IK: docs/school_student_graduation/05-approve.md
+    tour.register(
+        "ssi_school_student_graduation_school_student_graduation_approve",
+        {
+            test: true,
+            url: "/web",
+        },
+        [].concat(
+            // Flow 1 -- Open the Student Graduations menu.
+            openGraduationList(),
+            // Flow 2 -- Open the record to approve.
+            openRecordByStudent("TOUR SG Approve Student"),
+            [
+                // Flow 3 -- Click the Approve button.
+                {
+                    content: "Click the Approve button",
+                    trigger:
+                        ".o_statusbar_buttons button[name='action_approve_approval']",
+                    extra_trigger: ".o_form_view",
+                },
+
+                // Flow 4 -- Click OK on the confirmation dialog.
+                {
+                    content: "Confirm the dialog",
+                    trigger: ".modal-footer button.btn-primary",
+                    in_modal: true,
+                },
+
+                // Post-Condition -- the single approval level is fulfilled,
+                // so status changes automatically to Done (there is no
+                // separate manual Finish step for this model).
+                {
+                    content: "Status is Done",
+                    trigger:
+                        ".o_statusbar_status .o_arrow_button[data-value='done'].btn-primary",
+                    run: function () {
+                        // Assertion only.
+                    },
+                },
+            ]
+        )
+    );
+
+    // IK: docs/school_student_graduation/06-reject.md
+    tour.register(
+        "ssi_school_student_graduation_school_student_graduation_reject",
+        {
+            test: true,
+            url: "/web",
+        },
+        [].concat(
+            // Flow 1 -- Open the Student Graduations menu.
+            openGraduationList(),
+            // Flow 2 -- Open the record to reject.
+            openRecordByStudent("TOUR SG Reject Student"),
+            [
+                // Flow 3 -- Click the Reject button.
+                {
+                    content: "Click the Reject button",
+                    trigger:
+                        ".o_statusbar_buttons button[name='action_reject_approval']",
+                    extra_trigger: ".o_form_view",
+                },
+
+                // Flow 4 -- Click OK on the confirmation dialog.
+                {
+                    content: "Confirm the dialog",
+                    trigger: ".modal-footer button.btn-primary",
+                    in_modal: true,
+                },
+
+                // Post-Condition -- status changes to Rejected.
+                {
+                    content: "Status is Rejected",
+                    trigger:
+                        ".o_statusbar_status .o_arrow_button[data-value='reject'].btn-primary",
+                    run: function () {
+                        // Assertion only.
+                    },
+                },
+            ]
+        )
+    );
+
+    // IK: docs/school_student_graduation/10-cancel.md
+    tour.register(
+        "ssi_school_student_graduation_school_student_graduation_cancel",
+        {
+            test: true,
+            url: "/web",
+        },
+        [].concat(
+            // Flow 1 -- Open the Student Graduations menu.
+            openGraduationList(),
+            // Flow 2 -- Open the record to cancel.
+            openRecordByStudent("TOUR SG Cancel Student"),
+            [
+                // Flow 3 -- Click the Cancel button (opens the reason
+                // wizard; the rendered button name is a numeric action id,
+                // so match by label instead of button[name=...] -- the
+                // button is type="action", see selectors.md §4).
+                {
+                    content: "Click the Cancel button",
+                    trigger: ".o_statusbar_buttons button:enabled:contains('Cancel')",
+                    extra_trigger: ".o_form_view",
+                },
+                {
+                    // 14.0: JANGAN prefiks `.modal` -- trigger dicari DI
+                    // DALAM modal, jadi `.o_form_view` saja. Lihat
+                    // patterns.md skill odoo-development-ui-test §H.
+                    content: "Wizard is open",
+                    trigger: ".o_form_view",
+                    run: function () {
+                        // Assertion only.
+                    },
+                },
+
+                // Flow 4 -- In the wizard, select the Cancellation Reason
+                // (radio widget).
+                {
+                    content: "Select the cancellation reason",
+                    trigger:
+                        ".o_field_widget[name='cancel_reason_id'] " +
+                        ".o_radio_item:contains(TOUR SG Cancel Reason) input",
+                    run: "click",
+                },
+
+                // Flow 5 -- Click Confirm.
+                {
+                    content: "Confirm the wizard",
+                    trigger: ".modal-footer button[name='action_confirm']",
+                },
+
+                // Flow 6 -- Click OK on the confirmation dialog. The
+                // wizard's Confirm button itself carries a "Are you
+                // sure?" confirm attribute, stacking a second dialog on
+                // top.
+                {
+                    content: "Confirm the Are you sure? dialog",
+                    trigger: ".modal-footer button.btn-primary",
+                    in_modal: true,
+                },
+
+                // Post-Condition -- status changes to Cancelled.
+                {
+                    content: "Status is Cancelled",
+                    trigger:
+                        ".o_statusbar_status .o_arrow_button[data-value='cancel'].btn-primary",
+                    run: function () {
+                        // Assertion only.
+                    },
+                },
+            ]
+        )
+    );
+
+    // IK: docs/school_student_graduation/12-restart.md
+    tour.register(
+        "ssi_school_student_graduation_school_student_graduation_restart",
+        {
+            test: true,
+            url: "/web",
+        },
+        [].concat(
+            // Flow 1 -- Open the Student Graduations menu.
+            openGraduationList(),
+            // Flow 2 -- Open the record to restart.
+            openRecordByStudent("TOUR SG Restart Student"),
+            [
+                // Flow 3 -- Click the Restart button.
+                {
+                    content: "Click the Restart button",
+                    trigger: ".o_statusbar_buttons button[name='action_restart']",
+                    extra_trigger: ".o_form_view",
+                },
+
+                // Flow 4 -- Click OK on the confirmation dialog.
+                {
+                    content: "Confirm the dialog",
+                    trigger: ".modal-footer button.btn-primary",
+                    in_modal: true,
+                },
+
+                // Post-Condition -- status returns to Draft.
+                {
+                    content: "Status is Draft",
+                    trigger:
+                        ".o_statusbar_status .o_arrow_button[data-value='draft'].btn-primary",
+                    run: function () {
+                        // Assertion only.
+                    },
+                },
+            ]
+        )
+    );
+
+    // IK: docs/school_student_graduation/13-reset-number.md
+    tour.register(
+        "ssi_school_student_graduation_school_student_graduation_reset_number",
+        {
+            test: true,
+            url: "/web",
+        },
+        [].concat(
+            // Flow 1 -- Open the Student Graduations menu.
+            openGraduationList(),
+            // Flow 2 -- Open the record whose document number will be
+            // reset.
+            openRecordByStudent("TOUR SG Reset Number Student"),
+            [
+                // Flow 3 -- Click the Reset Document Number button.
+                {
+                    content: "Click the Reset Document Number button",
+                    trigger:
+                        ".o_statusbar_buttons button[name='action_reset_document_number']",
+                    extra_trigger: ".o_form_view",
+                },
+
+                // Flow 4 -- Click OK on the confirmation dialog.
+                {
+                    content: "Confirm the dialog",
+                    trigger: ".modal-footer button.btn-primary",
+                    in_modal: true,
+                },
+
+                // Post-Condition -- document number returns to "/". After
+                // the reset, the form re-renders read-only, so the visible
+                // field is "display_name"; name_get() renders "/" as
+                // "*<id>", which is the observable marker that the reset
+                // took effect.
+                {
+                    content: "Document number is reset (display name shows *)",
+                    trigger:
+                        ".oe_title .o_field_widget[name='display_name']:contains(*)",
+                    run: function () {
+                        // Assertion only.
+                    },
+                },
+            ]
+        )
+    );
+
+    // IK: docs/school_student_graduation/14-restart-approval.md
+    //
+    // Config Pre-Condition note: policy_template/school_student_graduation.xml
+    // does not ship a policy.template_detail granting restart_approval_ok
+    // (a policy field with no matching detail always defaults to False, so
+    // the button below would never render). The test file's setUpClass
+    // supplies that missing policy.template_detail directly as HttpCase
+    // setup data -- exactly the Config Pre-Condition this IK documents.
+    tour.register(
+        "ssi_school_student_graduation_school_student_graduation_restart_approval",
+        {
+            test: true,
+            url: "/web",
+        },
+        [].concat(
+            // Flow 1 -- Open the Student Graduations menu.
+            openGraduationList(),
+            // Flow 2 -- Open the record whose approval process is stalled.
+            openRecordByStudent("TOUR SG Restart Approval Student"),
+            [
+                // Flow 3 -- Click the Restart Approval Process button.
+                {
+                    content: "Click the Restart Approval Process button",
+                    trigger:
+                        ".o_statusbar_buttons button[name='action_reload_approval_template']",
+                    extra_trigger: ".o_form_view",
+                },
+
+                // Flow 4 -- Click OK on the confirmation dialog.
+                {
+                    content: "Confirm the dialog",
+                    trigger: ".modal-footer button.btn-primary",
+                    in_modal: true,
+                },
+
+                // Post-Condition -- status remains Waiting for Approval.
+                {
+                    content: "Status is still Waiting for Approval",
+                    trigger:
+                        ".o_statusbar_status .o_arrow_button[data-value='confirm'].btn-primary",
+                    run: function () {
+                        // Assertion only.
+                    },
+                },
+            ]
+        )
+    );
+
+    // IK: docs/school_student_graduation/15-print.md
+    //
+    // Boundary (patterns.md §Q): this tour only proves the Print button
+    // opens the "Select Report To Print" wizard, then closes it via
+    // Cancel. It never selects a report nor clicks the wizard's own Print
+    // button, because the resulting report action is an
+    // ir.actions.act_url download with no DOM "finished" signal --
+    // clicking through it could hang headless Chrome.
+    tour.register(
+        "ssi_school_student_graduation_school_student_graduation_print",
+        {
+            test: true,
+            url: "/web",
+        },
+        [].concat(
+            // Flow 1 -- Open the Student Graduations menu.
+            openGraduationList(),
+            // Flow 2 -- Open the record to print.
+            openRecordByStudent("TOUR SG Print Student"),
+            [
+                // Flow 3 -- Click Print in the header. The button is
+                // injected by ssi_print_mixin as type="action" -- its
+                // "name" attribute is a numeric action id resolved at
+                // render time, so it must be targeted by its visible
+                // label (selectors.md §4), not by [name=...].
+                {
+                    content: "Click the Print button",
+                    trigger: ".o_statusbar_buttons button:enabled:contains('Print')",
+                    extra_trigger: ".o_form_view",
+                },
+
+                // Flow 4/5 boundary -- the wizard is proven open, then
+                // closed. Selecting the Report Template and clicking the
+                // wizard's own Print button are intentionally NOT
+                // executed -- see the boundary note above.
+                //
+                // 14.0: do NOT prefix the trigger with ".modal" -- when a
+                // modal is displayed, web_tour scopes the search to
+                // $modal_displayed.find(trigger), and $modal_displayed
+                // already IS the ".modal" element (patterns.md §H box).
+                {
+                    content: "The Select Report To Print wizard is displayed",
+                    trigger: ".modal-title:contains('Select Report To Print')",
+                    run: function () {
+                        // Assertion only.
+                    },
+                },
+                {
+                    content: "Close the wizard",
+                    trigger: ".modal-footer button[special='cancel']",
+                    in_modal: true,
+                },
+
+                // Post-Condition (tour boundary) -- the wizard is closed
+                // and the record form is displayed again. Whether a
+                // report is actually generated and downloaded is out of
+                // tour scope.
+                {
+                    content: "Wizard is closed and the form is displayed again",
+                    trigger: ".o_form_view",
+                    extra_trigger: "body:not(:has(.modal))",
+                    run: function () {
+                        // Assertion only.
+                    },
+                },
+            ]
+        )
+    );
+
+    // IK: docs/school_student_graduation/16-reload-template-policy.md
+    //
+    // Boundary: action_reload_policy_template (ssi_policy_mixin) writes
+    // policy_template_id and returns nothing, so the client just re-reads
+    // the record -- there is no dialog, notification, or other kasatmata
+    // signal that distinguishes "reassigned" from "already was assigned".
+    // This tour therefore only proves the button is reachable on the
+    // Policies tab and clickable, and that the form survives the click
+    // without error; the actual re-assignment outcome is unit test
+    // territory (odoo-development-unit-test).
+    tour.register(
+        "ssi_school_student_graduation_school_student_graduation_reload_template_policy",
+        {
+            test: true,
+            url: "/web",
+        },
+        [].concat(
+            // Flow 1 -- Open the Student Graduations menu.
+            openGraduationList(),
+            // Flow 2 -- Open the record whose assigned policy template
+            // should be re-evaluated.
+            openRecordByStudent("TOUR SG Reload Policy Student"),
+            [
+                // Flow 3 -- On the Policies tab, click Reload Template
+                // Policy. The Policies tab itself is always visible; only
+                // the inner group holding this button is gated by
+                // base.group_system, which the tour's admin login holds
+                // by default.
+                {
+                    content: "Open the Policies tab",
+                    trigger: ".o_notebook .nav-link:contains(Policies)",
+                },
+                {
+                    content: "Click the Reload Template Policy button",
+                    trigger:
+                        ".o_form_view button[name='action_reload_policy_template']:enabled",
+                },
+
+                // Post-Condition (tour boundary) -- the form survives the
+                // click: the button is still visible and enabled once the
+                // client is done processing the reload.
+                {
+                    content: "Form is intact after the reload",
+                    trigger: "body:not(.o_ui_blocked)",
+                    extra_trigger:
+                        ".o_form_view button[name='action_reload_policy_template']:enabled",
+                    run: function () {
+                        // Assertion only.
+                    },
+                },
+            ]
+        )
+    );
+});

--- a/ssi_school_student_graduation/tests/__init__.py
+++ b/ssi_school_student_graduation/tests/__init__.py
@@ -5,4 +5,6 @@
 from . import (  # noqa: F401
     test_school_student_graduation,
     test_school_student_graduation_batch,
+    test_ui_school_student_graduation,
+    test_ui_school_student_graduation_batch,
 )

--- a/ssi_school_student_graduation/tests/test_ui_school_student_graduation.py
+++ b/ssi_school_student_graduation/tests/test_ui_school_student_graduation.py
@@ -1,0 +1,459 @@
+# Copyright 2026 OpenSynergy Indonesia
+# Copyright 2026 PT. Simetri Sinergi Indonesia
+# License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl).
+
+from odoo.tests import HttpSavepointCase, tagged
+
+
+@tagged("post_install", "-at_install")
+class TestUiSchoolStudentGraduation(HttpSavepointCase):
+    """Tour tests for the ``school_student_graduation`` work instructions."""
+
+    @classmethod
+    def setUpClass(cls):
+        """Create every Pre-Condition fixture required by the 12 tours.
+
+        Each tour gets its own isolated grade type / school / grade /
+        grade class / academic year & term / student, brought to the
+        Enrolled state via ``_create_open_enrollment``, so
+        state-changing tours (confirm, approve, reject, cancel,
+        restart, ...) never interfere with each other's data.
+        """
+        super().setUpClass()
+        cls.admin = cls.env.ref("base.user_admin")
+
+        # Config Pre-Condition shared by 10-cancel.md: a cancel reason
+        # usable on any model.
+        cls.cancel_reason = cls.env["base.cancel_reason"].create(
+            {
+                "name": "TOUR SG Cancel Reason",
+                "code": "TOUR-SG-CANCEL",
+                "global_use": True,
+            }
+        )
+
+        # Config Pre-Condition for 15-print.md: a print_document_type
+        # linking a report to school_student_graduation, so the
+        # "Select Report To Print" wizard has a report to offer. The
+        # tour itself never selects nor prints the report (see
+        # test_print docstring), so this report action is a
+        # placeholder that is never rendered.
+        cls.print_report_action = cls.env["ir.actions.report"].create(
+            {
+                "name": "TOUR Student Graduation Report",
+                "model": "school_student_graduation",
+                "report_type": "qweb-pdf",
+                "report_name": (
+                    "ssi_school_student_graduation."
+                    "tour_school_student_graduation_report"
+                ),
+            }
+        )
+        cls.env["print_document_type"].create(
+            {
+                "name": "TOUR SG Print Type",
+                "model_id": cls.env["ir.model"]._get_id("school_student_graduation"),
+                "report_ids": [(6, 0, [cls.print_report_action.id])],
+            }
+        )
+
+        # Config Pre-Condition for 14-restart-approval.md: the IK
+        # itself states that an active policy.template must grant
+        # restart_approval_ok for state "confirm" to the actor's
+        # group, but policy_template/school_student_graduation.xml
+        # does not ship that policy.template_detail (verified: no
+        # module data file in ssi_school_student_graduation grants
+        # restart_approval_ok for this model). Without it,
+        # restart_approval_ok always defaults to False
+        # (ssi_policy_mixin._prepare_policy_field_data leaves any
+        # policy field with no matching detail at False) and the
+        # "Restart Approval Process" button never renders. This is
+        # exactly the class of Config Pre-Condition the IK documents
+        # but the module does not ship by default, so it is supplied
+        # here as HttpCase setup data -- mirroring the declarative
+        # shape of the other <field>_ok details already shipped in
+        # policy_template/school_student_graduation.xml. The IK's
+        # Actor for this button is "User" (not "Validator"), so the
+        # group granted is school_student_graduation_user_group,
+        # matching the confirm_ok detail in that same file rather than
+        # the Validator-gated ones (cancel_ok, restart_ok,
+        # manual_number_ok).
+        policy_template = cls.env.ref(
+            "ssi_school_student_graduation.policy_template_school_student_graduation"
+        )
+        state_field = cls.env["ir.model.fields"].search(
+            [
+                ("model_id.model", "=", "school_student_graduation"),
+                ("name", "=", "state"),
+            ],
+            limit=1,
+        )
+        state_confirm = cls.env["ir.model.fields.selection"].search(
+            [
+                ("field_id", "=", state_field.id),
+                ("value", "=", "confirm"),
+            ],
+            limit=1,
+        )
+        restart_approval_field = cls.env["ir.model.fields"].search(
+            [
+                ("model_id.model", "=", "school_student_graduation"),
+                ("name", "=", "restart_approval_ok"),
+            ],
+            limit=1,
+        )
+        user_group = cls.env.ref(
+            "ssi_school_student_graduation.school_student_graduation_user_group"
+        )
+        cls.env["policy.template_detail"].create(
+            {
+                "template_id": policy_template.id,
+                "field_id": restart_approval_field.id,
+                "restrict_state": True,
+                "state_ids": [(6, 0, state_confirm.ids)],
+                "restrict_user": True,
+                "computation_method": "use_group",
+                "group_ids": [(6, 0, [user_group.id])],
+                "restrict_additional": False,
+            }
+        )
+
+        # 01-create.md -- no graduation record is pre-created; the
+        # create tour creates a new one. It only needs an Enrolled
+        # student to pick from the list.
+        cls._create_open_enrollment("CR", "Create")
+
+        # 02-edit.md -- Draft record on an initial student, plus a
+        # second Enrolled student the tour reassigns the record to.
+        data_ed = cls._create_open_enrollment("ED", "Edit")
+        cls._create_open_enrollment("EDT", "Edit Target")
+        cls.graduation_edit = cls._create_graduation(data_ed)
+
+        # 03-delete.md -- Draft record to delete.
+        data_dl = cls._create_open_enrollment("DL", "Delete")
+        cls.graduation_delete = cls._create_graduation(data_dl)
+
+        # 04-confirm.md -- Draft record to confirm.
+        data_co = cls._create_open_enrollment("CO", "Confirm")
+        cls.graduation_confirm = cls._create_graduation(data_co)
+
+        # 05-approve.md -- Waiting for Approval record to approve.
+        data_ap = cls._create_open_enrollment("AP", "Approve")
+        cls.graduation_approve = cls._create_graduation(data_ap)
+        cls.graduation_approve.with_user(cls.admin).action_confirm()
+
+        # 06-reject.md -- Waiting for Approval record to reject.
+        data_rj = cls._create_open_enrollment("RJ", "Reject")
+        cls.graduation_reject = cls._create_graduation(data_rj)
+        cls.graduation_reject.with_user(cls.admin).action_confirm()
+
+        # 10-cancel.md -- Waiting for Approval record to cancel.
+        data_cn = cls._create_open_enrollment("CN", "Cancel")
+        cls.graduation_cancel = cls._create_graduation(data_cn)
+        cls.graduation_cancel.with_user(cls.admin).action_confirm()
+
+        # 12-restart.md -- Cancelled record to restart.
+        data_rs = cls._create_open_enrollment("RS", "Restart")
+        cls.graduation_restart = cls._create_graduation(data_rs)
+        cls.graduation_restart.with_user(cls.admin).action_confirm()
+        cls.graduation_restart.with_user(cls.admin).action_cancel(cls.cancel_reason)
+
+        # 13-reset-number.md -- Draft record with a manually-set
+        # document number (the "name" field is editable in Draft
+        # status).
+        data_rn = cls._create_open_enrollment("RN", "Reset Number")
+        cls.graduation_reset_number = cls._create_graduation(data_rn)
+        cls.graduation_reset_number.write({"name": "TOUR-SG-MANUAL-001"})
+
+        # 14-restart-approval.md -- Waiting for Approval record whose
+        # approval process is stalled (no approval template assigned,
+        # existing approval records discarded), matching the IK's
+        # Pre-Condition literally. The restart_approval_ok policy
+        # detail created above supplies the Config Pre-Condition the
+        # IK requires, so the "Restart Approval Process" button
+        # renders for this record.
+        data_ra = cls._create_open_enrollment("RA", "Restart Approval")
+        cls.graduation_restart_approval = cls._create_graduation(data_ra)
+        cls.graduation_restart_approval.with_user(cls.admin).action_confirm()
+        cls.graduation_restart_approval.sudo().approval_ids.unlink()
+        cls.graduation_restart_approval.sudo().write({"approval_template_id": False})
+
+        # 15-print.md -- any state is usable per the IK; a fresh Draft
+        # record is enough.
+        data_pr = cls._create_open_enrollment("PR", "Print")
+        cls.graduation_print = cls._create_graduation(data_pr)
+
+        # 16-reload-template-policy.md -- any state is usable per the
+        # IK; a fresh Draft record is enough.
+        data_rt = cls._create_open_enrollment("RT", "Reload Policy")
+        cls.graduation_reload_template_policy = cls._create_graduation(data_rt)
+
+    @classmethod
+    def _create_open_enrollment(cls, suffix, label):
+        """Build one isolated grade/school/class/year/term/enrollment.
+
+        Brings a new Enrollment to Open status via Confirm + Approve
+        (run as ``base.user_admin``, who holds the Validator group so
+        the confirm_ok/approve_ok policy fields compute True), which
+        also moves the student to the "enrol" state via the
+        enrollment's post_open hook.
+
+        :param suffix: short unique code suffix for this fixture set.
+        :param label: action label (e.g. "Create", "Edit") used to
+            build the tour marker name "TOUR SG <label> Student",
+            kept in sync with the literals used by
+            school_student_graduation_tour.js.
+        :return: dict with the created records, keyed by role.
+        """
+        grade_type = cls.env["school_grade_type"].create(
+            {
+                "name": "TOUR SG Grade Type %s" % suffix,
+                "code": "GTSG%s" % suffix,
+                "sequence": 10,
+            }
+        )
+        school = cls.env["school"].create(
+            {
+                "name": "TOUR SG School %s" % suffix,
+                "code": "SCHSG%s" % suffix,
+                "grade_type_id": grade_type.id,
+            }
+        )
+        grade = cls.env["school_grade"].create(
+            {
+                "name": "TOUR SG Grade %s" % suffix,
+                "code": "GSG%s" % suffix,
+                "sequence": 10,
+                "type_id": grade_type.id,
+            }
+        )
+        grade_class = cls.env["school_grade_class"].create(
+            {
+                "name": "TOUR SG %s Class" % label,
+                "code": "CLSG%s" % suffix,
+                "school_id": school.id,
+                "grade_id": grade.id,
+                "capacity": 30,
+            }
+        )
+        year = cls.env["school_academic_year"].create(
+            {
+                "name": "TOUR SG Year %s" % suffix,
+                "code": "AYSG%s" % suffix,
+                "date_start": "2024-07-01",
+                "date_end": "2025-06-30",
+            }
+        )
+        term = cls.env["school_academic_term"].create(
+            {
+                "name": "TOUR SG Term %s" % suffix,
+                "code": "TMSG%s" % suffix,
+                "date_start": "2024-07-01",
+                "date_end": "2024-12-31",
+                "year_id": year.id,
+                "enrollment_state": "open",
+            }
+        )
+        student_name = "TOUR SG %s Student" % label
+        contact = cls.env["res.partner"].create({"name": "%s Contact" % student_name})
+        student = cls.env["school_student"].create(
+            {
+                "name": student_name,
+                "code": "STUSG%s" % suffix,
+                "contact_id": contact.id,
+                "school_id": school.id,
+            }
+        )
+        enrollment = cls.env["school_enrollment"].create(
+            {
+                "date": "2024-07-01",
+                "academic_year_id": year.id,
+                "academic_term_id": term.id,
+                "school_id": school.id,
+                "grade_id": grade.id,
+                "grade_class_id": grade_class.id,
+                "student_id": student.id,
+                "currency_id": cls.env.company.currency_id.id,
+            }
+        )
+        enrollment.with_user(cls.admin).action_confirm()
+        enrollment.invalidate_cache()
+        enrollment.with_user(cls.admin).action_approve_approval()
+        return {
+            "school": school,
+            "grade": grade,
+            "grade_class": grade_class,
+            "student": student,
+            "enrollment": enrollment,
+        }
+
+    @classmethod
+    def _create_graduation(cls, data):
+        """Create a Draft graduation for the student in ``data``.
+
+        :param data: dict returned by ``_create_open_enrollment``.
+        :return: the created ``school_student_graduation`` record.
+        """
+        return cls.env["school_student_graduation"].create(
+            {
+                "date": "2025-06-30",
+                "student_id": data["student"].id,
+                "graduation_date": "2025-06-30",
+            }
+        )
+
+    def test_create(self):
+        """Run the create tour for ``school_student_graduation``.
+
+        IK: docs/school_student_graduation/01-create.md
+        """
+        self.start_tour(
+            "/web",
+            "ssi_school_student_graduation_school_student_graduation_create",
+            login="admin",
+        )
+
+    def test_edit(self):
+        """Run the edit tour for ``school_student_graduation``.
+
+        IK: docs/school_student_graduation/02-edit.md
+        """
+        self.start_tour(
+            "/web",
+            "ssi_school_student_graduation_school_student_graduation_edit",
+            login="admin",
+        )
+
+    def test_delete(self):
+        """Run the delete tour for ``school_student_graduation``.
+
+        IK: docs/school_student_graduation/03-delete.md
+        """
+        self.start_tour(
+            "/web",
+            "ssi_school_student_graduation_school_student_graduation_delete",
+            login="admin",
+        )
+
+    def test_confirm(self):
+        """Run the confirm tour for ``school_student_graduation``.
+
+        IK: docs/school_student_graduation/04-confirm.md
+        """
+        self.start_tour(
+            "/web",
+            "ssi_school_student_graduation_school_student_graduation_confirm",
+            login="admin",
+        )
+
+    def test_approve(self):
+        """Run the approve tour for ``school_student_graduation``.
+
+        IK: docs/school_student_graduation/05-approve.md
+        """
+        self.start_tour(
+            "/web",
+            "ssi_school_student_graduation_school_student_graduation_approve",
+            login="admin",
+        )
+
+    def test_reject(self):
+        """Run the reject tour for ``school_student_graduation``.
+
+        IK: docs/school_student_graduation/06-reject.md
+        """
+        self.start_tour(
+            "/web",
+            "ssi_school_student_graduation_school_student_graduation_reject",
+            login="admin",
+        )
+
+    def test_cancel(self):
+        """Run the cancel tour for ``school_student_graduation``.
+
+        IK: docs/school_student_graduation/10-cancel.md
+        """
+        self.start_tour(
+            "/web",
+            "ssi_school_student_graduation_school_student_graduation_cancel",
+            login="admin",
+        )
+
+    def test_restart(self):
+        """Run the restart tour for ``school_student_graduation``.
+
+        IK: docs/school_student_graduation/12-restart.md
+        """
+        self.start_tour(
+            "/web",
+            "ssi_school_student_graduation_school_student_graduation_restart",
+            login="admin",
+        )
+
+    def test_reset_number(self):
+        """Run the reset document number tour.
+
+        IK: docs/school_student_graduation/13-reset-number.md
+        """
+        self.start_tour(
+            "/web",
+            "ssi_school_student_graduation_school_student_graduation_reset_number",
+            login="admin",
+        )
+
+    def test_restart_approval(self):
+        """Run the restart approval process tour.
+
+        IK: docs/school_student_graduation/14-restart-approval.md
+
+        Config Pre-Condition note: policy_template/school_student_
+        graduation.xml does not ship a policy.template_detail granting
+        restart_approval_ok, so this HttpCase's setUpClass supplies
+        that detail directly (as the IK's own Config Pre-Condition
+        requires), mirroring the declarative shape of the details
+        already shipped in that file. Without it the "Restart
+        Approval Process" button would never render for any user.
+        """
+        self.start_tour(
+            "/web",
+            "ssi_school_student_graduation_school_student_graduation_restart_approval",
+            login="admin",
+        )
+
+    def test_print(self):
+        """Assert the Print wizard opens then close it, without printing.
+
+        IK: docs/school_student_graduation/15-print.md
+
+        Boundary: the tour only proves the ``Select Report To Print``
+        wizard opens after clicking Print, then closes it via Cancel. It
+        never selects a report nor clicks the wizard's own Print button,
+        because the resulting report action is an ``ir.actions.act_url``
+        download with no DOM "finished" signal -- clicking through it
+        could hang headless Chrome. See patterns.md §Q.
+        """
+        self.start_tour(
+            "/web",
+            "ssi_school_student_graduation_school_student_graduation_print",
+            login="admin",
+        )
+
+    def test_reload_template_policy(self):
+        """Run the reload template policy tour.
+
+        IK: docs/school_student_graduation/16-reload-template-policy.md
+
+        Boundary: action_reload_policy_template returns nothing and
+        triggers no dialog, so the tour only proves the button on the
+        Policies tab is reachable and clickable, and that the form
+        survives the click without error. The actual template
+        re-assignment is unit test territory.
+        """
+        self.start_tour(
+            "/web",
+            (
+                "ssi_school_student_graduation_school_student_graduation_"
+                "reload_template_policy"
+            ),
+            login="admin",
+        )

--- a/ssi_school_student_graduation/tests/test_ui_school_student_graduation.py
+++ b/ssi_school_student_graduation/tests/test_ui_school_student_graduation.py
@@ -291,6 +291,14 @@ class TestUiSchoolStudentGraduation(HttpSavepointCase):
     def _create_graduation(cls, data):
         """Create a Draft graduation for the student in ``data``.
 
+        ``user_id`` is set explicitly to ``base.user_admin`` -- without
+        it, ``mixin.transaction._default_user_id`` defaults new
+        records to the superuser (``SavepointCase.setUpClass`` runs as
+        ``SUPERUSER_ID``), and the internal-user record rule
+        ``[('user_id', '=', user.id)]`` then hides the fixture from
+        the tour's "admin" session, so the list shows zero rows with
+        no error (verified in issue #227 / PR #250).
+
         :param data: dict returned by ``_create_open_enrollment``.
         :return: the created ``school_student_graduation`` record.
         """
@@ -299,6 +307,7 @@ class TestUiSchoolStudentGraduation(HttpSavepointCase):
                 "date": "2025-06-30",
                 "student_id": data["student"].id,
                 "graduation_date": "2025-06-30",
+                "user_id": cls.admin.id,
             }
         )
 

--- a/ssi_school_student_graduation/tests/test_ui_school_student_graduation_batch.py
+++ b/ssi_school_student_graduation/tests/test_ui_school_student_graduation_batch.py
@@ -111,14 +111,22 @@ class TestUiSchoolStudentGraduationBatch(HttpSavepointCase):
         # it.
         cls._create_eligible_student("CR", "Create Eligible")
 
-        # 02-edit.md -- Draft batch to edit, plus its own eligible
-        # student for the re-populate step. Uses a distinct suffix
-        # ("EB") from the "Edit Eligible" fixture above ("ED") --
-        # _create_batch calls _create_eligible_student internally
-        # with this same suffix, and reusing "ED" here collided on
-        # every master data "code" field (school_grade_type,
-        # school, ...), raising a "Duplicate code" UserError.
-        cls._create_eligible_student("ED", "Edit Eligible")
+        # 02-edit.md -- Draft batch to edit. No separate "eligible
+        # student" fixture is created here: _get_eligible_student_
+        # criteria only restricts by active_enrollment_id.
+        # academic_year_id when the batch's own academic_year_id is
+        # set, and _create_batch already sets it to the Academic Year
+        # of the one line student it creates internally ("TOUR SGB
+        # Edit Student", suffix "EB" -- distinct from "01-create"'s
+        # "CR" suffix to avoid the "Duplicate code" collision on
+        # shared master data codes like school_grade_type). That
+        # student is therefore itself the only record guaranteed to
+        # match this batch's Populate filter, so the tour re-populate
+        # step (school_student_graduation_batch_tour.js test_edit)
+        # asserts on "TOUR SGB Edit Student" reappearing after
+        # Populate -- a standalone student tied to a different
+        # Academic Year would never match this batch's filter and was
+        # never actually eligible for it, regardless of naming.
         cls.batch_edit = cls._create_batch("EB", "Edit")
 
         # 03-delete.md -- Draft batch to delete.

--- a/ssi_school_student_graduation/tests/test_ui_school_student_graduation_batch.py
+++ b/ssi_school_student_graduation/tests/test_ui_school_student_graduation_batch.py
@@ -112,9 +112,14 @@ class TestUiSchoolStudentGraduationBatch(HttpSavepointCase):
         cls._create_eligible_student("CR", "Create Eligible")
 
         # 02-edit.md -- Draft batch to edit, plus its own eligible
-        # student for the re-populate step.
+        # student for the re-populate step. Uses a distinct suffix
+        # ("EB") from the "Edit Eligible" fixture above ("ED") --
+        # _create_batch calls _create_eligible_student internally
+        # with this same suffix, and reusing "ED" here collided on
+        # every master data "code" field (school_grade_type,
+        # school, ...), raising a "Duplicate code" UserError.
         cls._create_eligible_student("ED", "Edit Eligible")
-        cls.batch_edit = cls._create_batch("ED", "Edit")
+        cls.batch_edit = cls._create_batch("EB", "Edit")
 
         # 03-delete.md -- Draft batch to delete.
         cls.batch_delete = cls._create_batch("DL", "Delete")
@@ -256,7 +261,11 @@ class TestUiSchoolStudentGraduationBatch(HttpSavepointCase):
         Academic Year ("TOUR SGB <label> Year") so the tour can find
         the record's row in the list, and one line is added manually
         (not via Populate) so the "at least one student line exists"
-        Pre-Condition holds for 04-confirm onward.
+        Pre-Condition holds for 04-confirm onward. ``user_id`` is set
+        explicitly to ``base.user_admin`` -- see the docstring note in
+        ``TestUiSchoolStudentGraduation._create_graduation`` for why
+        this is required for the tour's "admin" session to see the
+        record at all.
 
         :param suffix: short unique code suffix for this fixture set.
         :param label: label used to build the batch's tour marker
@@ -274,6 +283,7 @@ class TestUiSchoolStudentGraduationBatch(HttpSavepointCase):
                 "date": "2025-06-30",
                 "academic_year_id": year.id,
                 "line_ids": [(0, 0, {"student_id": student.id})],
+                "user_id": cls.admin.id,
             }
         )
 

--- a/ssi_school_student_graduation/tests/test_ui_school_student_graduation_batch.py
+++ b/ssi_school_student_graduation/tests/test_ui_school_student_graduation_batch.py
@@ -1,0 +1,434 @@
+# Copyright 2026 OpenSynergy Indonesia
+# Copyright 2026 PT. Simetri Sinergi Indonesia
+# License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl).
+
+from odoo.tests import HttpSavepointCase, tagged
+
+
+@tagged("post_install", "-at_install")
+class TestUiSchoolStudentGraduationBatch(HttpSavepointCase):
+    """Tour tests for the ``school_student_graduation_batch`` IK."""
+
+    @classmethod
+    def setUpClass(cls):
+        """Create every Pre-Condition fixture required by the 12 tours.
+
+        Each state-changing tour (confirm, approve, reject, cancel,
+        restart, ...) gets its own batch record, marked by a
+        uniquely-named Academic Year set on ``academic_year_id`` (used
+        as the list-row search marker, since the batch itself has no
+        free-text field of its own), plus one manually-added line so
+        the "at least one student line exists" Pre-Condition holds.
+        The create/edit tours instead rely on freshly-created eligible
+        students (Enrolled, no Next Grade) that the Populate Eligible
+        Students inline action discovers at runtime.
+        """
+        super().setUpClass()
+        cls.admin = cls.env.ref("base.user_admin")
+
+        # Config Pre-Condition shared by 10-cancel.md: a cancel reason
+        # usable on any model.
+        cls.cancel_reason = cls.env["base.cancel_reason"].create(
+            {
+                "name": "TOUR SGB Cancel Reason",
+                "code": "TOUR-SGB-CANCEL",
+                "global_use": True,
+            }
+        )
+
+        # Config Pre-Condition for 15-print.md.
+        cls.print_report_action = cls.env["ir.actions.report"].create(
+            {
+                "name": "TOUR Student Graduation Batch Report",
+                "model": "school_student_graduation_batch",
+                "report_type": "qweb-pdf",
+                "report_name": (
+                    "ssi_school_student_graduation."
+                    "tour_school_student_graduation_batch_report"
+                ),
+            }
+        )
+        cls.env["print_document_type"].create(
+            {
+                "name": "TOUR SGB Print Type",
+                "model_id": cls.env["ir.model"]._get_id(
+                    "school_student_graduation_batch"
+                ),
+                "report_ids": [(6, 0, [cls.print_report_action.id])],
+            }
+        )
+
+        # Config Pre-Condition for 14-restart-approval.md -- same
+        # reasoning as TestUiSchoolStudentGraduation.setUpClass:
+        # policy_template/school_student_graduation_batch.xml does not
+        # ship a policy.template_detail granting restart_approval_ok,
+        # so it is supplied here directly.
+        policy_template = cls.env.ref(
+            "ssi_school_student_graduation."
+            "policy_template_school_student_graduation_batch"
+        )
+        state_field = cls.env["ir.model.fields"].search(
+            [
+                ("model_id.model", "=", "school_student_graduation_batch"),
+                ("name", "=", "state"),
+            ],
+            limit=1,
+        )
+        state_confirm = cls.env["ir.model.fields.selection"].search(
+            [
+                ("field_id", "=", state_field.id),
+                ("value", "=", "confirm"),
+            ],
+            limit=1,
+        )
+        restart_approval_field = cls.env["ir.model.fields"].search(
+            [
+                ("model_id.model", "=", "school_student_graduation_batch"),
+                ("name", "=", "restart_approval_ok"),
+            ],
+            limit=1,
+        )
+        user_group = cls.env.ref(
+            "ssi_school_student_graduation."
+            "school_student_graduation_batch_user_group"
+        )
+        cls.env["policy.template_detail"].create(
+            {
+                "template_id": policy_template.id,
+                "field_id": restart_approval_field.id,
+                "restrict_state": True,
+                "state_ids": [(6, 0, state_confirm.ids)],
+                "restrict_user": True,
+                "computation_method": "use_group",
+                "group_ids": [(6, 0, [user_group.id])],
+                "restrict_additional": False,
+            }
+        )
+
+        # 01-create.md -- no batch record is pre-created; the create
+        # tour creates one and populates it. Only an eligible student
+        # (Enrolled, no Next Grade) needs to exist so Populate finds
+        # it.
+        cls._create_eligible_student("CR", "Create Eligible")
+
+        # 02-edit.md -- Draft batch to edit, plus its own eligible
+        # student for the re-populate step.
+        cls._create_eligible_student("ED", "Edit Eligible")
+        cls.batch_edit = cls._create_batch("ED", "Edit")
+
+        # 03-delete.md -- Draft batch to delete.
+        cls.batch_delete = cls._create_batch("DL", "Delete")
+
+        # 04-confirm.md -- Draft batch (with one line) to confirm.
+        cls.batch_confirm = cls._create_batch("CO", "Confirm")
+
+        # 05-approve.md -- Waiting for Approval batch to approve.
+        cls.batch_approve = cls._create_batch("AP", "Approve")
+        cls.batch_approve.with_user(cls.admin).action_confirm()
+
+        # 06-reject.md -- Waiting for Approval batch to reject.
+        cls.batch_reject = cls._create_batch("RJ", "Reject")
+        cls.batch_reject.with_user(cls.admin).action_confirm()
+
+        # 10-cancel.md -- Waiting for Approval batch to cancel.
+        cls.batch_cancel = cls._create_batch("CN", "Cancel")
+        cls.batch_cancel.with_user(cls.admin).action_confirm()
+
+        # 12-restart.md -- Cancelled batch to restart.
+        cls.batch_restart = cls._create_batch("RS", "Restart")
+        cls.batch_restart.with_user(cls.admin).action_confirm()
+        cls.batch_restart.with_user(cls.admin).action_cancel(cls.cancel_reason)
+
+        # 13-reset-number.md -- Draft batch with a manually-set
+        # document number.
+        cls.batch_reset_number = cls._create_batch("RN", "Reset Number")
+        cls.batch_reset_number.write({"name": "TOUR-SGB-MANUAL-001"})
+
+        # 14-restart-approval.md -- Waiting for Approval batch whose
+        # approval process is stalled.
+        cls.batch_restart_approval = cls._create_batch("RA", "Restart Approval")
+        cls.batch_restart_approval.with_user(cls.admin).action_confirm()
+        cls.batch_restart_approval.sudo().approval_ids.unlink()
+        cls.batch_restart_approval.sudo().write({"approval_template_id": False})
+
+        # 15-print.md -- any state is usable per the IK; a fresh Draft
+        # batch is enough.
+        cls.batch_print = cls._create_batch("PR", "Print")
+
+        # 16-reload-template-policy.md -- any state is usable per the
+        # IK; a fresh Draft batch is enough.
+        cls.batch_reload_template_policy = cls._create_batch("RT", "Reload Policy")
+
+    @classmethod
+    def _create_eligible_student(cls, suffix, label):
+        """Build one Enrolled student eligible for ``action_populate_lines``.
+
+        Creates an isolated grade type / school / grade / grade class
+        / academic year & term, then a student brought to the
+        Enrolled state with no Next Grade set.
+
+        :param suffix: short unique code suffix for this fixture set.
+        :param label: label used to build the student's tour marker
+            name "TOUR SGB <label> Student".
+        :return: the created ``school_student`` record.
+        """
+        grade_type = cls.env["school_grade_type"].create(
+            {
+                "name": "TOUR SGB Grade Type %s" % suffix,
+                "code": "GTSGB%s" % suffix,
+                "sequence": 10,
+            }
+        )
+        school = cls.env["school"].create(
+            {
+                "name": "TOUR SGB School %s" % suffix,
+                "code": "SCHSGB%s" % suffix,
+                "grade_type_id": grade_type.id,
+            }
+        )
+        grade = cls.env["school_grade"].create(
+            {
+                "name": "TOUR SGB Grade %s" % suffix,
+                "code": "GSGB%s" % suffix,
+                "sequence": 10,
+                "type_id": grade_type.id,
+            }
+        )
+        grade_class = cls.env["school_grade_class"].create(
+            {
+                "name": "TOUR SGB %s Class" % label,
+                "code": "CLSGB%s" % suffix,
+                "school_id": school.id,
+                "grade_id": grade.id,
+                "capacity": 30,
+            }
+        )
+        year = cls.env["school_academic_year"].create(
+            {
+                "name": "TOUR SGB %s Year" % label,
+                "code": "AYSGB%s" % suffix,
+                "date_start": "2024-07-01",
+                "date_end": "2025-06-30",
+            }
+        )
+        term = cls.env["school_academic_term"].create(
+            {
+                "name": "TOUR SGB Term %s" % suffix,
+                "code": "TMSGB%s" % suffix,
+                "date_start": "2024-07-01",
+                "date_end": "2024-12-31",
+                "year_id": year.id,
+                "enrollment_state": "open",
+            }
+        )
+        student_name = "TOUR SGB %s Student" % label
+        contact = cls.env["res.partner"].create({"name": "%s Contact" % student_name})
+        student = cls.env["school_student"].create(
+            {
+                "name": student_name,
+                "code": "STUSGB%s" % suffix,
+                "contact_id": contact.id,
+                "school_id": school.id,
+            }
+        )
+        enrollment = cls.env["school_enrollment"].create(
+            {
+                "date": "2024-07-01",
+                "academic_year_id": year.id,
+                "academic_term_id": term.id,
+                "school_id": school.id,
+                "grade_id": grade.id,
+                "grade_class_id": grade_class.id,
+                "student_id": student.id,
+                "currency_id": cls.env.company.currency_id.id,
+            }
+        )
+        enrollment.with_user(cls.admin).action_confirm()
+        enrollment.invalidate_cache()
+        enrollment.with_user(cls.admin).action_approve_approval()
+        return student
+
+    @classmethod
+    def _create_batch(cls, suffix, label):
+        """Create a Draft batch for state-changing tours.
+
+        The batch's ``academic_year_id`` is set to a uniquely-named
+        Academic Year ("TOUR SGB <label> Year") so the tour can find
+        the record's row in the list, and one line is added manually
+        (not via Populate) so the "at least one student line exists"
+        Pre-Condition holds for 04-confirm onward.
+
+        :param suffix: short unique code suffix for this fixture set.
+        :param label: label used to build the batch's tour marker
+            year name and the line student's name.
+        :return: the created ``school_student_graduation_batch``
+            record.
+        """
+        student = cls._create_eligible_student(suffix, label)
+        year = cls.env["school_academic_year"].search(
+            [("name", "=", "TOUR SGB %s Year" % label)],
+            limit=1,
+        )
+        return cls.env["school_student_graduation_batch"].create(
+            {
+                "date": "2025-06-30",
+                "academic_year_id": year.id,
+                "line_ids": [(0, 0, {"student_id": student.id})],
+            }
+        )
+
+    def test_create(self):
+        """Run the create tour for ``school_student_graduation_batch``.
+
+        IK: docs/school_student_graduation_batch/01-create.md
+        """
+        self.start_tour(
+            "/web",
+            "ssi_school_student_graduation_school_student_graduation_batch_create",
+            login="admin",
+        )
+
+    def test_edit(self):
+        """Run the edit tour for ``school_student_graduation_batch``.
+
+        IK: docs/school_student_graduation_batch/02-edit.md
+        """
+        self.start_tour(
+            "/web",
+            "ssi_school_student_graduation_school_student_graduation_batch_edit",
+            login="admin",
+        )
+
+    def test_delete(self):
+        """Run the delete tour for ``school_student_graduation_batch``.
+
+        IK: docs/school_student_graduation_batch/03-delete.md
+        """
+        self.start_tour(
+            "/web",
+            "ssi_school_student_graduation_school_student_graduation_batch_delete",
+            login="admin",
+        )
+
+    def test_confirm(self):
+        """Run the confirm tour for ``school_student_graduation_batch``.
+
+        IK: docs/school_student_graduation_batch/04-confirm.md
+        """
+        self.start_tour(
+            "/web",
+            "ssi_school_student_graduation_school_student_graduation_batch_confirm",
+            login="admin",
+        )
+
+    def test_approve(self):
+        """Run the approve tour for ``school_student_graduation_batch``.
+
+        IK: docs/school_student_graduation_batch/05-approve.md
+        """
+        self.start_tour(
+            "/web",
+            "ssi_school_student_graduation_school_student_graduation_batch_approve",
+            login="admin",
+        )
+
+    def test_reject(self):
+        """Run the reject tour for ``school_student_graduation_batch``.
+
+        IK: docs/school_student_graduation_batch/06-reject.md
+        """
+        self.start_tour(
+            "/web",
+            "ssi_school_student_graduation_school_student_graduation_batch_reject",
+            login="admin",
+        )
+
+    def test_cancel(self):
+        """Run the cancel tour for ``school_student_graduation_batch``.
+
+        IK: docs/school_student_graduation_batch/10-cancel.md
+        """
+        self.start_tour(
+            "/web",
+            "ssi_school_student_graduation_school_student_graduation_batch_cancel",
+            login="admin",
+        )
+
+    def test_restart(self):
+        """Run the restart tour for ``school_student_graduation_batch``.
+
+        IK: docs/school_student_graduation_batch/12-restart.md
+        """
+        self.start_tour(
+            "/web",
+            "ssi_school_student_graduation_school_student_graduation_batch_restart",
+            login="admin",
+        )
+
+    def test_reset_number(self):
+        """Run the reset document number tour.
+
+        IK: docs/school_student_graduation_batch/13-reset-number.md
+        """
+        self.start_tour(
+            "/web",
+            (
+                "ssi_school_student_graduation_school_student_graduation_"
+                "batch_reset_number"
+            ),
+            login="admin",
+        )
+
+    def test_restart_approval(self):
+        """Run the restart approval process tour.
+
+        IK: docs/school_student_graduation_batch/14-restart-approval.md
+
+        Config Pre-Condition note: same reasoning as
+        TestUiSchoolStudentGraduation.test_restart_approval -- this
+        HttpCase's setUpClass supplies the missing
+        restart_approval_ok policy.template_detail directly.
+        """
+        self.start_tour(
+            "/web",
+            (
+                "ssi_school_student_graduation_school_student_graduation_"
+                "batch_restart_approval"
+            ),
+            login="admin",
+        )
+
+    def test_print(self):
+        """Assert the Print wizard opens then close it, without printing.
+
+        IK: docs/school_student_graduation_batch/15-print.md
+
+        Boundary: same reasoning as
+        TestUiSchoolStudentGraduation.test_print -- the resulting
+        report action is an ``ir.actions.act_url`` download with no
+        DOM "finished" signal.
+        """
+        self.start_tour(
+            "/web",
+            "ssi_school_student_graduation_school_student_graduation_batch_print",
+            login="admin",
+        )
+
+    def test_reload_template_policy(self):
+        """Run the reload template policy tour.
+
+        IK: docs/school_student_graduation_batch/16-reload-template-policy.md
+
+        Boundary: action_reload_policy_template returns nothing and
+        triggers no dialog; the tour only proves the button on the
+        Policies tab is reachable and clickable, and that the form
+        survives the click without error.
+        """
+        self.start_tour(
+            "/web",
+            (
+                "ssi_school_student_graduation_school_student_graduation_"
+                "batch_reload_template_policy"
+            ),
+            login="admin",
+        )

--- a/ssi_school_student_graduation/views/assets.xml
+++ b/ssi_school_student_graduation/views/assets.xml
@@ -1,0 +1,22 @@
+<?xml version="1.0" encoding="utf-8" ?>
+<!-- Copyright 2026 OpenSynergy Indonesia
+     Copyright 2026 PT. Simetri Sinergi Indonesia
+     License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl). -->
+<odoo>
+    <template
+        id="assets_tests"
+        name="ssi_school_student_graduation assets tests"
+        inherit_id="web.assets_tests"
+    >
+        <xpath expr="." position="inside">
+            <script
+                type="text/javascript"
+                src="/ssi_school_student_graduation/static/tests/tours/school_student_graduation_tour.js"
+            />
+            <script
+                type="text/javascript"
+                src="/ssi_school_student_graduation/static/tests/tours/school_student_graduation_batch_tour.js"
+            />
+        </xpath>
+    </template>
+</odoo>

--- a/ssi_school_student_leave/__manifest__.py
+++ b/ssi_school_student_leave/__manifest__.py
@@ -28,5 +28,6 @@
         "approval_template/school_student_leave.xml",
         "policy_template/school_student_leave.xml",
         "views/school_student_leave.xml",
+        "views/assets.xml",
     ],
 }

--- a/ssi_school_student_leave/static/tests/tours/school_student_leave_tour.js
+++ b/ssi_school_student_leave/static/tests/tours/school_student_leave_tour.js
@@ -1,0 +1,705 @@
+// Copyright 2026 OpenSynergy Indonesia
+// Copyright 2026 PT. Simetri Sinergi Indonesia
+// License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl).
+
+odoo.define("ssi_school_student_leave.school_student_leave_tour", function (require) {
+    "use strict";
+
+    var tour = require("web_tour.tour");
+
+    // Shared navigation block reused by every tour below -- corresponds to
+    // Flow 1 of every school_student_leave IK: "Open the School > Student
+    // Activities > Student Leaves menu."
+    function openLeaveList() {
+        return [
+            tour.stepUtils.showAppsMenuItem(),
+            {
+                content: "Open the School app",
+                trigger: '.o_app[data-menu-xmlid="ssi_school.menu_school_root"]',
+            },
+            {
+                content: "Open the Student Activities menu",
+                trigger:
+                    '.o_menu_sections [data-menu-xmlid="ssi_school.menu_school_student_activity"]',
+            },
+            {
+                content: "Open the Student Leaves menu",
+                trigger:
+                    '.o_menu_sections [data-menu-xmlid="ssi_school_student_leave.school_student_leave_menu"]',
+            },
+            {
+                // Gerbang: tunggu action TUJUAN benar-benar terpasang, bukan
+                // sekadar "ada list di layar" (patterns.md skill
+                // odoo-development-ui-test §A).
+                content: "Student Leaves list is displayed",
+                trigger:
+                    ".o_control_panel .breadcrumb-item.active:contains(Student Leaves)",
+                extra_trigger: ".o_list_view",
+                run: function () {
+                    // Assertion only; do not trigger the default click action.
+                },
+            },
+        ];
+    }
+
+    // Selects an option from an open many2one autocomplete dropdown.
+    function pickMany2one(fieldName, label) {
+        return [
+            {
+                content: "Select the " + fieldName + " field value",
+                trigger: ".o_field_many2one[name='" + fieldName + "'] input",
+                run: "text " + label,
+            },
+            {
+                content: "Pick " + label + " from the dropdown",
+                trigger: ".ui-autocomplete .ui-menu-item a:contains(" + label + ")",
+                in_modal: false,
+            },
+        ];
+    }
+
+    // Opens the record identified by the unique Student name shown on the
+    // list row (used as Pre-Condition test data marker).
+    function openRecordByStudent(studentName) {
+        return [
+            {
+                content: "Open the record",
+                trigger: ".o_data_row:contains(" + studentName + ") .o_data_cell:first",
+                extra_trigger: ".o_list_view",
+            },
+            {
+                content: "Form is open",
+                trigger: ".o_form_view",
+                run: function () {
+                    // Assertion only.
+                },
+            },
+        ];
+    }
+
+    // IK: docs/school_student_leave/01-create.md
+    tour.register(
+        "ssi_school_student_leave_school_student_leave_create",
+        {
+            test: true,
+            url: "/web",
+        },
+        [].concat(
+            // Flow 1 -- Open the Student Leaves menu.
+            openLeaveList(),
+            [
+                // Flow 2 -- Click the New button. (14.0: "Create")
+                {
+                    content: "Click New",
+                    trigger: ".o_list_button_add",
+                    extra_trigger: ".o_list_view",
+                },
+                {
+                    content: "Form is open in edit mode",
+                    trigger: ".o_form_view.o_form_editable",
+                    run: function () {
+                        // Assertion only.
+                    },
+                },
+            ],
+            // Flow 3 -- Fill in the required field: Student. Active
+            // Enrollment is auto-filled, read-only, from the student.
+            pickMany2one("student_id", "TOUR SL Create Student"),
+            // Flow 3 -- Fill in the required field: Academic Term.
+            pickMany2one("academic_term_id", "TOUR SL Create Term"),
+            [
+                // Flow 4 -- Click Save.
+                {
+                    content: "Save the record",
+                    trigger: ".o_form_button_save",
+                },
+
+                // Post-Condition -- a new record is created in Draft
+                // status.
+                {
+                    content: "Record is saved",
+                    trigger: ".o_form_view.o_form_readonly",
+                    run: function () {
+                        // Assertion only.
+                    },
+                },
+                {
+                    content: "Status is Draft",
+                    trigger:
+                        ".o_statusbar_status .o_arrow_button[data-value='draft'].btn-primary",
+                    run: function () {
+                        // Assertion only.
+                    },
+                },
+            ]
+        )
+    );
+
+    // IK: docs/school_student_leave/02-edit.md
+    tour.register(
+        "ssi_school_student_leave_school_student_leave_edit",
+        {
+            test: true,
+            url: "/web",
+        },
+        [].concat(
+            // Flow 1 -- Open the Student Leaves menu.
+            openLeaveList(),
+            // Flow 2 -- Find and open the record to edit.
+            openRecordByStudent("TOUR SL Edit Student"),
+            [
+                // 14.0: a just-opened record is displayed read-only; an
+                // explicit Edit click is required before its fields become
+                // editable. Not itemized in 02-edit.md's Flow -- same
+                // documented 14.0 platform mechanic as
+                // school_student_mutation_tour.js test_edit.
+                {
+                    content: "Click the Edit button",
+                    trigger: ".o_form_button_edit",
+                },
+                {
+                    content: "Form is now editable",
+                    trigger: ".o_form_view.o_form_editable",
+                    run: function () {
+                        // Assertion only.
+                    },
+                },
+            ],
+            // Flow 3 -- Change the required field (Academic Term, from
+            // the initial term to a second one).
+            pickMany2one("academic_term_id", "TOUR SL Edit Target Term"),
+            [
+                // Flow 4 -- Click Save.
+                {
+                    content: "Save the record",
+                    trigger: ".o_form_button_save",
+                },
+
+                // Post-Condition -- the record is updated with the new
+                // values.
+                {
+                    content: "Record is saved",
+                    trigger: ".o_form_view.o_form_readonly",
+                    run: function () {
+                        // Assertion only.
+                    },
+                },
+            ]
+        )
+    );
+
+    // IK: docs/school_student_leave/03-delete.md
+    tour.register(
+        "ssi_school_student_leave_school_student_leave_delete",
+        {
+            test: true,
+            url: "/web",
+        },
+        [].concat(
+            // Flow 1 -- Open the Student Leaves menu.
+            openLeaveList(),
+            [
+                // Flow 2 -- Select the record to delete (check the
+                // checkbox).
+                {
+                    content: "Check the record's selector checkbox",
+                    trigger:
+                        ".o_data_row:contains(TOUR SL Delete Student) .o_list_record_selector input",
+                },
+
+                // Flow 3 -- Click Action > Delete.
+                {
+                    content: "Open the Action menu",
+                    trigger: ".o_cp_action_menus button:contains(Action)",
+                },
+                {
+                    content: "Click Delete",
+                    trigger: ".o_cp_action_menus .o_menu_item a",
+                    run: function () {
+                        var $delete = $(".o_cp_action_menus .o_menu_item a").filter(
+                            function () {
+                                return $(this).text().trim() === "Delete";
+                            }
+                        );
+                        $delete[0].click();
+                    },
+                },
+
+                // Flow 4 -- Click OK to confirm.
+                {
+                    content: "Confirm deletion",
+                    trigger: ".modal-footer button.btn-primary",
+                    in_modal: true,
+                },
+
+                // Post-Condition -- the selected records are permanently
+                // removed from the system.
+                {
+                    content: "Record no longer in the list",
+                    trigger:
+                        ".o_list_view:not(:has(.o_data_row:contains(TOUR SL Delete Student)))",
+                    run: function () {
+                        // Assertion only.
+                    },
+                },
+            ]
+        )
+    );
+
+    // IK: docs/school_student_leave/04-confirm.md
+    tour.register(
+        "ssi_school_student_leave_school_student_leave_confirm",
+        {
+            test: true,
+            url: "/web",
+        },
+        [].concat(
+            // Flow 1 -- Open the Student Leaves menu.
+            openLeaveList(),
+            // Flow 2 -- Open the record to confirm.
+            openRecordByStudent("TOUR SL Confirm Student"),
+            [
+                // Flow 3 -- Click the Confirm button.
+                {
+                    content: "Click the Confirm button",
+                    trigger: ".o_statusbar_buttons button[name='action_confirm']",
+                    extra_trigger: ".o_form_view",
+                },
+
+                // Flow 4 -- Click OK on the confirmation dialog.
+                {
+                    content: "Confirm the dialog",
+                    trigger: ".modal-footer button.btn-primary",
+                    in_modal: true,
+                },
+
+                // Post-Condition -- status changes to Waiting for
+                // Approval.
+                {
+                    content: "Status is Waiting for Approval",
+                    trigger:
+                        ".o_statusbar_status .o_arrow_button[data-value='confirm'].btn-primary",
+                    run: function () {
+                        // Assertion only.
+                    },
+                },
+            ]
+        )
+    );
+
+    // IK: docs/school_student_leave/05-approve.md
+    tour.register(
+        "ssi_school_student_leave_school_student_leave_approve",
+        {
+            test: true,
+            url: "/web",
+        },
+        [].concat(
+            // Flow 1 -- Open the Student Leaves menu.
+            openLeaveList(),
+            // Flow 2 -- Open the record to approve.
+            openRecordByStudent("TOUR SL Approve Student"),
+            [
+                // Flow 3 -- Click the Approve button.
+                {
+                    content: "Click the Approve button",
+                    trigger:
+                        ".o_statusbar_buttons button[name='action_approve_approval']",
+                    extra_trigger: ".o_form_view",
+                },
+
+                // Flow 4 -- Click OK on the confirmation dialog.
+                {
+                    content: "Confirm the dialog",
+                    trigger: ".modal-footer button.btn-primary",
+                    in_modal: true,
+                },
+
+                // Post-Condition -- the single approval level is fulfilled,
+                // so status changes automatically to Done (there is no
+                // separate manual Finish step for this model).
+                {
+                    content: "Status is Done",
+                    trigger:
+                        ".o_statusbar_status .o_arrow_button[data-value='done'].btn-primary",
+                    run: function () {
+                        // Assertion only.
+                    },
+                },
+            ]
+        )
+    );
+
+    // IK: docs/school_student_leave/06-reject.md
+    tour.register(
+        "ssi_school_student_leave_school_student_leave_reject",
+        {
+            test: true,
+            url: "/web",
+        },
+        [].concat(
+            // Flow 1 -- Open the Student Leaves menu.
+            openLeaveList(),
+            // Flow 2 -- Open the record to reject.
+            openRecordByStudent("TOUR SL Reject Student"),
+            [
+                // Flow 3 -- Click the Reject button.
+                {
+                    content: "Click the Reject button",
+                    trigger:
+                        ".o_statusbar_buttons button[name='action_reject_approval']",
+                    extra_trigger: ".o_form_view",
+                },
+
+                // Flow 4 -- Click OK on the confirmation dialog.
+                {
+                    content: "Confirm the dialog",
+                    trigger: ".modal-footer button.btn-primary",
+                    in_modal: true,
+                },
+
+                // Post-Condition -- status changes to Rejected.
+                {
+                    content: "Status is Rejected",
+                    trigger:
+                        ".o_statusbar_status .o_arrow_button[data-value='reject'].btn-primary",
+                    run: function () {
+                        // Assertion only.
+                    },
+                },
+            ]
+        )
+    );
+
+    // IK: docs/school_student_leave/10-cancel.md
+    tour.register(
+        "ssi_school_student_leave_school_student_leave_cancel",
+        {
+            test: true,
+            url: "/web",
+        },
+        [].concat(
+            // Flow 1 -- Open the Student Leaves menu.
+            openLeaveList(),
+            // Flow 2 -- Open the record to cancel.
+            openRecordByStudent("TOUR SL Cancel Student"),
+            [
+                // Flow 3 -- Click the Cancel button.
+                {
+                    content: "Click the Cancel button",
+                    trigger: ".o_statusbar_buttons button:enabled:contains('Cancel')",
+                    extra_trigger: ".o_form_view",
+                },
+                {
+                    content: "Wizard is open",
+                    trigger: ".o_form_view",
+                    run: function () {
+                        // Assertion only.
+                    },
+                },
+
+                // Flow 4 -- In the wizard, select the Cancellation Reason
+                // (radio widget).
+                {
+                    content: "Select the cancellation reason",
+                    trigger:
+                        ".o_field_widget[name='cancel_reason_id'] " +
+                        ".o_radio_item:contains(TOUR SL Cancel Reason) input",
+                    run: "click",
+                },
+
+                // Flow 5 -- Click Confirm.
+                {
+                    content: "Confirm the wizard",
+                    trigger: ".modal-footer button[name='action_confirm']",
+                },
+
+                // Flow 6 -- Click OK on the confirmation dialog.
+                {
+                    content: "Confirm the Are you sure? dialog",
+                    trigger: ".modal-footer button.btn-primary",
+                    in_modal: true,
+                },
+
+                // Post-Condition -- status changes to Cancelled.
+                {
+                    content: "Status is Cancelled",
+                    trigger:
+                        ".o_statusbar_status .o_arrow_button[data-value='cancel'].btn-primary",
+                    run: function () {
+                        // Assertion only.
+                    },
+                },
+            ]
+        )
+    );
+
+    // IK: docs/school_student_leave/12-restart.md
+    tour.register(
+        "ssi_school_student_leave_school_student_leave_restart",
+        {
+            test: true,
+            url: "/web",
+        },
+        [].concat(
+            // Flow 1 -- Open the Student Leaves menu.
+            openLeaveList(),
+            // Flow 2 -- Open the record to restart.
+            openRecordByStudent("TOUR SL Restart Student"),
+            [
+                // Flow 3 -- Click the Restart button.
+                {
+                    content: "Click the Restart button",
+                    trigger: ".o_statusbar_buttons button[name='action_restart']",
+                    extra_trigger: ".o_form_view",
+                },
+
+                // Flow 4 -- Click OK on the confirmation dialog.
+                {
+                    content: "Confirm the dialog",
+                    trigger: ".modal-footer button.btn-primary",
+                    in_modal: true,
+                },
+
+                // Post-Condition -- status returns to Draft.
+                {
+                    content: "Status is Draft",
+                    trigger:
+                        ".o_statusbar_status .o_arrow_button[data-value='draft'].btn-primary",
+                    run: function () {
+                        // Assertion only.
+                    },
+                },
+            ]
+        )
+    );
+
+    // IK: docs/school_student_leave/13-reset-number.md
+    tour.register(
+        "ssi_school_student_leave_school_student_leave_reset_number",
+        {
+            test: true,
+            url: "/web",
+        },
+        [].concat(
+            // Flow 1 -- Open the Student Leaves menu.
+            openLeaveList(),
+            // Flow 2 -- Open the record whose document number will be
+            // reset.
+            openRecordByStudent("TOUR SL Reset Number Student"),
+            [
+                // Flow 3 -- Click the Reset Document Number button.
+                {
+                    content: "Click the Reset Document Number button",
+                    trigger:
+                        ".o_statusbar_buttons button[name='action_reset_document_number']",
+                    extra_trigger: ".o_form_view",
+                },
+
+                // Flow 4 -- Click OK on the confirmation dialog.
+                {
+                    content: "Confirm the dialog",
+                    trigger: ".modal-footer button.btn-primary",
+                    in_modal: true,
+                },
+
+                // Post-Condition -- document number returns to "/".
+                {
+                    content: "Document number is reset (display name shows *)",
+                    trigger:
+                        ".oe_title .o_field_widget[name='display_name']:contains(*)",
+                    run: function () {
+                        // Assertion only.
+                    },
+                },
+            ]
+        )
+    );
+
+    // IK: docs/school_student_leave/14-restart-approval.md
+    //
+    // Config Pre-Condition note: policy_template/school_student_leave.xml
+    // does not ship a policy.template_detail granting restart_approval_ok,
+    // so the test file's setUpClass supplies it directly.
+    tour.register(
+        "ssi_school_student_leave_school_student_leave_restart_approval",
+        {
+            test: true,
+            url: "/web",
+        },
+        [].concat(
+            // Flow 1 -- Open the Student Leaves menu.
+            openLeaveList(),
+            // Flow 2 -- Open the record whose approval process is stalled.
+            openRecordByStudent("TOUR SL Restart Approval Student"),
+            [
+                // Flow 3 -- Click the Restart Approval Process button.
+                {
+                    content: "Click the Restart Approval Process button",
+                    trigger:
+                        ".o_statusbar_buttons button[name='action_reload_approval_template']",
+                    extra_trigger: ".o_form_view",
+                },
+
+                // Flow 4 -- Click OK on the confirmation dialog.
+                {
+                    content: "Confirm the dialog",
+                    trigger: ".modal-footer button.btn-primary",
+                    in_modal: true,
+                },
+
+                // Post-Condition -- status remains Waiting for Approval.
+                {
+                    content: "Status is still Waiting for Approval",
+                    trigger:
+                        ".o_statusbar_status .o_arrow_button[data-value='confirm'].btn-primary",
+                    run: function () {
+                        // Assertion only.
+                    },
+                },
+            ]
+        )
+    );
+
+    // IK: docs/school_student_leave/15-return.md
+    //
+    // Note: unlike confirm/approve/reject/cancel/restart/restart-approval,
+    // clicking Return does NOT show a confirmation dialog (the button has
+    // no confirm attribute in the view), and this leave document's own
+    // status is not changed -- only the student's state, which is unit
+    // test territory. This tour therefore stops at proving the button is
+    // clickable and the form survives the click.
+    tour.register(
+        "ssi_school_student_leave_school_student_leave_return",
+        {
+            test: true,
+            url: "/web",
+        },
+        [].concat(
+            // Flow 1 -- Open the Student Leaves menu.
+            openLeaveList(),
+            // Flow 2 -- Open the Done record whose student is currently
+            // On Leave.
+            openRecordByStudent("TOUR SL Return Student"),
+            [
+                // Flow 3 -- Click the Return button.
+                {
+                    content: "Click the Return button",
+                    trigger: ".o_statusbar_buttons button[name='action_return']",
+                    extra_trigger: ".o_form_view",
+                },
+
+                // Post-Condition (tour boundary) -- no dialog appears; the
+                // student's state changes, but that is unit test
+                // territory. The tour proves the form survives the click
+                // and the document status remains Done.
+                {
+                    content: "Form is intact and status is still Done",
+                    trigger:
+                        ".o_statusbar_status .o_arrow_button[data-value='done'].btn-primary",
+                    extra_trigger: "body:not(.o_ui_blocked)",
+                    run: function () {
+                        // Assertion only.
+                    },
+                },
+            ]
+        )
+    );
+
+    // IK: docs/school_student_leave/16-print.md
+    //
+    // Boundary (patterns.md §Q): same reasoning as
+    // school_student_mutation_tour.js test_print -- the tour only proves
+    // the wizard opens then closes it, without printing.
+    tour.register(
+        "ssi_school_student_leave_school_student_leave_print",
+        {
+            test: true,
+            url: "/web",
+        },
+        [].concat(
+            // Flow 1 -- Open the Student Leaves menu.
+            openLeaveList(),
+            // Flow 2 -- Open the record to print.
+            openRecordByStudent("TOUR SL Print Student"),
+            [
+                // Flow 3 -- Click Print in the header.
+                {
+                    content: "Click the Print button",
+                    trigger: ".o_statusbar_buttons button:enabled:contains('Print')",
+                    extra_trigger: ".o_form_view",
+                },
+
+                // Flow 4/5 boundary -- the wizard is proven open, then
+                // closed.
+                {
+                    content: "The Select Report To Print wizard is displayed",
+                    trigger: ".modal-title:contains('Select Report To Print')",
+                    run: function () {
+                        // Assertion only.
+                    },
+                },
+                {
+                    content: "Close the wizard",
+                    trigger: ".modal-footer button[special='cancel']",
+                    in_modal: true,
+                },
+
+                // Post-Condition (tour boundary) -- the wizard is closed
+                // and the record form is displayed again.
+                {
+                    content: "Wizard is closed and the form is displayed again",
+                    trigger: ".o_form_view",
+                    extra_trigger: "body:not(:has(.modal))",
+                    run: function () {
+                        // Assertion only.
+                    },
+                },
+            ]
+        )
+    );
+
+    // IK: docs/school_student_leave/17-reload-template-policy.md
+    //
+    // Boundary: same reasoning as school_student_mutation_tour.js
+    // test_reload_template_policy -- no dialog/notification signal.
+    tour.register(
+        "ssi_school_student_leave_school_student_leave_reload_template_policy",
+        {
+            test: true,
+            url: "/web",
+        },
+        [].concat(
+            // Flow 1 -- Open the Student Leaves menu.
+            openLeaveList(),
+            // Flow 2 -- Open the record whose assigned policy template
+            // should be re-evaluated.
+            openRecordByStudent("TOUR SL Reload Policy Student"),
+            [
+                // Flow 3 -- On the Policies tab, click Reload Template
+                // Policy.
+                {
+                    content: "Open the Policies tab",
+                    trigger: ".o_notebook .nav-link:contains(Policies)",
+                },
+                {
+                    content: "Click the Reload Template Policy button",
+                    trigger:
+                        ".o_form_view button[name='action_reload_policy_template']:enabled",
+                },
+
+                // Post-Condition (tour boundary) -- the form survives the
+                // click.
+                {
+                    content: "Form is intact after the reload",
+                    trigger: "body:not(.o_ui_blocked)",
+                    extra_trigger:
+                        ".o_form_view button[name='action_reload_policy_template']:enabled",
+                    run: function () {
+                        // Assertion only.
+                    },
+                },
+            ]
+        )
+    );
+});

--- a/ssi_school_student_leave/tests/__init__.py
+++ b/ssi_school_student_leave/tests/__init__.py
@@ -4,4 +4,5 @@
 
 from . import (  # noqa: F401
     test_school_student_leave,
+    test_ui_school_student_leave,
 )

--- a/ssi_school_student_leave/tests/test_ui_school_student_leave.py
+++ b/ssi_school_student_leave/tests/test_ui_school_student_leave.py
@@ -170,10 +170,24 @@ class TestUiSchoolStudentLeave(HttpSavepointCase):
         cls.leave_restart_approval.sudo().write({"approval_template_id": False})
 
         # 15-return.md -- Done record whose student is currently On
-        # Leave.
+        # Leave. Unlike every other fixture above, this is the only
+        # one that drives both Confirm AND Approve from Python in the
+        # same setUpClass (every other state-changing tour only needs
+        # Confirm here and lets the tour itself click Approve in the
+        # browser, where each click is a fresh HTTP request with its
+        # own cache). Chaining both calls on the same in-process
+        # recordset needs an explicit invalidate_cache() between them
+        # -- the same requirement documented on
+        # ``_create_open_enrollment``'s enrollment.action_confirm() /
+        # invalidate_cache() / action_approve_approval() sequence --
+        # otherwise the policy_template_school_student_leave_approve
+        # detail's additional_python_code reads a stale (pre-approval-
+        # record) ``document.active_approver_user_ids`` and raises
+        # "Document is not allowed to approve".
         data_rt = cls._create_open_enrollment("RT", "Return")
         cls.leave_return = cls._create_leave(data_rt)
         cls.leave_return.with_user(cls.admin).action_confirm()
+        cls.leave_return.invalidate_cache()
         cls.leave_return.with_user(cls.admin).action_approve_approval()
         cls.leave_return.invalidate_cache()
         assert cls.leave_return.state == "done"
@@ -295,6 +309,12 @@ class TestUiSchoolStudentLeave(HttpSavepointCase):
     def _create_leave(cls, data):
         """Create a Draft leave for the student/term in ``data``.
 
+        ``user_id`` is set explicitly to ``base.user_admin`` -- see
+        the docstring note in
+        ``TestUiSchoolStudentGraduation._create_graduation``
+        (ssi_school_student_graduation) for why this is required for
+        the tour's "admin" session to see the record at all.
+
         :param data: dict returned by ``_create_open_enrollment``.
         :return: the created ``school_student_leave`` record.
         """
@@ -303,6 +323,7 @@ class TestUiSchoolStudentLeave(HttpSavepointCase):
                 "date": "2024-08-01",
                 "student_id": data["student"].id,
                 "academic_term_id": data["term"].id,
+                "user_id": cls.admin.id,
             }
         )
 

--- a/ssi_school_student_leave/tests/test_ui_school_student_leave.py
+++ b/ssi_school_student_leave/tests/test_ui_school_student_leave.py
@@ -1,0 +1,470 @@
+# Copyright 2026 OpenSynergy Indonesia
+# Copyright 2026 PT. Simetri Sinergi Indonesia
+# License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl).
+
+from odoo.tests import HttpSavepointCase, tagged
+
+
+@tagged("post_install", "-at_install")
+class TestUiSchoolStudentLeave(HttpSavepointCase):
+    """Tour tests for the ``school_student_leave`` work instructions."""
+
+    @classmethod
+    def setUpClass(cls):
+        """Create every Pre-Condition fixture required by the 13 tours.
+
+        Each tour gets its own isolated grade type / school / grade /
+        grade class / academic year & term(s) / student, brought to
+        the Enrolled state via ``_create_open_enrollment``, so
+        state-changing tours (confirm, approve, reject, cancel,
+        restart, return, ...) never interfere with each other's data.
+        """
+        super().setUpClass()
+        cls.admin = cls.env.ref("base.user_admin")
+
+        # Config Pre-Condition shared by 10-cancel.md: a cancel reason
+        # usable on any model.
+        cls.cancel_reason = cls.env["base.cancel_reason"].create(
+            {
+                "name": "TOUR SL Cancel Reason",
+                "code": "TOUR-SL-CANCEL",
+                "global_use": True,
+            }
+        )
+
+        # Config Pre-Condition for 16-print.md.
+        cls.print_report_action = cls.env["ir.actions.report"].create(
+            {
+                "name": "TOUR Student Leave Report",
+                "model": "school_student_leave",
+                "report_type": "qweb-pdf",
+                "report_name": (
+                    "ssi_school_student_leave.tour_school_student_leave_report"
+                ),
+            }
+        )
+        cls.env["print_document_type"].create(
+            {
+                "name": "TOUR SL Print Type",
+                "model_id": cls.env["ir.model"]._get_id("school_student_leave"),
+                "report_ids": [(6, 0, [cls.print_report_action.id])],
+            }
+        )
+
+        # Config Pre-Condition for 14-restart-approval.md -- same
+        # reasoning as ssi_school's test_ui_school_student_mutation.py:
+        # policy_template/school_student_leave.xml does not ship a
+        # policy.template_detail granting restart_approval_ok, so it
+        # is supplied here directly.
+        policy_template = cls.env.ref(
+            "ssi_school_student_leave.policy_template_school_student_leave"
+        )
+        state_field = cls.env["ir.model.fields"].search(
+            [
+                ("model_id.model", "=", "school_student_leave"),
+                ("name", "=", "state"),
+            ],
+            limit=1,
+        )
+        state_confirm = cls.env["ir.model.fields.selection"].search(
+            [
+                ("field_id", "=", state_field.id),
+                ("value", "=", "confirm"),
+            ],
+            limit=1,
+        )
+        restart_approval_field = cls.env["ir.model.fields"].search(
+            [
+                ("model_id.model", "=", "school_student_leave"),
+                ("name", "=", "restart_approval_ok"),
+            ],
+            limit=1,
+        )
+        user_group = cls.env.ref(
+            "ssi_school_student_leave.school_student_leave_user_group"
+        )
+        cls.env["policy.template_detail"].create(
+            {
+                "template_id": policy_template.id,
+                "field_id": restart_approval_field.id,
+                "restrict_state": True,
+                "state_ids": [(6, 0, state_confirm.ids)],
+                "restrict_user": True,
+                "computation_method": "use_group",
+                "group_ids": [(6, 0, [user_group.id])],
+                "restrict_additional": False,
+            }
+        )
+
+        # 01-create.md -- no leave record is pre-created; the create
+        # tour creates a new one. It needs an Enrolled student and a
+        # second academic term to pick from the list.
+        data_cr = cls._create_open_enrollment("CR", "Create")
+        cls.term_create_target = cls.env["school_academic_term"].create(
+            {
+                "name": "TOUR SL Create Term",
+                "code": "TMSLCR2",
+                "date_start": "2025-01-01",
+                "date_end": "2025-06-30",
+                "year_id": data_cr["year"].id,
+                "enrollment_state": "open",
+            }
+        )
+
+        # 02-edit.md -- Draft record to edit, plus a second Academic
+        # Term the tour switches to.
+        data_ed = cls._create_open_enrollment("ED", "Edit")
+        cls.term_edit_target = cls.env["school_academic_term"].create(
+            {
+                "name": "TOUR SL Edit Target Term",
+                "code": "TMSLED2",
+                "date_start": "2025-01-01",
+                "date_end": "2025-06-30",
+                "year_id": data_ed["year"].id,
+                "enrollment_state": "open",
+            }
+        )
+        cls.leave_edit = cls._create_leave(data_ed)
+
+        # 03-delete.md -- Draft record to delete.
+        data_dl = cls._create_open_enrollment("DL", "Delete")
+        cls.leave_delete = cls._create_leave(data_dl)
+
+        # 04-confirm.md -- Draft record to confirm.
+        data_co = cls._create_open_enrollment("CO", "Confirm")
+        cls.leave_confirm = cls._create_leave(data_co)
+
+        # 05-approve.md -- Waiting for Approval record to approve.
+        data_ap = cls._create_open_enrollment("AP", "Approve")
+        cls.leave_approve = cls._create_leave(data_ap)
+        cls.leave_approve.with_user(cls.admin).action_confirm()
+
+        # 06-reject.md -- Waiting for Approval record to reject.
+        data_rj = cls._create_open_enrollment("RJ", "Reject")
+        cls.leave_reject = cls._create_leave(data_rj)
+        cls.leave_reject.with_user(cls.admin).action_confirm()
+
+        # 10-cancel.md -- Waiting for Approval record to cancel.
+        data_cn = cls._create_open_enrollment("CN", "Cancel")
+        cls.leave_cancel = cls._create_leave(data_cn)
+        cls.leave_cancel.with_user(cls.admin).action_confirm()
+
+        # 12-restart.md -- Cancelled record to restart.
+        data_rs = cls._create_open_enrollment("RS", "Restart")
+        cls.leave_restart = cls._create_leave(data_rs)
+        cls.leave_restart.with_user(cls.admin).action_confirm()
+        cls.leave_restart.with_user(cls.admin).action_cancel(cls.cancel_reason)
+
+        # 13-reset-number.md -- Draft record with a manually-set
+        # document number.
+        data_rn = cls._create_open_enrollment("RN", "Reset Number")
+        cls.leave_reset_number = cls._create_leave(data_rn)
+        cls.leave_reset_number.write({"name": "TOUR-SL-MANUAL-001"})
+
+        # 14-restart-approval.md -- Waiting for Approval record whose
+        # approval process is stalled.
+        data_ra = cls._create_open_enrollment("RA", "Restart Approval")
+        cls.leave_restart_approval = cls._create_leave(data_ra)
+        cls.leave_restart_approval.with_user(cls.admin).action_confirm()
+        cls.leave_restart_approval.sudo().approval_ids.unlink()
+        cls.leave_restart_approval.sudo().write({"approval_template_id": False})
+
+        # 15-return.md -- Done record whose student is currently On
+        # Leave.
+        data_rt = cls._create_open_enrollment("RT", "Return")
+        cls.leave_return = cls._create_leave(data_rt)
+        cls.leave_return.with_user(cls.admin).action_confirm()
+        cls.leave_return.with_user(cls.admin).action_approve_approval()
+        cls.leave_return.invalidate_cache()
+        assert cls.leave_return.state == "done"
+        data_rt["student"].invalidate_cache()
+        assert data_rt["student"].state == "on_leave"
+
+        # 16-print.md -- any state is usable per the IK; a fresh Draft
+        # record is enough.
+        data_pr = cls._create_open_enrollment("PR", "Print")
+        cls.leave_print = cls._create_leave(data_pr)
+
+        # 17-reload-template-policy.md -- any state is usable per the
+        # IK; a fresh Draft record is enough.
+        data_rp = cls._create_open_enrollment("RP", "Reload Policy")
+        cls.leave_reload_template_policy = cls._create_leave(data_rp)
+
+    @classmethod
+    def _create_open_enrollment(cls, suffix, label):
+        """Build one isolated grade/school/class/year/term/enrollment.
+
+        Brings a new Enrollment to Open status via Confirm + Approve
+        (run as ``base.user_admin``, who holds the Validator group so
+        the confirm_ok/approve_ok policy fields compute True), which
+        also moves the student to the "enrol" state via the
+        enrollment's post_open hook.
+
+        :param suffix: short unique code suffix for this fixture set.
+        :param label: action label (e.g. "Create", "Edit") used to
+            build the tour marker names "TOUR SL <label> Student" /
+            "TOUR SL <label> Term", kept in sync with the literals
+            used by school_student_leave_tour.js.
+        :return: dict with the created records, keyed by role.
+        """
+        grade_type = cls.env["school_grade_type"].create(
+            {
+                "name": "TOUR SL Grade Type %s" % suffix,
+                "code": "GTSL%s" % suffix,
+                "sequence": 10,
+            }
+        )
+        school = cls.env["school"].create(
+            {
+                "name": "TOUR SL School %s" % suffix,
+                "code": "SCHSL%s" % suffix,
+                "grade_type_id": grade_type.id,
+            }
+        )
+        grade = cls.env["school_grade"].create(
+            {
+                "name": "TOUR SL Grade %s" % suffix,
+                "code": "GSL%s" % suffix,
+                "sequence": 10,
+                "type_id": grade_type.id,
+            }
+        )
+        grade_class = cls.env["school_grade_class"].create(
+            {
+                "name": "TOUR SL %s Class" % label,
+                "code": "CLSL%s" % suffix,
+                "school_id": school.id,
+                "grade_id": grade.id,
+                "capacity": 30,
+            }
+        )
+        year = cls.env["school_academic_year"].create(
+            {
+                "name": "TOUR SL Year %s" % suffix,
+                "code": "AYSL%s" % suffix,
+                "date_start": "2024-07-01",
+                "date_end": "2025-06-30",
+            }
+        )
+        term = cls.env["school_academic_term"].create(
+            {
+                "name": "TOUR SL %s Term" % label,
+                "code": "TMSL%s" % suffix,
+                "date_start": "2024-07-01",
+                "date_end": "2024-12-31",
+                "year_id": year.id,
+                "enrollment_state": "open",
+            }
+        )
+        student_name = "TOUR SL %s Student" % label
+        contact = cls.env["res.partner"].create({"name": "%s Contact" % student_name})
+        student = cls.env["school_student"].create(
+            {
+                "name": student_name,
+                "code": "STUSL%s" % suffix,
+                "contact_id": contact.id,
+                "school_id": school.id,
+            }
+        )
+        enrollment = cls.env["school_enrollment"].create(
+            {
+                "date": "2024-07-01",
+                "academic_year_id": year.id,
+                "academic_term_id": term.id,
+                "school_id": school.id,
+                "grade_id": grade.id,
+                "grade_class_id": grade_class.id,
+                "student_id": student.id,
+                "currency_id": cls.env.company.currency_id.id,
+            }
+        )
+        enrollment.with_user(cls.admin).action_confirm()
+        enrollment.invalidate_cache()
+        enrollment.with_user(cls.admin).action_approve_approval()
+        return {
+            "school": school,
+            "grade": grade,
+            "grade_class": grade_class,
+            "year": year,
+            "term": term,
+            "student": student,
+            "enrollment": enrollment,
+        }
+
+    @classmethod
+    def _create_leave(cls, data):
+        """Create a Draft leave for the student/term in ``data``.
+
+        :param data: dict returned by ``_create_open_enrollment``.
+        :return: the created ``school_student_leave`` record.
+        """
+        return cls.env["school_student_leave"].create(
+            {
+                "date": "2024-08-01",
+                "student_id": data["student"].id,
+                "academic_term_id": data["term"].id,
+            }
+        )
+
+    def test_create(self):
+        """Run the create tour for ``school_student_leave``.
+
+        IK: docs/school_student_leave/01-create.md
+        """
+        self.start_tour(
+            "/web",
+            "ssi_school_student_leave_school_student_leave_create",
+            login="admin",
+        )
+
+    def test_edit(self):
+        """Run the edit tour for ``school_student_leave``.
+
+        IK: docs/school_student_leave/02-edit.md
+        """
+        self.start_tour(
+            "/web",
+            "ssi_school_student_leave_school_student_leave_edit",
+            login="admin",
+        )
+
+    def test_delete(self):
+        """Run the delete tour for ``school_student_leave``.
+
+        IK: docs/school_student_leave/03-delete.md
+        """
+        self.start_tour(
+            "/web",
+            "ssi_school_student_leave_school_student_leave_delete",
+            login="admin",
+        )
+
+    def test_confirm(self):
+        """Run the confirm tour for ``school_student_leave``.
+
+        IK: docs/school_student_leave/04-confirm.md
+        """
+        self.start_tour(
+            "/web",
+            "ssi_school_student_leave_school_student_leave_confirm",
+            login="admin",
+        )
+
+    def test_approve(self):
+        """Run the approve tour for ``school_student_leave``.
+
+        IK: docs/school_student_leave/05-approve.md
+        """
+        self.start_tour(
+            "/web",
+            "ssi_school_student_leave_school_student_leave_approve",
+            login="admin",
+        )
+
+    def test_reject(self):
+        """Run the reject tour for ``school_student_leave``.
+
+        IK: docs/school_student_leave/06-reject.md
+        """
+        self.start_tour(
+            "/web",
+            "ssi_school_student_leave_school_student_leave_reject",
+            login="admin",
+        )
+
+    def test_cancel(self):
+        """Run the cancel tour for ``school_student_leave``.
+
+        IK: docs/school_student_leave/10-cancel.md
+        """
+        self.start_tour(
+            "/web",
+            "ssi_school_student_leave_school_student_leave_cancel",
+            login="admin",
+        )
+
+    def test_restart(self):
+        """Run the restart tour for ``school_student_leave``.
+
+        IK: docs/school_student_leave/12-restart.md
+        """
+        self.start_tour(
+            "/web",
+            "ssi_school_student_leave_school_student_leave_restart",
+            login="admin",
+        )
+
+    def test_reset_number(self):
+        """Run the reset document number tour.
+
+        IK: docs/school_student_leave/13-reset-number.md
+        """
+        self.start_tour(
+            "/web",
+            "ssi_school_student_leave_school_student_leave_reset_number",
+            login="admin",
+        )
+
+    def test_restart_approval(self):
+        """Run the restart approval process tour.
+
+        IK: docs/school_student_leave/14-restart-approval.md
+
+        Config Pre-Condition note: policy_template/school_student_
+        leave.xml does not ship a policy.template_detail granting
+        restart_approval_ok, so this HttpCase's setUpClass supplies
+        that detail directly.
+        """
+        self.start_tour(
+            "/web",
+            "ssi_school_student_leave_school_student_leave_restart_approval",
+            login="admin",
+        )
+
+    def test_return(self):
+        """Run the return tour for ``school_student_leave``.
+
+        IK: docs/school_student_leave/15-return.md
+
+        Boundary: clicking Return shows no confirmation dialog and does
+        not change this document's own status (it stays Done) -- only
+        the student's state changes, which is unit test territory. The
+        tour only proves the button is reachable, clickable, and the
+        form survives the click.
+        """
+        self.start_tour(
+            "/web",
+            "ssi_school_student_leave_school_student_leave_return",
+            login="admin",
+        )
+
+    def test_print(self):
+        """Assert the Print wizard opens then close it, without printing.
+
+        IK: docs/school_student_leave/16-print.md
+
+        Boundary: the resulting report action is an
+        ``ir.actions.act_url`` download with no DOM "finished" signal --
+        clicking through it could hang headless Chrome.
+        """
+        self.start_tour(
+            "/web",
+            "ssi_school_student_leave_school_student_leave_print",
+            login="admin",
+        )
+
+    def test_reload_template_policy(self):
+        """Run the reload template policy tour.
+
+        IK: docs/school_student_leave/17-reload-template-policy.md
+
+        Boundary: action_reload_policy_template returns nothing and
+        triggers no dialog; the tour only proves the button on the
+        Policies tab is reachable and clickable, and that the form
+        survives the click without error.
+        """
+        self.start_tour(
+            "/web",
+            ("ssi_school_student_leave_school_student_leave_" "reload_template_policy"),
+            login="admin",
+        )

--- a/ssi_school_student_leave/views/assets.xml
+++ b/ssi_school_student_leave/views/assets.xml
@@ -1,0 +1,18 @@
+<?xml version="1.0" encoding="utf-8" ?>
+<!-- Copyright 2026 OpenSynergy Indonesia
+     Copyright 2026 PT. Simetri Sinergi Indonesia
+     License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl). -->
+<odoo>
+    <template
+        id="assets_tests"
+        name="ssi_school_student_leave assets tests"
+        inherit_id="web.assets_tests"
+    >
+        <xpath expr="." position="inside">
+            <script
+                type="text/javascript"
+                src="/ssi_school_student_leave/static/tests/tours/school_student_leave_tour.js"
+            />
+        </xpath>
+    </template>
+</odoo>

--- a/ssi_school_student_withdrawal/__manifest__.py
+++ b/ssi_school_student_withdrawal/__manifest__.py
@@ -31,5 +31,6 @@
         "approval_template/school_student_withdrawal.xml",
         "policy_template/school_student_withdrawal.xml",
         "views/school_student_withdrawal.xml",
+        "views/assets.xml",
     ],
 }

--- a/ssi_school_student_withdrawal/static/tests/tours/school_student_withdrawal_tour.js
+++ b/ssi_school_student_withdrawal/static/tests/tours/school_student_withdrawal_tour.js
@@ -1,0 +1,683 @@
+// Copyright 2026 OpenSynergy Indonesia
+// Copyright 2026 PT. Simetri Sinergi Indonesia
+// License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl).
+
+odoo.define("ssi_school_student_withdrawal.school_student_withdrawal_tour", function (
+    require
+) {
+    "use strict";
+
+    var tour = require("web_tour.tour");
+
+    // Shared navigation block reused by every tour below --
+    // corresponds to Flow 1 of every school_student_withdrawal IK:
+    // "Open the School > Student Activities > Student Withdrawals
+    // menu."
+    function openWithdrawalList() {
+        return [
+            tour.stepUtils.showAppsMenuItem(),
+            {
+                content: "Open the School app",
+                trigger: '.o_app[data-menu-xmlid="ssi_school.menu_school_root"]',
+            },
+            {
+                content: "Open the Student Activities menu",
+                trigger:
+                    '.o_menu_sections [data-menu-xmlid="ssi_school.menu_school_student_activity"]',
+            },
+            {
+                content: "Open the Student Withdrawals menu",
+                trigger:
+                    '.o_menu_sections [data-menu-xmlid="ssi_school_student_withdrawal.school_student_withdrawal_menu"]',
+            },
+            {
+                // Gerbang: tunggu action TUJUAN benar-benar terpasang,
+                // bukan sekadar "ada list di layar" (patterns.md skill
+                // odoo-development-ui-test §A).
+                content: "Student Withdrawals list is displayed",
+                trigger:
+                    ".o_control_panel .breadcrumb-item.active:contains(Student Withdrawals)",
+                extra_trigger: ".o_list_view",
+                run: function () {
+                    // Assertion only; do not trigger the default click
+                    // action.
+                },
+            },
+        ];
+    }
+
+    // Selects an option from an open many2one autocomplete dropdown.
+    function pickMany2one(fieldName, label) {
+        return [
+            {
+                content: "Select the " + fieldName + " field value",
+                trigger: ".o_field_many2one[name='" + fieldName + "'] input",
+                run: "text " + label,
+            },
+            {
+                content: "Pick " + label + " from the dropdown",
+                trigger: ".ui-autocomplete .ui-menu-item a:contains(" + label + ")",
+                in_modal: false,
+            },
+        ];
+    }
+
+    // Selects an option from a 14.0 <select> Selection field. The
+    // <select> itself carries the o_field_widget class (not wrapped in
+    // a div), so the selector is a combined tag+class, not a
+    // descendant selector (patterns.md skill odoo-development-ui-test
+    // "Field selection").
+    function pickSelection(fieldName, label) {
+        return [
+            {
+                content: "Select " + label + " for the " + fieldName + " field",
+                trigger: "select.o_field_widget[name='" + fieldName + "']",
+                run: "text " + label,
+            },
+        ];
+    }
+
+    // Opens the record identified by the unique Student name shown on
+    // the list row (used as Pre-Condition test data marker).
+    function openRecordByStudent(studentName) {
+        return [
+            {
+                content: "Open the record",
+                trigger: ".o_data_row:contains(" + studentName + ") .o_data_cell:first",
+                extra_trigger: ".o_list_view",
+            },
+            {
+                content: "Form is open",
+                trigger: ".o_form_view",
+                run: function () {
+                    // Assertion only.
+                },
+            },
+        ];
+    }
+
+    // IK: docs/school_student_withdrawal/01-create.md
+    tour.register(
+        "ssi_school_student_withdrawal_school_student_withdrawal_create",
+        {
+            test: true,
+            url: "/web",
+        },
+        [].concat(
+            // Flow 1 -- Open the Student Withdrawals menu.
+            openWithdrawalList(),
+            [
+                // Flow 2 -- Click the New button. (14.0: "Create")
+                {
+                    content: "Click New",
+                    trigger: ".o_list_button_add",
+                    extra_trigger: ".o_list_view",
+                },
+                {
+                    content: "Form is open in edit mode",
+                    trigger: ".o_form_view.o_form_editable",
+                    run: function () {
+                        // Assertion only.
+                    },
+                },
+            ],
+            // Flow 3 -- Fill in the required field: Student. Active
+            // Enrollment is auto-filled, read-only, from the student.
+            pickMany2one("student_id", "TOUR SW Create Student"),
+            // Flow 3 -- Fill in the required field: Reason Type.
+            pickSelection("reason_type", "Resignation"),
+            [
+                // Flow 4 -- Click Save.
+                {
+                    content: "Save the record",
+                    trigger: ".o_form_button_save",
+                },
+
+                // Post-Condition -- a new record is created in Draft
+                // status.
+                {
+                    content: "Record is saved",
+                    trigger: ".o_form_view.o_form_readonly",
+                    run: function () {
+                        // Assertion only.
+                    },
+                },
+                {
+                    content: "Status is Draft",
+                    trigger:
+                        ".o_statusbar_status .o_arrow_button[data-value='draft'].btn-primary",
+                    run: function () {
+                        // Assertion only.
+                    },
+                },
+            ]
+        )
+    );
+
+    // IK: docs/school_student_withdrawal/02-edit.md
+    tour.register(
+        "ssi_school_student_withdrawal_school_student_withdrawal_edit",
+        {
+            test: true,
+            url: "/web",
+        },
+        [].concat(
+            // Flow 1 -- Open the Student Withdrawals menu.
+            openWithdrawalList(),
+            // Flow 2 -- Find and open the record to edit.
+            openRecordByStudent("TOUR SW Edit Student"),
+            [
+                // 14.0: a just-opened record is displayed read-only; an
+                // explicit Edit click is required before its fields
+                // become editable. Not itemized in 02-edit.md's Flow --
+                // same documented 14.0 platform mechanic as
+                // school_student_mutation_tour.js test_edit.
+                {
+                    content: "Click the Edit button",
+                    trigger: ".o_form_button_edit",
+                },
+                {
+                    content: "Form is now editable",
+                    trigger: ".o_form_view.o_form_editable",
+                    run: function () {
+                        // Assertion only.
+                    },
+                },
+            ],
+            // Flow 3 -- Change the required field (Reason Type, from
+            // Resignation to Drop Out / Expelled).
+            pickSelection("reason_type", "Drop Out / Expelled"),
+            [
+                // Flow 4 -- Click Save.
+                {
+                    content: "Save the record",
+                    trigger: ".o_form_button_save",
+                },
+
+                // Post-Condition -- the record is updated with the new
+                // values.
+                {
+                    content: "Record is saved",
+                    trigger: ".o_form_view.o_form_readonly",
+                    run: function () {
+                        // Assertion only.
+                    },
+                },
+            ]
+        )
+    );
+
+    // IK: docs/school_student_withdrawal/03-delete.md
+    tour.register(
+        "ssi_school_student_withdrawal_school_student_withdrawal_delete",
+        {
+            test: true,
+            url: "/web",
+        },
+        [].concat(
+            // Flow 1 -- Open the Student Withdrawals menu.
+            openWithdrawalList(),
+            [
+                // Flow 2 -- Select the record to delete (check the
+                // checkbox).
+                {
+                    content: "Check the record's selector checkbox",
+                    trigger:
+                        ".o_data_row:contains(TOUR SW Delete Student) .o_list_record_selector input",
+                },
+
+                // Flow 3 -- Click Action > Delete.
+                {
+                    content: "Open the Action menu",
+                    trigger: ".o_cp_action_menus button:contains(Action)",
+                },
+                {
+                    content: "Click Delete",
+                    trigger: ".o_cp_action_menus .o_menu_item a",
+                    run: function () {
+                        var $delete = $(".o_cp_action_menus .o_menu_item a").filter(
+                            function () {
+                                return $(this).text().trim() === "Delete";
+                            }
+                        );
+                        $delete[0].click();
+                    },
+                },
+
+                // Flow 4 -- Click OK to confirm.
+                {
+                    content: "Confirm deletion",
+                    trigger: ".modal-footer button.btn-primary",
+                    in_modal: true,
+                },
+
+                // Post-Condition -- the selected records are
+                // permanently removed from the system.
+                {
+                    content: "Record no longer in the list",
+                    trigger:
+                        ".o_list_view:not(:has(.o_data_row:contains(TOUR SW Delete Student)))",
+                    run: function () {
+                        // Assertion only.
+                    },
+                },
+            ]
+        )
+    );
+
+    // IK: docs/school_student_withdrawal/04-confirm.md
+    tour.register(
+        "ssi_school_student_withdrawal_school_student_withdrawal_confirm",
+        {
+            test: true,
+            url: "/web",
+        },
+        [].concat(
+            // Flow 1 -- Open the Student Withdrawals menu.
+            openWithdrawalList(),
+            // Flow 2 -- Open the record to confirm.
+            openRecordByStudent("TOUR SW Confirm Student"),
+            [
+                // Flow 3 -- Click the Confirm button.
+                {
+                    content: "Click the Confirm button",
+                    trigger: ".o_statusbar_buttons button[name='action_confirm']",
+                    extra_trigger: ".o_form_view",
+                },
+
+                // Flow 4 -- Click OK on the confirmation dialog.
+                {
+                    content: "Confirm the dialog",
+                    trigger: ".modal-footer button.btn-primary",
+                    in_modal: true,
+                },
+
+                // Post-Condition -- status changes to Waiting for
+                // Approval.
+                {
+                    content: "Status is Waiting for Approval",
+                    trigger:
+                        ".o_statusbar_status .o_arrow_button[data-value='confirm'].btn-primary",
+                    run: function () {
+                        // Assertion only.
+                    },
+                },
+            ]
+        )
+    );
+
+    // IK: docs/school_student_withdrawal/05-approve.md
+    tour.register(
+        "ssi_school_student_withdrawal_school_student_withdrawal_approve",
+        {
+            test: true,
+            url: "/web",
+        },
+        [].concat(
+            // Flow 1 -- Open the Student Withdrawals menu.
+            openWithdrawalList(),
+            // Flow 2 -- Open the record to approve.
+            openRecordByStudent("TOUR SW Approve Student"),
+            [
+                // Flow 3 -- Click the Approve button.
+                {
+                    content: "Click the Approve button",
+                    trigger:
+                        ".o_statusbar_buttons button[name='action_approve_approval']",
+                    extra_trigger: ".o_form_view",
+                },
+
+                // Flow 4 -- Click OK on the confirmation dialog.
+                {
+                    content: "Confirm the dialog",
+                    trigger: ".modal-footer button.btn-primary",
+                    in_modal: true,
+                },
+
+                // Post-Condition -- the single approval level is
+                // fulfilled, so status changes automatically to Done
+                // (there is no separate manual Finish step for this
+                // model).
+                {
+                    content: "Status is Done",
+                    trigger:
+                        ".o_statusbar_status .o_arrow_button[data-value='done'].btn-primary",
+                    run: function () {
+                        // Assertion only.
+                    },
+                },
+            ]
+        )
+    );
+
+    // IK: docs/school_student_withdrawal/06-reject.md
+    tour.register(
+        "ssi_school_student_withdrawal_school_student_withdrawal_reject",
+        {
+            test: true,
+            url: "/web",
+        },
+        [].concat(
+            // Flow 1 -- Open the Student Withdrawals menu.
+            openWithdrawalList(),
+            // Flow 2 -- Open the record to reject.
+            openRecordByStudent("TOUR SW Reject Student"),
+            [
+                // Flow 3 -- Click the Reject button.
+                {
+                    content: "Click the Reject button",
+                    trigger:
+                        ".o_statusbar_buttons button[name='action_reject_approval']",
+                    extra_trigger: ".o_form_view",
+                },
+
+                // Flow 4 -- Click OK on the confirmation dialog.
+                {
+                    content: "Confirm the dialog",
+                    trigger: ".modal-footer button.btn-primary",
+                    in_modal: true,
+                },
+
+                // Post-Condition -- status changes to Rejected.
+                {
+                    content: "Status is Rejected",
+                    trigger:
+                        ".o_statusbar_status .o_arrow_button[data-value='reject'].btn-primary",
+                    run: function () {
+                        // Assertion only.
+                    },
+                },
+            ]
+        )
+    );
+
+    // IK: docs/school_student_withdrawal/10-cancel.md
+    tour.register(
+        "ssi_school_student_withdrawal_school_student_withdrawal_cancel",
+        {
+            test: true,
+            url: "/web",
+        },
+        [].concat(
+            // Flow 1 -- Open the Student Withdrawals menu.
+            openWithdrawalList(),
+            // Flow 2 -- Open the record to cancel.
+            openRecordByStudent("TOUR SW Cancel Student"),
+            [
+                // Flow 3 -- Click the Cancel button.
+                {
+                    content: "Click the Cancel button",
+                    trigger: ".o_statusbar_buttons button:enabled:contains('Cancel')",
+                    extra_trigger: ".o_form_view",
+                },
+                {
+                    content: "Wizard is open",
+                    trigger: ".o_form_view",
+                    run: function () {
+                        // Assertion only.
+                    },
+                },
+
+                // Flow 4 -- In the wizard, select the Cancellation
+                // Reason (radio widget).
+                {
+                    content: "Select the cancellation reason",
+                    trigger:
+                        ".o_field_widget[name='cancel_reason_id'] " +
+                        ".o_radio_item:contains(TOUR SW Cancel Reason) input",
+                    run: "click",
+                },
+
+                // Flow 5 -- Click Confirm.
+                {
+                    content: "Confirm the wizard",
+                    trigger: ".modal-footer button[name='action_confirm']",
+                },
+
+                // Flow 6 -- Click OK on the confirmation dialog.
+                {
+                    content: "Confirm the Are you sure? dialog",
+                    trigger: ".modal-footer button.btn-primary",
+                    in_modal: true,
+                },
+
+                // Post-Condition -- status changes to Cancelled.
+                {
+                    content: "Status is Cancelled",
+                    trigger:
+                        ".o_statusbar_status .o_arrow_button[data-value='cancel'].btn-primary",
+                    run: function () {
+                        // Assertion only.
+                    },
+                },
+            ]
+        )
+    );
+
+    // IK: docs/school_student_withdrawal/12-restart.md
+    tour.register(
+        "ssi_school_student_withdrawal_school_student_withdrawal_restart",
+        {
+            test: true,
+            url: "/web",
+        },
+        [].concat(
+            // Flow 1 -- Open the Student Withdrawals menu.
+            openWithdrawalList(),
+            // Flow 2 -- Open the record to restart.
+            openRecordByStudent("TOUR SW Restart Student"),
+            [
+                // Flow 3 -- Click the Restart button.
+                {
+                    content: "Click the Restart button",
+                    trigger: ".o_statusbar_buttons button[name='action_restart']",
+                    extra_trigger: ".o_form_view",
+                },
+
+                // Flow 4 -- Click OK on the confirmation dialog.
+                {
+                    content: "Confirm the dialog",
+                    trigger: ".modal-footer button.btn-primary",
+                    in_modal: true,
+                },
+
+                // Post-Condition -- status returns to Draft.
+                {
+                    content: "Status is Draft",
+                    trigger:
+                        ".o_statusbar_status .o_arrow_button[data-value='draft'].btn-primary",
+                    run: function () {
+                        // Assertion only.
+                    },
+                },
+            ]
+        )
+    );
+
+    // IK: docs/school_student_withdrawal/13-reset-number.md
+    tour.register(
+        "ssi_school_student_withdrawal_school_student_withdrawal_reset_number",
+        {
+            test: true,
+            url: "/web",
+        },
+        [].concat(
+            // Flow 1 -- Open the Student Withdrawals menu.
+            openWithdrawalList(),
+            // Flow 2 -- Open the record whose document number will be
+            // reset.
+            openRecordByStudent("TOUR SW Reset Number Student"),
+            [
+                // Flow 3 -- Click the Reset Document Number button.
+                {
+                    content: "Click the Reset Document Number button",
+                    trigger:
+                        ".o_statusbar_buttons button[name='action_reset_document_number']",
+                    extra_trigger: ".o_form_view",
+                },
+
+                // Flow 4 -- Click OK on the confirmation dialog.
+                {
+                    content: "Confirm the dialog",
+                    trigger: ".modal-footer button.btn-primary",
+                    in_modal: true,
+                },
+
+                // Post-Condition -- document number returns to "/".
+                {
+                    content: "Document number is reset (display name shows *)",
+                    trigger:
+                        ".oe_title .o_field_widget[name='display_name']:contains(*)",
+                    run: function () {
+                        // Assertion only.
+                    },
+                },
+            ]
+        )
+    );
+
+    // IK: docs/school_student_withdrawal/14-restart-approval.md
+    //
+    // Config Pre-Condition note: policy_template/school_student_
+    // withdrawal.xml does not ship a policy.template_detail granting
+    // restart_approval_ok, so the test file's setUpClass supplies it
+    // directly.
+    tour.register(
+        "ssi_school_student_withdrawal_school_student_withdrawal_restart_approval",
+        {
+            test: true,
+            url: "/web",
+        },
+        [].concat(
+            // Flow 1 -- Open the Student Withdrawals menu.
+            openWithdrawalList(),
+            // Flow 2 -- Open the record whose approval process is
+            // stalled.
+            openRecordByStudent("TOUR SW Restart Approval Student"),
+            [
+                // Flow 3 -- Click the Restart Approval Process button.
+                {
+                    content: "Click the Restart Approval Process button",
+                    trigger:
+                        ".o_statusbar_buttons button[name='action_reload_approval_template']",
+                    extra_trigger: ".o_form_view",
+                },
+
+                // Flow 4 -- Click OK on the confirmation dialog.
+                {
+                    content: "Confirm the dialog",
+                    trigger: ".modal-footer button.btn-primary",
+                    in_modal: true,
+                },
+
+                // Post-Condition -- status remains Waiting for
+                // Approval.
+                {
+                    content: "Status is still Waiting for Approval",
+                    trigger:
+                        ".o_statusbar_status .o_arrow_button[data-value='confirm'].btn-primary",
+                    run: function () {
+                        // Assertion only.
+                    },
+                },
+            ]
+        )
+    );
+
+    // IK: docs/school_student_withdrawal/16-print.md
+    //
+    // Boundary (patterns.md §Q): same reasoning as
+    // school_student_mutation_tour.js test_print -- the tour only
+    // proves the wizard opens then closes it, without printing.
+    tour.register(
+        "ssi_school_student_withdrawal_school_student_withdrawal_print",
+        {
+            test: true,
+            url: "/web",
+        },
+        [].concat(
+            // Flow 1 -- Open the Student Withdrawals menu.
+            openWithdrawalList(),
+            // Flow 2 -- Open the record to print.
+            openRecordByStudent("TOUR SW Print Student"),
+            [
+                // Flow 3 -- Click Print in the header.
+                {
+                    content: "Click the Print button",
+                    trigger: ".o_statusbar_buttons button:enabled:contains('Print')",
+                    extra_trigger: ".o_form_view",
+                },
+
+                // Flow 4/5 boundary -- the wizard is proven open, then
+                // closed.
+                {
+                    content: "The Select Report To Print wizard is displayed",
+                    trigger: ".modal-title:contains('Select Report To Print')",
+                    run: function () {
+                        // Assertion only.
+                    },
+                },
+                {
+                    content: "Close the wizard",
+                    trigger: ".modal-footer button[special='cancel']",
+                    in_modal: true,
+                },
+
+                // Post-Condition (tour boundary) -- the wizard is
+                // closed and the record form is displayed again.
+                {
+                    content: "Wizard is closed and the form is displayed again",
+                    trigger: ".o_form_view",
+                    extra_trigger: "body:not(:has(.modal))",
+                    run: function () {
+                        // Assertion only.
+                    },
+                },
+            ]
+        )
+    );
+
+    // IK: docs/school_student_withdrawal/17-reload-template-policy.md
+    //
+    // Boundary: same reasoning as school_student_mutation_tour.js
+    // test_reload_template_policy -- no dialog/notification signal.
+    tour.register(
+        "ssi_school_student_withdrawal_school_student_withdrawal_reload_template_policy",
+        {
+            test: true,
+            url: "/web",
+        },
+        [].concat(
+            // Flow 1 -- Open the Student Withdrawals menu.
+            openWithdrawalList(),
+            // Flow 2 -- Open the record whose assigned policy template
+            // should be re-evaluated.
+            openRecordByStudent("TOUR SW Reload Policy Student"),
+            [
+                // Flow 3 -- On the Policies tab, click Reload Template
+                // Policy.
+                {
+                    content: "Open the Policies tab",
+                    trigger: ".o_notebook .nav-link:contains(Policies)",
+                },
+                {
+                    content: "Click the Reload Template Policy button",
+                    trigger:
+                        ".o_form_view button[name='action_reload_policy_template']:enabled",
+                },
+
+                // Post-Condition (tour boundary) -- the form survives
+                // the click.
+                {
+                    content: "Form is intact after the reload",
+                    trigger: "body:not(.o_ui_blocked)",
+                    extra_trigger:
+                        ".o_form_view button[name='action_reload_policy_template']:enabled",
+                    run: function () {
+                        // Assertion only.
+                    },
+                },
+            ]
+        )
+    );
+});

--- a/ssi_school_student_withdrawal/tests/__init__.py
+++ b/ssi_school_student_withdrawal/tests/__init__.py
@@ -3,3 +3,4 @@
 # License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl).
 
 from . import test_school_student_withdrawal  # noqa: F401
+from . import test_ui_school_student_withdrawal  # noqa: F401

--- a/ssi_school_student_withdrawal/tests/test_ui_school_student_withdrawal.py
+++ b/ssi_school_student_withdrawal/tests/test_ui_school_student_withdrawal.py
@@ -1,0 +1,426 @@
+# Copyright 2026 OpenSynergy Indonesia
+# Copyright 2026 PT. Simetri Sinergi Indonesia
+# License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl).
+
+from odoo.tests import HttpSavepointCase, tagged
+
+
+@tagged("post_install", "-at_install")
+class TestUiSchoolStudentWithdrawal(HttpSavepointCase):
+    """Tour tests for the ``school_student_withdrawal`` IK."""
+
+    @classmethod
+    def setUpClass(cls):
+        """Create every Pre-Condition fixture required by the 12 tours.
+
+        Each tour gets its own isolated grade type / school / grade /
+        grade class / academic year & term / student, brought to the
+        Enrolled state via ``_create_open_enrollment``, so
+        state-changing tours (confirm, approve, reject, cancel,
+        restart, ...) never interfere with each other's data.
+        """
+        super().setUpClass()
+        cls.admin = cls.env.ref("base.user_admin")
+
+        # Config Pre-Condition shared by 10-cancel.md: a cancel reason
+        # usable on any model.
+        cls.cancel_reason = cls.env["base.cancel_reason"].create(
+            {
+                "name": "TOUR SW Cancel Reason",
+                "code": "TOUR-SW-CANCEL",
+                "global_use": True,
+            }
+        )
+
+        # Config Pre-Condition for 16-print.md.
+        cls.print_report_action = cls.env["ir.actions.report"].create(
+            {
+                "name": "TOUR Student Withdrawal Report",
+                "model": "school_student_withdrawal",
+                "report_type": "qweb-pdf",
+                "report_name": (
+                    "ssi_school_student_withdrawal."
+                    "tour_school_student_withdrawal_report"
+                ),
+            }
+        )
+        cls.env["print_document_type"].create(
+            {
+                "name": "TOUR SW Print Type",
+                "model_id": cls.env["ir.model"]._get_id("school_student_withdrawal"),
+                "report_ids": [(6, 0, [cls.print_report_action.id])],
+            }
+        )
+
+        # Config Pre-Condition for 14-restart-approval.md -- same
+        # reasoning as ssi_school's test_ui_school_student_mutation.py:
+        # policy_template/school_student_withdrawal.xml does not ship
+        # a policy.template_detail granting restart_approval_ok, so
+        # it is supplied here directly.
+        policy_template = cls.env.ref(
+            "ssi_school_student_withdrawal.policy_template_school_student_withdrawal"
+        )
+        state_field = cls.env["ir.model.fields"].search(
+            [
+                ("model_id.model", "=", "school_student_withdrawal"),
+                ("name", "=", "state"),
+            ],
+            limit=1,
+        )
+        state_confirm = cls.env["ir.model.fields.selection"].search(
+            [
+                ("field_id", "=", state_field.id),
+                ("value", "=", "confirm"),
+            ],
+            limit=1,
+        )
+        restart_approval_field = cls.env["ir.model.fields"].search(
+            [
+                ("model_id.model", "=", "school_student_withdrawal"),
+                ("name", "=", "restart_approval_ok"),
+            ],
+            limit=1,
+        )
+        user_group = cls.env.ref(
+            "ssi_school_student_withdrawal.school_student_withdrawal_user_group"
+        )
+        cls.env["policy.template_detail"].create(
+            {
+                "template_id": policy_template.id,
+                "field_id": restart_approval_field.id,
+                "restrict_state": True,
+                "state_ids": [(6, 0, state_confirm.ids)],
+                "restrict_user": True,
+                "computation_method": "use_group",
+                "group_ids": [(6, 0, [user_group.id])],
+                "restrict_additional": False,
+            }
+        )
+
+        # 01-create.md -- no withdrawal record is pre-created; the
+        # create tour creates a new one. It only needs an Enrolled
+        # student to pick from the list.
+        cls._create_open_enrollment("CR", "Create")
+
+        # 02-edit.md -- Draft record to edit.
+        data_ed = cls._create_open_enrollment("ED", "Edit")
+        cls.withdrawal_edit = cls._create_withdrawal(data_ed)
+
+        # 03-delete.md -- Draft record to delete.
+        data_dl = cls._create_open_enrollment("DL", "Delete")
+        cls.withdrawal_delete = cls._create_withdrawal(data_dl)
+
+        # 04-confirm.md -- Draft record to confirm.
+        data_co = cls._create_open_enrollment("CO", "Confirm")
+        cls.withdrawal_confirm = cls._create_withdrawal(data_co)
+
+        # 05-approve.md -- Waiting for Approval record to approve.
+        data_ap = cls._create_open_enrollment("AP", "Approve")
+        cls.withdrawal_approve = cls._create_withdrawal(data_ap)
+        cls.withdrawal_approve.with_user(cls.admin).action_confirm()
+
+        # 06-reject.md -- Waiting for Approval record to reject.
+        data_rj = cls._create_open_enrollment("RJ", "Reject")
+        cls.withdrawal_reject = cls._create_withdrawal(data_rj)
+        cls.withdrawal_reject.with_user(cls.admin).action_confirm()
+
+        # 10-cancel.md -- Waiting for Approval record to cancel.
+        data_cn = cls._create_open_enrollment("CN", "Cancel")
+        cls.withdrawal_cancel = cls._create_withdrawal(data_cn)
+        cls.withdrawal_cancel.with_user(cls.admin).action_confirm()
+
+        # 12-restart.md -- Cancelled record to restart.
+        data_rs = cls._create_open_enrollment("RS", "Restart")
+        cls.withdrawal_restart = cls._create_withdrawal(data_rs)
+        cls.withdrawal_restart.with_user(cls.admin).action_confirm()
+        cls.withdrawal_restart.with_user(cls.admin).action_cancel(cls.cancel_reason)
+
+        # 13-reset-number.md -- Draft record with a manually-set
+        # document number.
+        data_rn = cls._create_open_enrollment("RN", "Reset Number")
+        cls.withdrawal_reset_number = cls._create_withdrawal(data_rn)
+        cls.withdrawal_reset_number.write({"name": "TOUR-SW-MANUAL-001"})
+
+        # 14-restart-approval.md -- Waiting for Approval record whose
+        # approval process is stalled.
+        data_ra = cls._create_open_enrollment("RA", "Restart Approval")
+        cls.withdrawal_restart_approval = cls._create_withdrawal(data_ra)
+        cls.withdrawal_restart_approval.with_user(cls.admin).action_confirm()
+        cls.withdrawal_restart_approval.sudo().approval_ids.unlink()
+        cls.withdrawal_restart_approval.sudo().write({"approval_template_id": False})
+
+        # 16-print.md -- any state is usable per the IK; a fresh Draft
+        # record is enough.
+        data_pr = cls._create_open_enrollment("PR", "Print")
+        cls.withdrawal_print = cls._create_withdrawal(data_pr)
+
+        # 17-reload-template-policy.md -- any state is usable per the
+        # IK; a fresh Draft record is enough.
+        data_rt = cls._create_open_enrollment("RT", "Reload Policy")
+        cls.withdrawal_reload_template_policy = cls._create_withdrawal(data_rt)
+
+    @classmethod
+    def _create_open_enrollment(cls, suffix, label):
+        """Build one isolated grade/school/class/year/term/enrollment.
+
+        Brings a new Enrollment to Open status via Confirm + Approve
+        (run as ``base.user_admin``, who holds the Validator group so
+        the confirm_ok/approve_ok policy fields compute True), which
+        also moves the student to the "enrol" state via the
+        enrollment's post_open hook.
+
+        :param suffix: short unique code suffix for this fixture set.
+        :param label: action label (e.g. "Create", "Edit") used to
+            build the tour marker name "TOUR SW <label> Student", kept
+            in sync with the literals used by
+            school_student_withdrawal_tour.js.
+        :return: dict with the created records, keyed by role.
+        """
+        grade_type = cls.env["school_grade_type"].create(
+            {
+                "name": "TOUR SW Grade Type %s" % suffix,
+                "code": "GTSW%s" % suffix,
+                "sequence": 10,
+            }
+        )
+        school = cls.env["school"].create(
+            {
+                "name": "TOUR SW School %s" % suffix,
+                "code": "SCHSW%s" % suffix,
+                "grade_type_id": grade_type.id,
+            }
+        )
+        grade = cls.env["school_grade"].create(
+            {
+                "name": "TOUR SW Grade %s" % suffix,
+                "code": "GSW%s" % suffix,
+                "sequence": 10,
+                "type_id": grade_type.id,
+            }
+        )
+        grade_class = cls.env["school_grade_class"].create(
+            {
+                "name": "TOUR SW %s Class" % label,
+                "code": "CLSW%s" % suffix,
+                "school_id": school.id,
+                "grade_id": grade.id,
+                "capacity": 30,
+            }
+        )
+        year = cls.env["school_academic_year"].create(
+            {
+                "name": "TOUR SW Year %s" % suffix,
+                "code": "AYSW%s" % suffix,
+                "date_start": "2024-07-01",
+                "date_end": "2025-06-30",
+            }
+        )
+        term = cls.env["school_academic_term"].create(
+            {
+                "name": "TOUR SW Term %s" % suffix,
+                "code": "TMSW%s" % suffix,
+                "date_start": "2024-07-01",
+                "date_end": "2024-12-31",
+                "year_id": year.id,
+                "enrollment_state": "open",
+            }
+        )
+        student_name = "TOUR SW %s Student" % label
+        contact = cls.env["res.partner"].create({"name": "%s Contact" % student_name})
+        student = cls.env["school_student"].create(
+            {
+                "name": student_name,
+                "code": "STUSW%s" % suffix,
+                "contact_id": contact.id,
+                "school_id": school.id,
+            }
+        )
+        enrollment = cls.env["school_enrollment"].create(
+            {
+                "date": "2024-07-01",
+                "academic_year_id": year.id,
+                "academic_term_id": term.id,
+                "school_id": school.id,
+                "grade_id": grade.id,
+                "grade_class_id": grade_class.id,
+                "student_id": student.id,
+                "currency_id": cls.env.company.currency_id.id,
+            }
+        )
+        enrollment.with_user(cls.admin).action_confirm()
+        enrollment.invalidate_cache()
+        enrollment.with_user(cls.admin).action_approve_approval()
+        return {
+            "school": school,
+            "grade": grade,
+            "grade_class": grade_class,
+            "student": student,
+            "enrollment": enrollment,
+        }
+
+    @classmethod
+    def _create_withdrawal(cls, data):
+        """Create a Draft Resignation withdrawal for ``data``'s student.
+
+        :param data: dict returned by ``_create_open_enrollment``.
+        :return: the created ``school_student_withdrawal`` record.
+        """
+        return cls.env["school_student_withdrawal"].create(
+            {
+                "date": "2025-06-30",
+                "student_id": data["student"].id,
+                "reason_type": "resignation",
+            }
+        )
+
+    def test_create(self):
+        """Run the create tour for ``school_student_withdrawal``.
+
+        IK: docs/school_student_withdrawal/01-create.md
+        """
+        self.start_tour(
+            "/web",
+            "ssi_school_student_withdrawal_school_student_withdrawal_create",
+            login="admin",
+        )
+
+    def test_edit(self):
+        """Run the edit tour for ``school_student_withdrawal``.
+
+        IK: docs/school_student_withdrawal/02-edit.md
+        """
+        self.start_tour(
+            "/web",
+            "ssi_school_student_withdrawal_school_student_withdrawal_edit",
+            login="admin",
+        )
+
+    def test_delete(self):
+        """Run the delete tour for ``school_student_withdrawal``.
+
+        IK: docs/school_student_withdrawal/03-delete.md
+        """
+        self.start_tour(
+            "/web",
+            "ssi_school_student_withdrawal_school_student_withdrawal_delete",
+            login="admin",
+        )
+
+    def test_confirm(self):
+        """Run the confirm tour for ``school_student_withdrawal``.
+
+        IK: docs/school_student_withdrawal/04-confirm.md
+        """
+        self.start_tour(
+            "/web",
+            "ssi_school_student_withdrawal_school_student_withdrawal_confirm",
+            login="admin",
+        )
+
+    def test_approve(self):
+        """Run the approve tour for ``school_student_withdrawal``.
+
+        IK: docs/school_student_withdrawal/05-approve.md
+        """
+        self.start_tour(
+            "/web",
+            "ssi_school_student_withdrawal_school_student_withdrawal_approve",
+            login="admin",
+        )
+
+    def test_reject(self):
+        """Run the reject tour for ``school_student_withdrawal``.
+
+        IK: docs/school_student_withdrawal/06-reject.md
+        """
+        self.start_tour(
+            "/web",
+            "ssi_school_student_withdrawal_school_student_withdrawal_reject",
+            login="admin",
+        )
+
+    def test_cancel(self):
+        """Run the cancel tour for ``school_student_withdrawal``.
+
+        IK: docs/school_student_withdrawal/10-cancel.md
+        """
+        self.start_tour(
+            "/web",
+            "ssi_school_student_withdrawal_school_student_withdrawal_cancel",
+            login="admin",
+        )
+
+    def test_restart(self):
+        """Run the restart tour for ``school_student_withdrawal``.
+
+        IK: docs/school_student_withdrawal/12-restart.md
+        """
+        self.start_tour(
+            "/web",
+            "ssi_school_student_withdrawal_school_student_withdrawal_restart",
+            login="admin",
+        )
+
+    def test_reset_number(self):
+        """Run the reset document number tour.
+
+        IK: docs/school_student_withdrawal/13-reset-number.md
+        """
+        self.start_tour(
+            "/web",
+            "ssi_school_student_withdrawal_school_student_withdrawal_reset_number",
+            login="admin",
+        )
+
+    def test_restart_approval(self):
+        """Run the restart approval process tour.
+
+        IK: docs/school_student_withdrawal/14-restart-approval.md
+
+        Config Pre-Condition note: policy_template/school_student_
+        withdrawal.xml does not ship a policy.template_detail granting
+        restart_approval_ok, so this HttpCase's setUpClass supplies
+        that detail directly.
+        """
+        self.start_tour(
+            "/web",
+            (
+                "ssi_school_student_withdrawal_school_student_withdrawal_"
+                "restart_approval"
+            ),
+            login="admin",
+        )
+
+    def test_print(self):
+        """Assert the Print wizard opens then close it, without printing.
+
+        IK: docs/school_student_withdrawal/16-print.md
+
+        Boundary: the resulting report action is an
+        ``ir.actions.act_url`` download with no DOM "finished" signal --
+        clicking through it could hang headless Chrome.
+        """
+        self.start_tour(
+            "/web",
+            "ssi_school_student_withdrawal_school_student_withdrawal_print",
+            login="admin",
+        )
+
+    def test_reload_template_policy(self):
+        """Run the reload template policy tour.
+
+        IK: docs/school_student_withdrawal/17-reload-template-policy.md
+
+        Boundary: action_reload_policy_template returns nothing and
+        triggers no dialog; the tour only proves the button on the
+        Policies tab is reachable and clickable, and that the form
+        survives the click without error.
+        """
+        self.start_tour(
+            "/web",
+            (
+                "ssi_school_student_withdrawal_school_student_withdrawal_"
+                "reload_template_policy"
+            ),
+            login="admin",
+        )

--- a/ssi_school_student_withdrawal/tests/test_ui_school_student_withdrawal.py
+++ b/ssi_school_student_withdrawal/tests/test_ui_school_student_withdrawal.py
@@ -262,6 +262,12 @@ class TestUiSchoolStudentWithdrawal(HttpSavepointCase):
     def _create_withdrawal(cls, data):
         """Create a Draft Resignation withdrawal for ``data``'s student.
 
+        ``user_id`` is set explicitly to ``base.user_admin`` -- see
+        the docstring note in
+        ``TestUiSchoolStudentGraduation._create_graduation``
+        (ssi_school_student_graduation) for why this is required for
+        the tour's "admin" session to see the record at all.
+
         :param data: dict returned by ``_create_open_enrollment``.
         :return: the created ``school_student_withdrawal`` record.
         """
@@ -270,6 +276,7 @@ class TestUiSchoolStudentWithdrawal(HttpSavepointCase):
                 "date": "2025-06-30",
                 "student_id": data["student"].id,
                 "reason_type": "resignation",
+                "user_id": cls.admin.id,
             }
         )
 

--- a/ssi_school_student_withdrawal/views/assets.xml
+++ b/ssi_school_student_withdrawal/views/assets.xml
@@ -1,0 +1,18 @@
+<?xml version="1.0" encoding="utf-8" ?>
+<!-- Copyright 2026 OpenSynergy Indonesia
+     Copyright 2026 PT. Simetri Sinergi Indonesia
+     License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl). -->
+<odoo>
+    <template
+        id="assets_tests"
+        name="ssi_school_student_withdrawal assets tests"
+        inherit_id="web.assets_tests"
+    >
+        <xpath expr="." position="inside">
+            <script
+                type="text/javascript"
+                src="/ssi_school_student_withdrawal/static/tests/tours/school_student_withdrawal_tour.js"
+            />
+        </xpath>
+    </template>
+</odoo>


### PR DESCRIPTION
## Summary

Menambahkan tour UI (Odoo Tour, `HttpCase.start_tour`) untuk seluruh berkas
Instruksi Kerja pada tiga modul siklus hidup siswa:

- `ssi_school_student_graduation` — model `school_student_graduation` (12 tour)
  dan `school_student_graduation_batch` (12 tour, termasuk aksi inline
  `action_populate_lines` sebagai step di tour create/edit).
- `ssi_school_student_leave` — model `school_student_leave` (13 tour, termasuk
  tour Return `15-return.md`).
- `ssi_school_student_withdrawal` — model `school_student_withdrawal` (12
  tour).

Setiap tour tertaut ke berkas IK sumbernya lewat penanda
`IK: docs/<model>/NN-aksi.md` di docstring method `test_*`, memenuhi gerbang
tautan IK↔tour pada `validate-ik.sh` (0 error, 0 peringatan untuk ketiga
modul). Tour mengikuti Keputusan Desain issue: satu berkas IK = satu tour,
aksi inline tidak melahirkan tour sendiri, aksi bervonis N tidak dibuatkan
tour, dan tour tidak menguji nilai (hanya kasatmata: menu, view, tombol,
dialog, status, notifikasi).

Setiap modul di-commit terpisah:

- `3789e6f` — `[UPD] ssi_school_student_graduation`
- `1e60259` — `[UPD] ssi_school_student_leave`
- `d5dbd2c` — `[UPD] ssi_school_student_withdrawal`

Closes #228

## Test plan

- [x] `validate-ik.sh` untuk ketiga modul: 0 error, 0 peringatan (tautan
      IK↔tour lengkap).
- [x] Sintaks JS (`node --check`) dan Python (`py_compile`) untuk seluruh
      berkas baru.
- [x] `pre-commit run` (autoflake, black, prettier, eslint, flake8,
      pylint-odoo, oca-checks-odoo-module) lolos untuk seluruh berkas baru.
- [x] Docstring diverifikasi manual via AST (bahasa Inggris, gaya reST, baris
      pertama satu kalimat ≤ 79 karakter berakhiran titik).
- [ ] CI GitHub menjalankan tour (headless Chrome) — dipantau di PR ini.

🤖 Generated with [Claude Code](https://claude.com/claude-code)