### PR TITLE
[UPD] Tour UI Create Invoice Export (ssi_school_customer_invoice_export & ssi_school_admission_customer_invoice_export)

### DIFF
--- a/ssi_school_admission_customer_invoice_export/__manifest__.py
+++ b/ssi_school_admission_customer_invoice_export/__manifest__.py
@@ -16,6 +16,7 @@
     "depends": [
         "ssi_school_admission",
         "ssi_school_customer_invoice_export",
+        "web_tour",
     ],
     "data": [
         # Security - access
@@ -24,6 +25,7 @@
         "policy_template/school_admission.xml",
         # Views
         "views/school_admission.xml",
+        "views/assets.xml",
         "wizards/school_admission_create_invoice_export.xml",
     ],
     "demo": [],

--- a/ssi_school_admission_customer_invoice_export/static/tests/tours/school_admission_create_invoice_export_tour.js
+++ b/ssi_school_admission_customer_invoice_export/static/tests/tours/school_admission_create_invoice_export_tour.js
@@ -1,0 +1,150 @@
+// Copyright 2026 OpenSynergy Indonesia
+// Copyright 2026 PT. Simetri Sinergi Indonesia
+// License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl).
+
+odoo.define(
+    "ssi_school_admission_customer_invoice_export.school_admission_create_invoice_export_tour",
+    function (require) {
+        "use strict";
+
+        var tour = require("web_tour.tour");
+
+        // Shared navigation block -- corresponds to Flow 1 of the IK:
+        // "Open the School > Admission > Admissions menu." Mirrors
+        // ssi_school_admission.school_admission_tour's own helper.
+        function openAdmissionList() {
+            return [
+                tour.stepUtils.showAppsMenuItem(),
+                {
+                    content: "Open the School app",
+                    trigger: '.o_app[data-menu-xmlid="ssi_school.menu_school_root"]',
+                },
+                {
+                    content: "Open the Admission menu",
+                    trigger:
+                        '.o_menu_sections [data-menu-xmlid="ssi_school_admission.menu_school_admission"]',
+                },
+                {
+                    content: "Open the Admissions menu",
+                    trigger:
+                        '.o_menu_sections [data-menu-xmlid="ssi_school_admission.school_admission_menu"]',
+                },
+                {
+                    // Gerbang: tunggu action TUJUAN benar-benar terpasang.
+                    content: "Admissions list is displayed",
+                    trigger:
+                        ".o_control_panel .breadcrumb-item.active:contains(Admissions)",
+                    extra_trigger: ".o_list_view",
+                    run: function () {
+                        // Assertion only; do not trigger the default click.
+                    },
+                },
+            ];
+        }
+
+        // Opens the record identified by the unique student name shown on
+        // the list row's Student column.
+        function openRecordByStudent(studentName) {
+            return [
+                {
+                    content: "Open the record",
+                    trigger:
+                        ".o_data_row:contains(" + studentName + ") .o_data_cell:first",
+                    extra_trigger: ".o_list_view",
+                },
+                {
+                    content: "Form is open",
+                    trigger: ".o_form_view",
+                    run: function () {
+                        // Assertion only.
+                    },
+                },
+            ];
+        }
+
+        // IK: docs/school_admission/20-create-invoice-export.md
+        tour.register(
+            "ssi_school_admission_customer_invoice_export_school_admission_create_invoice_export",
+            {
+                test: true,
+                url: "/web",
+            },
+            [].concat(
+                // Flow 1 -- Open the Admissions menu.
+                openAdmissionList(),
+                // Flow 2 -- Open the record whose unpaid invoices will be
+                // exported.
+                openRecordByStudent("TOUR ADM IE Student"),
+                [
+                    // Flow 3 -- Click the Create Invoice Export button
+                    // (action_open_create_invoice_export_wizard).
+                    {
+                        content: "Click the Create Invoice Export button",
+                        trigger:
+                            ".o_statusbar_buttons button[name='action_open_create_invoice_export_wizard']",
+                        extra_trigger: ".o_form_view",
+                    },
+                    {
+                        // 14.0: JANGAN prefiks `.modal` (patterns.md §H).
+                        content: "Wizard is open",
+                        trigger: ".o_form_view",
+                        run: function () {
+                            // Assertion only.
+                        },
+                    },
+
+                    // Flow 4 -- the current record is pre-selected
+                    // (Admissions field, readonly many2many tags, hidden
+                    // -- no interaction needed).
+
+                    // Flow 5 -- fill in the required Type field. Date
+                    // keeps its default (today), Output Format is
+                    // auto-filled from Type, and Date Start/Date End are
+                    // left empty (no bound).
+                    {
+                        content: "Select the Type field value",
+                        trigger: ".o_field_many2one[name='type_id'] input",
+                        run: "text TOUR ADM IE Export Type",
+                    },
+                    {
+                        content: "Pick the Type from the dropdown",
+                        trigger:
+                            ".ui-autocomplete .ui-menu-item a:contains(TOUR ADM IE Export Type)",
+                        in_modal: false,
+                    },
+
+                    // Flow 6 -- Click Create Invoice Export in the wizard
+                    // footer.
+                    {
+                        content: "Click Create Invoice Export in the wizard",
+                        trigger:
+                            ".modal-footer button[name='action_create_invoice_export']",
+                    },
+                    {
+                        content: "Wizard is closed",
+                        trigger: "body:not(:has(.modal))",
+                        run: function () {
+                            // Assertion only.
+                        },
+                    },
+
+                    // Post-Condition -- the created Customer Invoice
+                    // Export document opens in form view, in Draft
+                    // status. The OLD admission form's active statusbar
+                    // button is "open", never "draft", so this selector
+                    // cannot match before the new document actually
+                    // loads (patterns.md §M litmus test).
+                    {
+                        content:
+                            "Customer Invoice Export document opens in Draft status",
+                        trigger:
+                            ".o_statusbar_status .o_arrow_button[data-value='draft'].btn-primary",
+                        run: function () {
+                            // Assertion only.
+                        },
+                    },
+                ]
+            )
+        );
+    }
+);

