### PR TITLE
[UPD] ssi_school_health: tour UI delta school_student (Health tab)

### DIFF
--- a/ssi_school_health/__manifest__.py
+++ b/ssi_school_health/__manifest__.py
@@ -13,9 +13,11 @@
     "depends": [
         "ssi_school",
         "ssi_partner_health",
+        "web_tour",
     ],
     "data": [
         "views/school_student.xml",
+        "views/assets.xml",
     ],
     "demo": [],
     "contributors": [

--- a/ssi_school_health/static/tests/tours/school_student_tour.js
+++ b/ssi_school_health/static/tests/tours/school_student_tour.js
@@ -1,0 +1,224 @@
+// Copyright 2026 OpenSynergy Indonesia
+// Copyright 2026 PT. Simetri Sinergi Indonesia
+// License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl).
+
+odoo.define("ssi_school_health.school_student_tour", function (require) {
+    "use strict";
+
+    var tour = require("web_tour.tour");
+
+    // Shared navigation block reused by both tours below -- corresponds to
+    // Flow 1 of the base school_student IK (ssi_school): "Open the School >
+    // Students menu." Re-declared here (rather than required from
+    // ssi_school's own tour module) because the base tour keeps this helper
+    // private to its own odoo.define closure.
+    function openStudentList() {
+        return [
+            tour.stepUtils.showAppsMenuItem(),
+            {
+                content: "Open the School app",
+                trigger: '.o_app[data-menu-xmlid="ssi_school.menu_school_root"]',
+            },
+            {
+                content: "Open the Students menu",
+                trigger:
+                    '.o_menu_sections [data-menu-xmlid="ssi_school.school_student_menu"]',
+            },
+            {
+                // Gerbang: tunggu action TUJUAN benar-benar terpasang,
+                // bukan sekadar "ada list di layar" (patterns.md §A).
+                content: "Students list is displayed",
+                trigger: ".o_control_panel .breadcrumb-item.active:contains(Students)",
+                extra_trigger: ".o_list_view",
+                run: function () {
+                    // Assertion only; do not trigger the default click action.
+                },
+            },
+        ];
+    }
+
+    // Assertion block shared by both tours below -- the five history
+    // widgets added by the Health tab (docs/school_student/01-create.md and
+    // 02-edit.md, E1 delta of ssi_school_health). Each pair of steps proves
+    // one widget from "## Additional Fields" is rendered and ready to
+    // accept a line: the group separator (always has text, so it is never
+    // a zero-pixel readonly box -- patterns.md §O) and the widget's own
+    // "Add a line" control. Delta-only: no line is filled and no value is
+    // asserted -- the Additional Post-Condition (Height/Weight/Head
+    // Circumference recomputed) is a computed-value fact and belongs to
+    // odoo-development-unit-test, not this tour.
+    function assertHealthTabFields() {
+        return [
+            {
+                content: "Height history is displayed",
+                trigger: ".o_horizontal_separator:contains(Height)",
+                run: function () {
+                    // Assertion only.
+                },
+            },
+            {
+                content: "Heights 'Add a line' control is displayed",
+                trigger:
+                    ".o_field_widget[name='height_ids'] .o_field_x2many_list_row_add a",
+                run: function () {
+                    // Assertion only.
+                },
+            },
+            {
+                content: "Weight history is displayed",
+                trigger: ".o_horizontal_separator:contains(Weight)",
+                run: function () {
+                    // Assertion only.
+                },
+            },
+            {
+                content: "Weights 'Add a line' control is displayed",
+                trigger:
+                    ".o_field_widget[name='weight_ids'] .o_field_x2many_list_row_add a",
+                run: function () {
+                    // Assertion only.
+                },
+            },
+            {
+                content: "Head Circumference history is displayed",
+                trigger: ".o_horizontal_separator:contains(Head Circumference)",
+                run: function () {
+                    // Assertion only.
+                },
+            },
+            {
+                content: "Head Circumferences 'Add a line' control is displayed",
+                trigger:
+                    ".o_field_widget[name='head_circumference_ids'] .o_field_x2many_list_row_add a",
+                run: function () {
+                    // Assertion only.
+                },
+            },
+            {
+                content: "Allergies history is displayed",
+                trigger: ".o_horizontal_separator:contains(Allergies)",
+                run: function () {
+                    // Assertion only.
+                },
+            },
+            {
+                content: "Allergies 'Add a line' control is displayed",
+                trigger:
+                    ".o_field_widget[name='allergy_ids'] .o_field_x2many_list_row_add a",
+                run: function () {
+                    // Assertion only.
+                },
+            },
+            {
+                content: "Disease History is displayed",
+                trigger: ".o_horizontal_separator:contains(Disease History)",
+                run: function () {
+                    // Assertion only.
+                },
+            },
+            {
+                content: "Disease History 'Add a line' control is displayed",
+                trigger:
+                    ".o_field_widget[name='disease_history_ids'] .o_field_x2many_list_row_add a",
+                run: function () {
+                    // Assertion only.
+                },
+            },
+        ];
+    }
+
+    // IK: docs/school_student/01-create.md (E1 delta -- Additional Fields)
+    tour.register(
+        "ssi_school_health_school_student_create",
+        {
+            test: true,
+            url: "/web",
+        },
+        [].concat(
+            // ── Base Flow 1 — Open the School > Students menu.
+            openStudentList(),
+            [
+                // ── Base Flow 2 — Click the New button. (14.0: "Create")
+                {
+                    content: "Click New",
+                    trigger: ".o_list_button_add",
+                    extra_trigger: ".o_list_view",
+                },
+                {
+                    content: "Form is open in edit mode",
+                    trigger: ".o_form_view.o_form_editable",
+                    run: function () {
+                        // Assertion only.
+                    },
+                },
+
+                // ── Additional Fields — the create form gains a Health
+                // tab. Delta-only tour: it stops after the tab and its
+                // five history widgets are proven to render; it does not
+                // fill any line, does not fill the base required fields,
+                // and does not continue to Save (see the boundary comment
+                // above assertHealthTabFields).
+                {
+                    content: "Open the Health tab",
+                    trigger: ".o_notebook .nav-link:contains(Health)",
+                },
+            ],
+            assertHealthTabFields()
+        )
+    );
+
+    // IK: docs/school_student/02-edit.md (E1 delta -- Additional Fields)
+    tour.register(
+        "ssi_school_health_school_student_edit",
+        {
+            test: true,
+            url: "/web",
+        },
+        [].concat(
+            // ── Base Flow 1 — Open the School > Students menu.
+            openStudentList(),
+            [
+                // ── Base Flow 2 — Find and open the record to edit.
+                {
+                    content: "Open the record",
+                    trigger:
+                        ".o_data_row:contains(TOUR STUDENT HEALTH EDIT) .o_data_cell:first",
+                    extra_trigger: ".o_list_view",
+                },
+                {
+                    content: "Form is open",
+                    trigger: ".o_form_view",
+                    run: function () {
+                        // Assertion only.
+                    },
+                },
+                // 14.0: an existing record opens read-only -- Edit first
+                // (patterns.md skill odoo-development-ui-test §E).
+                {
+                    content: "Click the Edit button",
+                    trigger: ".o_form_button_edit",
+                },
+                {
+                    content: "Form is now editable",
+                    trigger: ".o_form_view.o_form_editable",
+                    run: function () {
+                        // Assertion only.
+                    },
+                },
+
+                // ── Additional Fields — the Health tab described in
+                // 01-create remains available for editing. Delta-only
+                // tour: it stops after the tab and its five history
+                // widgets are proven to still render and accept a line on
+                // an existing record; it does not add/edit/remove a line,
+                // and does not continue to the base Flow's Generate
+                // Code/Save/Reset code steps.
+                {
+                    content: "Open the Health tab",
+                    trigger: ".o_notebook .nav-link:contains(Health)",
+                },
+            ],
+            assertHealthTabFields()
+        )
+    );
+});

--- a/ssi_school_health/tests/__init__.py
+++ b/ssi_school_health/tests/__init__.py
@@ -3,3 +3,4 @@
 # License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl).
 
 from . import test_school_health
+from . import test_ui_school_student

--- a/ssi_school_health/tests/test_ui_school_student.py
+++ b/ssi_school_health/tests/test_ui_school_student.py
@@ -1,0 +1,74 @@
+# Copyright 2026 OpenSynergy Indonesia
+# Copyright 2026 PT. Simetri Sinergi Indonesia
+# License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl).
+
+from odoo.tests import HttpSavepointCase, tagged
+
+
+@tagged("post_install", "-at_install")
+class TestUiSchoolStudent(HttpSavepointCase):
+    """Tour tests for the ``school_student`` Health tab delta."""
+
+    @classmethod
+    def setUpClass(cls):
+        """Prepare the school, contact, and record used by the tours.
+
+        Pre-Condition IK is prepared here -- NOT by clicking through the
+        UI. ``school_student_group`` already includes ``base.user_admin``
+        (``ssi_school``, ``security/res_group_data.xml``), so no extra
+        group grant is required for the menu or the Health tab to be
+        visible -- the tab is not gated by any group.
+        """
+        super().setUpClass()
+        cls.grade_type = cls.env["school_grade_type"].create(
+            {
+                "name": "TOUR Health Grade Type",
+                "code": "TOURHLTHGT",
+                "sequence": 10,
+            }
+        )
+        cls.school = cls.env["school"].create(
+            {
+                "name": "TOUR HEALTH SCHOOL",
+                "code": "TOURHLTHSCH",
+                "grade_type_id": cls.grade_type.id,
+            }
+        )
+
+        # Pre-Condition for docs/school_student/02-edit.md: an existing
+        # Student record must already exist, found and opened by the edit
+        # tour. Not needed for the create tour, which only exercises a
+        # brand-new (unsaved) record.
+        cls.contact_edit = cls.env["res.partner"].create(
+            {"name": "TOUR STUDENT HEALTH CONTACT EDIT"}
+        )
+        cls.student_edit = cls.env["school_student"].create(
+            {
+                "name": "TOUR STUDENT HEALTH EDIT",
+                "code": "/",
+                "contact_id": cls.contact_edit.id,
+                "school_id": cls.school.id,
+            }
+        )
+
+    def test_create(self):
+        """Run the Health tab delta tour for the create form.
+
+        IK: docs/school_student/01-create.md
+        """
+        self.start_tour(
+            "/web",
+            "ssi_school_health_school_student_create",
+            login="admin",
+        )
+
+    def test_edit(self):
+        """Run the Health tab delta tour for the edit form.
+
+        IK: docs/school_student/02-edit.md
+        """
+        self.start_tour(
+            "/web",
+            "ssi_school_health_school_student_edit",
+            login="admin",
+        )

--- a/ssi_school_health/views/assets.xml
+++ b/ssi_school_health/views/assets.xml
@@ -1,0 +1,18 @@
+<?xml version="1.0" encoding="utf-8" ?>
+<!-- Copyright 2026 OpenSynergy Indonesia
+     Copyright 2026 PT. Simetri Sinergi Indonesia
+     License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl). -->
+<odoo>
+    <template
+        id="assets_tests"
+        name="ssi_school_health assets tests"
+        inherit_id="web.assets_tests"
+    >
+        <xpath expr="." position="inside">
+            <script
+                type="text/javascript"
+                src="/ssi_school_health/static/tests/tours/school_student_tour.js"
+            />
+        </xpath>
+    </template>
+</odoo>