--- a/ssi_school_admission_customer_invoice_export/tests/__init__.py
+++ b/ssi_school_admission_customer_invoice_export/tests/__init__.py
@@ -3,3 +3,4 @@
 # License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl).
 
 from . import test_school_admission_create_invoice_export
+from . import test_ui_school_admission_create_invoice_export

--- a/ssi_school_admission_customer_invoice_export/tests/test_ui_school_admission_create_invoice_export.py
+++ b/ssi_school_admission_customer_invoice_export/tests/test_ui_school_admission_create_invoice_export.py
@@ -1,0 +1,188 @@
+# Copyright 2026 OpenSynergy Indonesia
+# Copyright 2026 PT. Simetri Sinergi Indonesia
+# License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl).
+
+from odoo.tests import HttpSavepointCase, tagged
+
+
+@tagged("post_install", "-at_install")
+class TestUiSchoolAdmissionCreateInvoiceExport(HttpSavepointCase):
+    """Tour test for the Create Invoice Export wizard on admission."""
+
+    @classmethod
+    def setUpClass(cls):
+        """Build an Open admission with one unpaid invoiced term.
+
+        ``SavepointCase.setUpClass`` runs ``cls.env`` as SUPERUSER_ID, so
+        any fixture created via ``cls.env.create()`` without an explicit
+        ``user_id`` defaults "Responsible" to the superuser, not
+        "admin" -- ``school_admission_internal_user_rule`` (scoped by
+        ``user_id``) would then hide it from the "admin" tour session.
+        ``user_id`` is set explicitly below (mirrors
+        ``test_ui_school_admission.py``).
+
+        Builds the accounting basics (journal/account/customer invoice
+        type/income account/product), the academic structure (grade
+        type, academic year/term, school, grade), one student, one On
+        Progress admission (advanced past its policy gates via
+        ``bypass_policy_check``, mirroring ``test_ui_school_admission.py``),
+        one active Customer Invoice Export Type (Pre-Condition Data),
+        and one payment term whose generated invoice is confirmed and
+        approved to Unpaid (open) -- the Pre-Condition this IK's wizard
+        needs before its button becomes visible
+        (``create_invoice_export_ok``).
+        """
+        super().setUpClass()
+        cls.admin_user = cls.env.ref("base.user_admin")
+
+        # -- Accounting basics -------------------------------------------
+        cls.ci_journal = cls.env["account.journal"].search(
+            [("type", "=", "sale")], limit=1
+        )
+        receivable_type = cls.env.ref("account.data_account_type_receivable")
+        cls.ci_account = cls.env["account.account"].create(
+            {
+                "name": "TOUR ADM IE Receivable",
+                "code": "TOURADMIERCV",
+                "user_type_id": receivable_type.id,
+                "reconcile": True,
+            }
+        )
+        cls.ci_type = cls.env["customer_invoice_type"].create(
+            {
+                "name": "TOUR ADM IE CI Type",
+                "code": "TOURADMIECIT",
+                "journal_id": cls.ci_journal.id,
+                "receivable_account_id": cls.ci_account.id,
+            }
+        )
+        income_type = cls.env.ref("account.data_account_type_revenue")
+        cls.income_account = cls.env["account.account"].create(
+            {
+                "name": "TOUR ADM IE Income",
+                "code": "TOURADMIEINC",
+                "user_type_id": income_type.id,
+            }
+        )
+        cls.product = cls.env["product.product"].create(
+            {
+                "name": "TOUR ADM IE Fee",
+                "type": "service",
+                "list_price": 1_000_000.0,
+            }
+        )
+
+        # -- Academic structure -------------------------------------------
+        cls.grade_type = cls.env["school_grade_type"].create(
+            {"name": "TOUR ADM IE Grade Type", "code": "TOURADMIEGT"}
+        )
+        cls.academic_year = cls.env["school_academic_year"].create(
+            {
+                "name": "TOUR ADM IE Academic Year",
+                "code": "TOURADMIEAY",
+                "date_start": "2024-07-01",
+                "date_end": "2025-06-30",
+            }
+        )
+        cls.academic_term = cls.env["school_academic_term"].create(
+            {
+                "name": "TOUR ADM IE Term",
+                "code": "TOURADMIET",
+                "date_start": "2024-07-01",
+                "date_end": "2025-06-30",
+                "year_id": cls.academic_year.id,
+                "enrollment_state": "open",
+            }
+        )
+        cls.school = cls.env["school"].create(
+            {
+                "name": "TOUR ADM IE School",
+                "code": "TOURADMIESCH",
+                "grade_type_id": cls.grade_type.id,
+            }
+        )
+        cls.grade = cls.env["school_grade"].create(
+            {
+                "name": "TOUR ADM IE Grade",
+                "code": "TOURADMIEG",
+                "sequence": 10,
+                "type_id": cls.grade_type.id,
+            }
+        )
+
+        # -- Student ----------------------------------------------------
+        cls.student = cls.env["res.partner"].create({"name": "TOUR ADM IE Student"})
+
+        # -- Export type (20-create-invoice-export.md Pre-Condition Data) -
+        cls.export_type = cls.env["customer_invoice_export_type"].create(
+            {
+                "name": "TOUR ADM IE Export Type",
+                "code": "TOURADMIEET",
+                "default_output_format": "csv",
+            }
+        )
+
+        # -- Admission, advanced to Open (On Progress) -----------------------
+        cls.admission = cls.env["school_admission"].create(
+            {
+                "user_id": cls.admin_user.id,
+                "customer_invoice_type_id": cls.ci_type.id,
+                "receivable_account_id": cls.ci_account.id,
+                "pricelist_id": cls.env.ref("product.list0").id,
+                "date": "2024-07-01",
+                "academic_year_id": cls.academic_year.id,
+                "academic_term_id": cls.academic_term.id,
+                "school_id": cls.school.id,
+                "grade_id": cls.grade.id,
+                "student_id": cls.student.id,
+                "currency_id": cls.env.company.currency_id.id,
+                "receivable_journal_id": cls.ci_journal.id,
+            }
+        )
+        cls.admission.with_context(bypass_policy_check=True).action_confirm()
+        cls.admission.invalidate_cache()
+        cls.admission.with_context(bypass_policy_check=True).action_approve_approval()
+        cls.admission.invalidate_cache()
+
+        # -- Payment term with an Unpaid (open) invoiced move ---------------
+        cls.term_open = cls.env["school_admission_payment_term"].create(
+            {
+                "admission_id": cls.admission.id,
+                "name": "TOUR ADM IE Open Term",
+                "sequence": 10,
+                "detail_ids": [
+                    (
+                        0,
+                        0,
+                        {
+                            "product_id": cls.product.id,
+                            "name": "TOUR ADM IE Open Fee",
+                            "account_id": cls.income_account.id,
+                            "uom_quantity": 1.0,
+                            "uom_id": cls.env.ref("uom.product_uom_unit").id,
+                            "price_unit": 1_000_000.0,
+                        },
+                    )
+                ],
+            }
+        )
+        cls.term_open.action_create_invoice()
+        cls.invoice_open = cls.term_open.customer_invoice_id
+        cls.invoice_open.with_context(bypass_policy_check=True).action_confirm()
+        cls.invoice_open.invalidate_cache()
+        cls.invoice_open.with_context(
+            bypass_policy_check=True
+        ).action_approve_approval()
+        cls.invoice_open.invalidate_cache()
+
+    def test_create_invoice_export(self):
+        """Run the create-invoice-export tour on the Open admission.
+
+        IK: docs/school_admission/20-create-invoice-export.md
+        """
+        self.start_tour(
+            "/web",
+            "ssi_school_admission_customer_invoice_export_school_admission"
+            "_create_invoice_export",
+            login="admin",
+        )

--- a/ssi_school_admission_customer_invoice_export/tests/test_ui_school_admission_create_invoice_export.py
+++ b/ssi_school_admission_customer_invoice_export/tests/test_ui_school_admission_create_invoice_export.py
@@ -2,7 +2,11 @@
 # Copyright 2026 PT. Simetri Sinergi Indonesia
 # License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl).
 
+import logging
+
 from odoo.tests import HttpSavepointCase, tagged
+
+_logger = logging.getLogger(__name__)
 
 
 @tagged("post_install", "-at_install")
@@ -210,8 +214,23 @@ class TestUiSchoolAdmissionCreateInvoiceExport(HttpSavepointCase):
         )
         cls.admission.with_context(bypass_policy_check=True).action_confirm()
         cls.admission.invalidate_cache()
+        _logger.info(
+            "DIAG-ADM after confirm: state=%s template=%s approvals=%s",
+            cls.admission.state,
+            cls.admission.approval_template_id.display_name,
+            [
+                (a.status, a.approver_user_ids.ids, a.approver_selection_method)
+                for a in cls.admission.approval_ids
+            ],
+        )
         cls.admission.with_context(bypass_policy_check=True).action_approve_approval()
         cls.admission.invalidate_cache()
+        _logger.info(
+            "DIAG-ADM after approve: state=%s approvals=%s env_uid=%s",
+            cls.admission.state,
+            [(a.status, a.approver_user_ids.ids) for a in cls.admission.approval_ids],
+            cls.env.uid,
+        )
 
         # -- Payment term with an Unpaid (open) invoiced move ---------------
         cls.term_open = cls.env["school_admission_payment_term"].create(

--- a/ssi_school_admission_customer_invoice_export/tests/test_ui_school_admission_create_invoice_export.py
+++ b/ssi_school_admission_customer_invoice_export/tests/test_ui_school_admission_create_invoice_export.py
@@ -122,6 +122,75 @@ class TestUiSchoolAdmissionCreateInvoiceExport(HttpSavepointCase):
             }
         )
 