### PR DESCRIPTION
## Ringkasan

Menulis tour UI (delta-only) untuk berkas IK delta `school_student` yang
dihasilkan issue #222 di modul `ssi_school_health` — tab **Health** pada
form Student.

- `docs/school_student/01-create.md` → tour `ssi_school_health_school_student_create`
- `docs/school_student/02-edit.md` → tour `ssi_school_health_school_student_edit`

Kedua tour delta-only: membuka tab Health lalu memverifikasi kelima widget
riwayat (Heights, Weights, Head Circumferences, Allergies, Disease
History) ter-render & siap menerima baris baru — tanpa mengisi baris dan
tanpa menguji nilai ringkasan computed (Height/Weight/Head Circumference),
karena itu wilayah unit test, bukan tour.

## Modul `ssi_school_qr_code`: TIDAK mendapat tour

Issue #222 memvonis `ssi_school_qr_code` **nol IK** (halaman QR Code hanya
berisi field computed/read-only `qr_image`, tanpa input pengguna). Karena
tidak ada berkas IK, sesuai Keputusan Desain issue #230 modul ini juga
tidak mendapat tour. Lihat komentar issue #230.

## Kriteria Penerimaan

- [x] Setiap berkas IK yang berhak atas tour (hanya `ssi_school_health`)
      punya tepat satu tour
- [x] Tidak ada tour untuk aksi inline maupun aksi bervonis N
- [x] Tidak ada step tour yang tak punya padanan langkah di Flow IK
- [x] Tidak ada assertion nilai di dalam tour
- [x] Berkas `tests/test_ui_school_student.py` memuat penanda `IK:` yang
      menunjuk berkas IK sumbernya
- [ ] Seluruh tour hijau di CI GitHub — menunggu hasil CI PR ini

Closes #230