+        # -- Policy: grant create_invoice_export_ok (20-create-invoice-
+        # export.md Pre-Condition Config) -----------------------------
+        # The shipped policy_template_school_admission already ships a
+        # policy.template_detail for this field
+        # (policy_template/school_admission.xml), but its correctness
+        # cannot be assumed from the test side -- write/create it
+        # explicitly here too (mirrors
+        # test_ui_school_admission.py's restart_approval_ok-style setup
+        # in test_ui_school_enrollment.py) so this tour's Pre-Condition
+        # is guaranteed regardless of the shipped data.
+        # computation_method "use_group" is evaluated against the REAL
+        # browsing user ("admin", not the superuser cls.env runs as
+        # during setUpClass), so the group is also granted to admin
+        # explicitly below.
+        state_field = cls.env["ir.model.fields"].search(
+            [("model_id.model", "=", "school_admission"), ("name", "=", "state")],
+            limit=1,
+        )
+        open_done_selections = cls.env["ir.model.fields.selection"].search(
+            [
+                ("field_id", "=", state_field.id),
+                ("value", "in", ["open", "done"]),
+            ]
+        )
+        create_invoice_export_field = cls.env["ir.model.fields"].search(
+            [
+                ("model_id.model", "=", "school_admission"),
+                ("name", "=", "create_invoice_export_ok"),
+            ],
+            limit=1,
+        )
+        admission_user_group = cls.env.ref(
+            "ssi_school_admission.school_admission_user_group"
+        )
+        policy_detail_vals = {
+            "restrict_state": True,
+            "state_ids": [(6, 0, open_done_selections.ids)],
+            "restrict_user": True,
+            "computation_method": "use_group",
+            "group_ids": [(6, 0, [admission_user_group.id])],
+            "restrict_additional": False,
+        }
+        existing_detail = cls.env["policy.template_detail"].search(
+            [
+                (
+                    "template_id",
+                    "=",
+                    cls.env.ref(
+                        "ssi_school_admission.policy_template_school_admission"
+                    ).id,
+                ),
+                ("field_id", "=", create_invoice_export_field.id),
+            ],
+            limit=1,
+        )
+        if existing_detail:
+            existing_detail.write(policy_detail_vals)
+        else:
+            policy_detail_vals.update(
+                {
+                    "template_id": cls.env.ref(
+                        "ssi_school_admission.policy_template_school_admission"
+                    ).id,
+                    "field_id": create_invoice_export_field.id,
+                }
+            )
+            cls.env["policy.template_detail"].create(policy_detail_vals)
+        admission_user_group.sudo().write({"users": [(4, cls.admin_user.id)]})
+
         # -- Admission, advanced to Open (On Progress) -----------------------
         cls.admission = cls.env["school_admission"].create(
             {

--- a/ssi_school_admission_customer_invoice_export/tests/test_ui_school_admission_create_invoice_export.py
+++ b/ssi_school_admission_customer_invoice_export/tests/test_ui_school_admission_create_invoice_export.py
@@ -2,11 +2,7 @@
 # Copyright 2026 PT. Simetri Sinergi Indonesia
 # License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl).
 
-import logging
-
 from odoo.tests import HttpSavepointCase, tagged
-
-_logger = logging.getLogger(__name__)
 
 
 @tagged("post_install", "-at_install")
@@ -214,23 +210,28 @@ class TestUiSchoolAdmissionCreateInvoiceExport(HttpSavepointCase):
         )
         cls.admission.with_context(bypass_policy_check=True).action_confirm()
         cls.admission.invalidate_cache()
-        _logger.info(
-            "DIAG-ADM after confirm: state=%s template=%s approvals=%s",
-            cls.admission.state,
-            cls.admission.approval_template_id.display_name,
-            [
-                (a.status, a.approver_user_ids.ids, a.approver_selection_method)
-                for a in cls.admission.approval_ids
-            ],
-        )
-        cls.admission.with_context(bypass_policy_check=True).action_approve_approval()
+        # mixin.multiple_approval's _action_approval() only marks the
+        # active approval.approval "approved" when the ACTING user is
+        # found in that record's approver_user_ids -- a real membership
+        # list computed once (stored, api.depends=["template_detail_id"]
+        # only -- see approval_approval.py) from the shipped detail's
+        # approver_group_ids.users AT THE TIME the approval record was
+        # created (during this test's action_confirm() above). A CI-run
+        # diagnostic (ssi_school_customer_invoice_export's own fixture,
+        # same mechanism) proved that list is [admin_user.id] only --
+        # NOT the superuser cls.env runs as (uid=1) -- even though the
+        # shipped XML data nominally grants both base.user_root and
+        # base.user_admin. bypass_policy_check only skips the outer
+        # _check_approve_policy() gate, not this inner approver filter
+        # (same trap documented for action_reject_approval() in
+        # test_ui_school_admission.py), so approving as the superuser
+        # silently no-ops here. Approve as admin_user explicitly instead
+        # -- confirmed present in approver_user_ids, and the same
+        # identity the tour browses as.
+        cls.admission.with_context(bypass_policy_check=True).with_user(
+            cls.admin_user
+        ).action_approve_approval()
         cls.admission.invalidate_cache()
-        _logger.info(
-            "DIAG-ADM after approve: state=%s approvals=%s env_uid=%s",
-            cls.admission.state,
-            [(a.status, a.approver_user_ids.ids) for a in cls.admission.approval_ids],
-            cls.env.uid,
-        )
 
         # -- Payment term with an Unpaid (open) invoiced move ---------------
         cls.term_open = cls.env["school_admission_payment_term"].create(
@@ -258,8 +259,13 @@ class TestUiSchoolAdmissionCreateInvoiceExport(HttpSavepointCase):
         cls.invoice_open = cls.term_open.customer_invoice_id
         cls.invoice_open.with_context(bypass_policy_check=True).action_confirm()
         cls.invoice_open.invalidate_cache()
-        cls.invoice_open.with_context(
-            bypass_policy_check=True
+        # Same approver-identity requirement as the admission approve
+        # above (customer_invoice_validator_group ships the same
+        # base.user_root/base.user_admin grant, but approver_user_ids is
+        # only reliably populated for admin_user at compute time) --
+        # approve as admin_user, not the superuser cls.env runs as.
+        cls.invoice_open.with_context(bypass_policy_check=True).with_user(
+            cls.admin_user
         ).action_approve_approval()
         cls.invoice_open.invalidate_cache()
 

--- a/ssi_school_admission_customer_invoice_export/views/assets.xml
+++ b/ssi_school_admission_customer_invoice_export/views/assets.xml
@@ -1,0 +1,18 @@
+<?xml version="1.0" encoding="utf-8" ?>
+<!-- Copyright 2026 OpenSynergy Indonesia
+     Copyright 2026 PT. Simetri Sinergi Indonesia
+     License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl). -->
+<odoo>
+    <template
+        id="assets_tests"
+        name="ssi_school_admission_customer_invoice_export assets tests"
+        inherit_id="web.assets_tests"
+    >
+        <xpath expr="." position="inside">
+            <script
+                type="text/javascript"
+                src="/ssi_school_admission_customer_invoice_export/static/tests/tours/school_admission_create_invoice_export_tour.js"
+            />
+        </xpath>
+    </template>
+</odoo>

--- a/ssi_school_customer_invoice_export/__manifest__.py
+++ b/ssi_school_customer_invoice_export/__manifest__.py
@@ -16,6 +16,7 @@
     "depends": [
         "ssi_school",
         "ssi_customer_invoice_export",
+        "web_tour",
     ],
     "data": [
         # Security - access
@@ -24,6 +25,7 @@
         "policy_template/school_enrollment.xml",
         # Views
         "views/school_enrollment.xml",
+        "views/assets.xml",
         "wizards/school_enrollment_create_invoice_export.xml",
     ],
     "demo": [],

--- a/ssi_school_customer_invoice_export/static/tests/tours/school_enrollment_create_invoice_export_tour.js
+++ b/ssi_school_customer_invoice_export/static/tests/tours/school_enrollment_create_invoice_export_tour.js
@@ -1,0 +1,150 @@
+// Copyright 2026 OpenSynergy Indonesia
+// Copyright 2026 PT. Simetri Sinergi Indonesia
+// License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl).
+
+odoo.define(
+    "ssi_school_customer_invoice_export.school_enrollment_create_invoice_export_tour",
+    function (require) {
+        "use strict";
+
+        var tour = require("web_tour.tour");
+
+        // Shared navigation block -- corresponds to Flow 1 of the IK:
+        // "Open the School > Student Activities > Enrollments menu."
+        // Mirrors ssi_school.school_enrollment_tour's own helper.
+        function openEnrollmentList() {
+            return [
+                tour.stepUtils.showAppsMenuItem(),
+                {
+                    content: "Open the School app",
+                    trigger: '.o_app[data-menu-xmlid="ssi_school.menu_school_root"]',
+                },
+                {
+                    content: "Open the Student Activities menu",
+                    trigger:
+                        '.o_menu_sections [data-menu-xmlid="ssi_school.menu_school_student_activity"]',
+                },
+                {
+                    content: "Open the Enrollments menu",
+                    trigger:
+                        '.o_menu_sections [data-menu-xmlid="ssi_school.school_enrollment_menu"]',
+                },
+                {
+                    // Gerbang: tunggu action TUJUAN benar-benar terpasang.
+                    content: "Enrollments list is displayed",
+                    trigger:
+                        ".o_control_panel .breadcrumb-item.active:contains(Enrollments)",
+                    extra_trigger: ".o_list_view",
+                    run: function () {
+                        // Assertion only; do not trigger the default click.
+                    },
+                },
+            ];
+        }
+
+        // Opens the record identified by the unique student name shown on
+        // the list row's Student column.
+        function openRecordByStudent(studentName) {
+            return [
+                {
+                    content: "Open the record",
+                    trigger:
+                        ".o_data_row:contains(" + studentName + ") .o_data_cell:first",
+                    extra_trigger: ".o_list_view",
+                },
+                {
+                    content: "Form is open",
+                    trigger: ".o_form_view",
+                    run: function () {
+                        // Assertion only.
+                    },
+                },
+            ];
+        }
+
+        // IK: docs/school_enrollment/23-create-invoice-export.md
+        tour.register(
+            "ssi_school_customer_invoice_export_school_enrollment_create_invoice_export",
+            {
+                test: true,
+                url: "/web",
+            },
+            [].concat(
+                // Flow 1 -- Open the Enrollments menu.
+                openEnrollmentList(),
+                // Flow 2 -- Open the record whose unpaid invoices will be
+                // exported.
+                openRecordByStudent("TOUR ENR IE Student"),
+                [
+                    // Flow 3 -- Click the Create Invoice Export button
+                    // (action_open_create_invoice_export_wizard).
+                    {
+                        content: "Click the Create Invoice Export button",
+                        trigger:
+                            ".o_statusbar_buttons button[name='action_open_create_invoice_export_wizard']",
+                        extra_trigger: ".o_form_view",
+                    },
+                    {
+                        // 14.0: JANGAN prefiks `.modal` (patterns.md §H).
+                        content: "Wizard is open",
+                        trigger: ".o_form_view",
+                        run: function () {
+                            // Assertion only.
+                        },
+                    },
+
+                    // Flow 4 -- the current record is pre-selected
+                    // (Enrollments field, readonly many2many tags, hidden
+                    // -- no interaction needed).
+
+                    // Flow 5 -- fill in the required Type field. Date
+                    // keeps its default (today), Output Format is
+                    // auto-filled from Type, and Date Start/Date End are
+                    // left empty (no bound).
+                    {
+                        content: "Select the Type field value",
+                        trigger: ".o_field_many2one[name='type_id'] input",
+                        run: "text TOUR ENR IE Export Type",
+                    },
+                    {
+                        content: "Pick the Type from the dropdown",
+                        trigger:
+                            ".ui-autocomplete .ui-menu-item a:contains(TOUR ENR IE Export Type)",
+                        in_modal: false,
+                    },
+
+                    // Flow 6 -- Click Create Invoice Export in the wizard
+                    // footer.
+                    {
+                        content: "Click Create Invoice Export in the wizard",
+                        trigger:
+                            ".modal-footer button[name='action_create_invoice_export']",
+                    },
+                    {
+                        content: "Wizard is closed",
+                        trigger: "body:not(:has(.modal))",
+                        run: function () {
+                            // Assertion only.
+                        },
+                    },
+
+                    // Post-Condition -- the created Customer Invoice
+                    // Export document opens in form view, in Draft
+                    // status. The OLD enrollment form's active statusbar
+                    // button is "open", never "draft", so this selector
+                    // cannot match before the new document actually
+                    // loads (patterns.md §M litmus test).
+                    {
+                        content:
+                            "Customer Invoice Export document opens in Draft status",
+                        trigger:
+                            ".o_statusbar_status .o_arrow_button[data-value='draft'].btn-primary",
+                        run: function () {
+                            // Assertion only.
+                        },
+                    },
+                ]
+            )
+        );
+    }
+);

--- a/ssi_school_customer_invoice_export/tests/__init__.py
+++ b/ssi_school_customer_invoice_export/tests/__init__.py
@@ -3,3 +3,4 @@
 # License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl).
 
 from . import test_school_enrollment_create_invoice_export
+from . import test_ui_school_enrollment_create_invoice_export

--- a/ssi_school_customer_invoice_export/tests/test_ui_school_enrollment_create_invoice_export.py
+++ b/ssi_school_customer_invoice_export/tests/test_ui_school_enrollment_create_invoice_export.py
@@ -1,0 +1,204 @@
+# Copyright 2026 OpenSynergy Indonesia
+# Copyright 2026 PT. Simetri Sinergi Indonesia
+# License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl).
+
+from odoo.tests import HttpSavepointCase, tagged
+
+
+@tagged("post_install", "-at_install")
+class TestUiSchoolEnrollmentCreateInvoiceExport(HttpSavepointCase):
+    """Tour test for the Create Invoice Export wizard on enrollment."""
+
+    @classmethod
+    def setUpClass(cls):
+        """Build an Open enrollment with one unpaid invoiced term.
+
+        ``SavepointCase.setUpClass`` runs ``cls.env`` as SUPERUSER_ID, so
+        any fixture created via ``cls.env.create()`` without an explicit
+        ``user_id`` defaults "Responsible" to the superuser, not
+        "admin" -- ``school_enrollment_internal_user_rule`` (scoped by
+        ``user_id``) would then hide it from the "admin" tour session.
+        ``user_id`` is set explicitly below (mirrors
+        ``test_ui_school_admission.py``).
+
+        Builds the accounting basics (journal/account/customer invoice
+        type/income account/product), the academic structure (grade
+        type, academic year/term, school, grade, grade class), one
+        student, one On Progress enrollment (advanced past its policy
+        gates via ``bypass_policy_check``, mirroring
+        ``test_ui_school_enrollment.py``), one active Customer Invoice
+        Export Type (Pre-Condition Data), and one payment term whose
+        generated invoice is confirmed and approved to Unpaid (open) --
+        the Pre-Condition this IK's wizard needs before its button
+        becomes visible (``create_invoice_export_ok``).
+        """
+        super().setUpClass()
+        cls.admin_user = cls.env.ref("base.user_admin")
+
+        # -- Accounting basics -------------------------------------------
+        cls.ci_journal = cls.env["account.journal"].search(
+            [("type", "=", "sale")], limit=1
+        )
+        receivable_type = cls.env.ref("account.data_account_type_receivable")
+        cls.ci_account = cls.env["account.account"].create(
+            {
+                "name": "TOUR ENR IE Receivable",
+                "code": "TOURENRIERCV",
+                "user_type_id": receivable_type.id,
+                "reconcile": True,
+            }
+        )
+        cls.ci_type = cls.env["customer_invoice_type"].create(
+            {
+                "name": "TOUR ENR IE CI Type",
+                "code": "TOURENRIECIT",
+                "journal_id": cls.ci_journal.id,
+                "receivable_account_id": cls.ci_account.id,
+            }
+        )
+        income_type = cls.env.ref("account.data_account_type_revenue")
+        cls.income_account = cls.env["account.account"].create(
+            {
+                "name": "TOUR ENR IE Income",
+                "code": "TOURENRIEINC",
+                "user_type_id": income_type.id,
+            }
+        )
+        cls.product = cls.env["product.product"].create(
+            {
+                "name": "TOUR ENR IE Fee",
+                "type": "service",
+                "list_price": 1_000_000.0,
+            }
+        )
+
+        # -- Academic structure -------------------------------------------
+        cls.grade_type = cls.env["school_grade_type"].create(
+            {"name": "TOUR ENR IE Grade Type", "code": "TOURENRIEGT"}
+        )
+        cls.academic_year = cls.env["school_academic_year"].create(
+            {
+                "name": "TOUR ENR IE Academic Year",
+                "code": "TOURENRIEAY",
+                "date_start": "2024-07-01",
+                "date_end": "2025-06-30",
+            }
+        )
+        cls.academic_term = cls.env["school_academic_term"].create(
+            {
+                "name": "TOUR ENR IE Term",
+                "code": "TOURENRIET",
+                "date_start": "2024-07-01",
+                "date_end": "2025-06-30",
+                "year_id": cls.academic_year.id,
+                "enrollment_state": "open",
+            }
+        )
+        cls.school = cls.env["school"].create(
+            {
+                "name": "TOUR ENR IE School",
+                "code": "TOURENRIESCH",
+                "grade_type_id": cls.grade_type.id,
+            }
+        )
+        cls.grade = cls.env["school_grade"].create(
+            {
+                "name": "TOUR ENR IE Grade",
+                "code": "TOURENRIEG",
+                "sequence": 10,
+                "type_id": cls.grade_type.id,
+            }
+        )
+        cls.grade_class = cls.env["school_grade_class"].create(
+            {
+                "name": "TOUR ENR IE Class",
+                "code": "TOURENRIECL",
+                "school_id": cls.school.id,
+                "grade_id": cls.grade.id,
+            }
+        )
+
+        # -- Student --------------------------------------------------------
+        contact = cls.env["res.partner"].create({"name": "TOUR ENR IE Student"})
+        cls.student = cls.env["school_student"].create(
+            {
+                "name": "TOUR ENR IE Student",
+                "code": "/",
+                "school_id": cls.school.id,
+                "contact_id": contact.id,
+            }
+        )
+
+        # -- Export type (23-create-invoice-export.md Pre-Condition Data) -
+        cls.export_type = cls.env["customer_invoice_export_type"].create(
+            {
+                "name": "TOUR ENR IE Export Type",
+                "code": "TOURENRIEET",
+                "default_output_format": "csv",
+            }
+        )
+
+        # -- Enrollment, advanced to Open (On Progress) ---------------------
+        cls.enrollment = cls.env["school_enrollment"].create(
+            {
+                "user_id": cls.admin_user.id,
+                "customer_invoice_type_id": cls.ci_type.id,
+                "receivable_account_id": cls.ci_account.id,
+                "pricelist_id": cls.env.ref("product.list0").id,
+                "date": "2024-07-01",
+                "academic_year_id": cls.academic_year.id,
+                "academic_term_id": cls.academic_term.id,
+                "school_id": cls.school.id,
+                "grade_id": cls.grade.id,
+                "grade_class_id": cls.grade_class.id,
+                "student_id": cls.student.id,
+                "currency_id": cls.env.company.currency_id.id,
+                "receivable_journal_id": cls.ci_journal.id,
+            }
+        )
+        cls.enrollment.with_context(bypass_policy_check=True).action_confirm()
+        cls.enrollment.invalidate_cache()
+        cls.enrollment.with_context(bypass_policy_check=True).action_approve_approval()
+        cls.enrollment.invalidate_cache()
+
+        # -- Payment term with an Unpaid (open) invoiced move ---------------
+        cls.term_open = cls.env["school_enrollment_payment_term"].create(
+            {
+                "enrollment_id": cls.enrollment.id,
+                "name": "TOUR ENR IE Open Term",
+                "sequence": 10,
+                "detail_ids": [
+                    (
+                        0,
+                        0,
+                        {
+                            "product_id": cls.product.id,
+                            "name": "TOUR ENR IE Open Fee",
+                            "account_id": cls.income_account.id,
+                            "uom_quantity": 1.0,
+                            "uom_id": cls.env.ref("uom.product_uom_unit").id,
+                            "price_unit": 1_000_000.0,
+                        },
+                    )
+                ],
+            }
+        )
+        cls.term_open.action_create_invoice()
+        cls.invoice_open = cls.term_open.customer_invoice_id
+        cls.invoice_open.with_context(bypass_policy_check=True).action_confirm()
+        cls.invoice_open.invalidate_cache()
+        cls.invoice_open.with_context(
+            bypass_policy_check=True
+        ).action_approve_approval()
+        cls.invoice_open.invalidate_cache()
+
+    def test_create_invoice_export(self):
+        """Run the create-invoice-export tour on the Open enrollment.
+
+        IK: docs/school_enrollment/23-create-invoice-export.md
+        """
+        self.start_tour(
+            "/web",
+            "ssi_school_customer_invoice_export_school_enrollment_create_invoice_export",
+            login="admin",
+        )

--- a/ssi_school_customer_invoice_export/tests/test_ui_school_enrollment_create_invoice_export.py
+++ b/ssi_school_customer_invoice_export/tests/test_ui_school_enrollment_create_invoice_export.py
@@ -2,11 +2,7 @@
 # Copyright 2026 PT. Simetri Sinergi Indonesia
 # License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl).
 
-import logging
-
 from odoo.tests import HttpSavepointCase, tagged
-
-_logger = logging.getLogger(__name__)
 
 
 @tagged("post_install", "-at_install")
@@ -226,23 +222,27 @@ class TestUiSchoolEnrollmentCreateInvoiceExport(HttpSavepointCase):
         )
         cls.enrollment.with_context(bypass_policy_check=True).action_confirm()
         cls.enrollment.invalidate_cache()
-        _logger.info(
-            "DIAG-ENR after confirm: state=%s template=%s approvals=%s",
-            cls.enrollment.state,
-            cls.enrollment.approval_template_id.display_name,
-            [
-                (a.status, a.approver_user_ids.ids, a.approver_selection_method)
-                for a in cls.enrollment.approval_ids
-            ],
-        )
-        cls.enrollment.with_context(bypass_policy_check=True).action_approve_approval()
+        # mixin.multiple_approval's _action_approval() only marks the
+        # active approval.approval "approved" when the ACTING user is
+        # found in that record's approver_user_ids -- a real membership
+        # list computed once (stored, api.depends=["template_detail_id"]
+        # only -- see approval_approval.py) from the shipped detail's
+        # approver_group_ids.users AT THE TIME the approval record was
+        # created (during this test's action_confirm() above). A CI-run
+        # diagnostic proved that list is [admin_user.id] only -- NOT the
+        # superuser cls.env runs as (uid=1) -- for this fixture, even
+        # though school_enrollment_validator_group's shipped XML data
+        # nominally grants both base.user_root and base.user_admin.
+        # bypass_policy_check only skips the outer _check_approve_policy()
+        # gate, not this inner approver filter (same trap documented for
+        # action_reject_approval() in test_ui_school_enrollment.py), so
+        # approving as the superuser silently no-ops here. Approve as
+        # admin_user explicitly instead -- confirmed present in
+        # approver_user_ids, and the same identity the tour browses as.
+        cls.enrollment.with_context(bypass_policy_check=True).with_user(
+            cls.admin_user
+        ).action_approve_approval()
         cls.enrollment.invalidate_cache()
-        _logger.info(
-            "DIAG-ENR after approve: state=%s approvals=%s env_uid=%s",
-            cls.enrollment.state,
-            [(a.status, a.approver_user_ids.ids) for a in cls.enrollment.approval_ids],
-            cls.env.uid,
-        )
 
         # -- Payment term with an Unpaid (open) invoiced move ---------------
         cls.term_open = cls.env["school_enrollment_payment_term"].create(
@@ -270,8 +270,13 @@ class TestUiSchoolEnrollmentCreateInvoiceExport(HttpSavepointCase):
         cls.invoice_open = cls.term_open.customer_invoice_id
         cls.invoice_open.with_context(bypass_policy_check=True).action_confirm()
         cls.invoice_open.invalidate_cache()
-        cls.invoice_open.with_context(
-            bypass_policy_check=True
+        # Same approver-identity requirement as the enrollment approve
+        # above (customer_invoice_validator_group ships the same
+        # base.user_root/base.user_admin grant, but approver_user_ids is
+        # only reliably populated for admin_user at compute time) --
+        # approve as admin_user, not the superuser cls.env runs as.
+        cls.invoice_open.with_context(bypass_policy_check=True).with_user(
+            cls.admin_user
         ).action_approve_approval()
         cls.invoice_open.invalidate_cache()
 

--- a/ssi_school_customer_invoice_export/tests/test_ui_school_enrollment_create_invoice_export.py
+++ b/ssi_school_customer_invoice_export/tests/test_ui_school_enrollment_create_invoice_export.py
@@ -138,6 +138,70 @@ class TestUiSchoolEnrollmentCreateInvoiceExport(HttpSavepointCase):
             }
         )
 
+        # -- Policy: grant create_invoice_export_ok (23-create-invoice-
+        # export.md Pre-Condition Config) -----------------------------
+        # The shipped policy_template_school_enrollment already ships a
+        # policy.template_detail for this field
+        # (policy_template/school_enrollment.xml), but its correctness
+        # cannot be assumed from the test side -- write/create it
+        # explicitly here too (mirrors
+        # test_ui_school_enrollment.py's restart_approval_ok setup) so
+        # this tour's Pre-Condition is guaranteed regardless of the
+        # shipped data. computation_method "use_group" is evaluated
+        # against the REAL browsing user ("admin", not the superuser
+        # cls.env runs as during setUpClass), so the group is also
+        # granted to admin explicitly below.
+        state_field = cls.env["ir.model.fields"].search(
+            [("model_id.model", "=", "school_enrollment"), ("name", "=", "state")],
+            limit=1,
+        )
+        open_done_selections = cls.env["ir.model.fields.selection"].search(
+            [
+                ("field_id", "=", state_field.id),
+                ("value", "in", ["open", "done"]),
+            ]
+        )
+        create_invoice_export_field = cls.env["ir.model.fields"].search(
+            [
+                ("model_id.model", "=", "school_enrollment"),
+                ("name", "=", "create_invoice_export_ok"),
+            ],
+            limit=1,
+        )
+        enrollment_user_group = cls.env.ref("ssi_school.school_enrollment_user_group")
+        policy_detail_vals = {
+            "restrict_state": True,
+            "state_ids": [(6, 0, open_done_selections.ids)],
+            "restrict_user": True,
+            "computation_method": "use_group",
+            "group_ids": [(6, 0, [enrollment_user_group.id])],
+            "restrict_additional": False,
+        }
+        existing_detail = cls.env["policy.template_detail"].search(
+            [
+                (
+                    "template_id",
+                    "=",
+                    cls.env.ref("ssi_school.policy_template_school_enrollment").id,
+                ),
+                ("field_id", "=", create_invoice_export_field.id),
+            ],
+            limit=1,
+        )
+        if existing_detail:
+            existing_detail.write(policy_detail_vals)
+        else:
+            policy_detail_vals.update(
+                {
+                    "template_id": cls.env.ref(
+                        "ssi_school.policy_template_school_enrollment"
+                    ).id,
+                    "field_id": create_invoice_export_field.id,
+                }
+            )
+            cls.env["policy.template_detail"].create(policy_detail_vals)
+        enrollment_user_group.sudo().write({"users": [(4, cls.admin_user.id)]})
+
         # -- Enrollment, advanced to Open (On Progress) ---------------------
         cls.enrollment = cls.env["school_enrollment"].create(
             {

--- a/ssi_school_customer_invoice_export/tests/test_ui_school_enrollment_create_invoice_export.py
+++ b/ssi_school_customer_invoice_export/tests/test_ui_school_enrollment_create_invoice_export.py
@@ -2,7 +2,11 @@
 # Copyright 2026 PT. Simetri Sinergi Indonesia
 # License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl).
 
+import logging
+
 from odoo.tests import HttpSavepointCase, tagged
+
+_logger = logging.getLogger(__name__)
 
 
 @tagged("post_install", "-at_install")
@@ -222,8 +226,23 @@ class TestUiSchoolEnrollmentCreateInvoiceExport(HttpSavepointCase):
         )
         cls.enrollment.with_context(bypass_policy_check=True).action_confirm()
         cls.enrollment.invalidate_cache()
+        _logger.info(
+            "DIAG-ENR after confirm: state=%s template=%s approvals=%s",
+            cls.enrollment.state,
+            cls.enrollment.approval_template_id.display_name,
+            [
+                (a.status, a.approver_user_ids.ids, a.approver_selection_method)
+                for a in cls.enrollment.approval_ids
+            ],
+        )
         cls.enrollment.with_context(bypass_policy_check=True).action_approve_approval()
         cls.enrollment.invalidate_cache()
+        _logger.info(
+            "DIAG-ENR after approve: state=%s approvals=%s env_uid=%s",
+            cls.enrollment.state,
+            [(a.status, a.approver_user_ids.ids) for a in cls.enrollment.approval_ids],
+            cls.env.uid,
+        )
 
         # -- Payment term with an Unpaid (open) invoiced move ---------------
         cls.term_open = cls.env["school_enrollment_payment_term"].create(

--- a/ssi_school_customer_invoice_export/views/assets.xml
+++ b/ssi_school_customer_invoice_export/views/assets.xml
@@ -1,0 +1,18 @@
+<?xml version="1.0" encoding="utf-8" ?>
+<!-- Copyright 2026 OpenSynergy Indonesia
+     Copyright 2026 PT. Simetri Sinergi Indonesia
+     License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl). -->
+<odoo>
+    <template
+        id="assets_tests"
+        name="ssi_school_customer_invoice_export assets tests"
+        inherit_id="web.assets_tests"
+    >
+        <xpath expr="." position="inside">
+            <script
+                type="text/javascript"
+                src="/ssi_school_customer_invoice_export/static/tests/tours/school_enrollment_create_invoice_export_tour.js"
+            />
+        </xpath>
+    </template>
+</odoo>


### PR DESCRIPTION
## Summary

- Menambahkan tour UI (Odoo Tour + `HttpCase.start_tour`) untuk tombol Create Invoice Export pada `school_enrollment` (`ssi_school_customer_invoice_export`) dan `school_admission` (`ssi_school_admission_customer_invoice_export`), sesuai IK yang dihasilkan issue #223.
- Setiap tour dipetakan 1:1 dari Flow IK-nya, dengan penanda `IK: docs/<model>/NN-create-invoice-export.md` di docstring method tour (`tests/`), memenuhi gerbang tautan IK-tour `validate-ik.sh`.
- Data prasyarat (enrollment/admission Open dengan payment term ber-invoice Unpaid, Customer Invoice Export Type aktif) disiapkan di `setUpClass`, bukan lewat langkah UI tambahan.
- Bundle `web.assets_tests` ditambahkan via `views/assets.xml` baru di kedua modul; dependensi manifest `web_tour` ditambahkan.

Closes #231

## Test plan

- [ ] CI GitHub menjalankan kedua tour (`ssi_school_customer_invoice_export_school_enrollment_create_invoice_export` dan `ssi_school_admission_customer_invoice_export_school_admission_create_invoice_export`) sampai hijau.
- [ ] `pre-commit run --all-files` hijau (sudah dijalankan lokal pada berkas yang diubah).