### PR TITLE
[UPD] ssi_school - Tangani enrollment siswa transfer-in di grade non-awal

### DIFF
--- a/ssi_school/models/school_enrollment.py
+++ b/ssi_school/models/school_enrollment.py
@@ -510,15 +510,16 @@ class SchoolEnrollment(models.Model):
 
     @api.depends("academic_term_id", "grade_id", "school_id")
     def _compute_allowed_student_ids(self):
-        """Compute the students selectable on this enrollment.
+        """Determine which students may be selected for this enrollment.
 
-        Fills ``allowed_student_ids`` with the ``draft`` students of
-        the same ``school_id``, matched on grade according to the
-        term: in a first term the student's ``next_grade_id`` must
-        equal ``grade_id`` (the student is being promoted into it),
-        in any other term the student's ``current_grade_id`` must
-        equal ``grade_id``. The field stays empty until academic term,
-        grade, and school are all set.
+        Two criteria are unioned: (1) regular eligibility, matching
+        ``next_grade_id`` on the academic year's first term or
+        ``current_grade_id`` on any other term; and (2) transfer-in
+        eligibility, which admits any ``draft`` student flagged
+        ``is_transfer_in`` in the same school, regardless of grade,
+        so a student transferring in mid-year can be enrolled directly
+        into the target grade of any term. The field stays empty until
+        academic term, grade, and school are all set.
 
         :return: None
         """
@@ -533,7 +534,20 @@ class SchoolEnrollment(models.Model):
                     criteria += [("next_grade_id", "=", record.grade_id.id)]
                 else:
                     criteria += [("current_grade_id", "=", record.grade_id.id)]
-                result = self.env["school_student"].search(criteria).ids
+                student_ids = set(self.env["school_student"].search(criteria).ids)
+
+                # Transfer-in students may be enrolled into any grade of any
+                # term, regardless of their computed current/next grade.
+                transfer_in_criteria = [
+                    ("state", "=", "draft"),
+                    ("school_id", "=", record.school_id.id),
+                    ("is_transfer_in", "=", True),
+                ]
+                student_ids |= set(
+                    self.env["school_student"].search(transfer_in_criteria).ids
+                )
+
+                result = list(student_ids)
             record.allowed_student_ids = result
 
     @api.onchange(

--- a/ssi_school/models/school_student.py
+++ b/ssi_school/models/school_student.py
@@ -277,6 +277,26 @@ class SchoolStudent(models.Model):
         domain=[("is_company", "=", False)],
         help="Contact data of the student's guardian if parents cannot be reached.",
     )
+
+    # Transfer In
+    is_transfer_in = fields.Boolean(
+        string="Transfer In",
+        help=(
+            "Indicates that this student transferred in from another "
+            "school, and may therefore be enrolled directly into any "
+            "grade of any term, regardless of the computed current/next "
+            "grade."
+        ),
+    )
+    origin_school = fields.Char(
+        string="Origin School",
+        help="Name of the school this transfer-in student came from.",
+    )
+    transfer_date = fields.Date(
+        string="Transfer Date",
+        help="Date on which this student transferred in from the origin school.",
+    )
+
     state = fields.Selection(
         string="State",
         selection=[

--- a/ssi_school/tests/__init__.py
+++ b/ssi_school/tests/__init__.py
@@ -19,6 +19,7 @@ from . import (  # noqa: F401
     test_school_student_personal_data,
     test_school_student_family,
     test_school_student_states,
+    test_school_student_transfer_in,
     test_school_enrollment_payment_template,
     test_school_enrollment_payment_product_configurator,
     test_school_enrollment,

--- a/ssi_school/tests/test_data_student_transfer_in.yaml
+++ b/ssi_school/tests/test_data_student_transfer_in.yaml
@@ -1,0 +1,249 @@
+options:
+  auto_refresh: true
+scenarios:
+  - name: "Transfer-in Student Allowed On Non-First Term Middle Grade"
+    steps:
+      - step: "Setup - create grade type"
+        action: "create"
+        model: "school_grade_type"
+        save_as: "grade_type"
+        values:
+          name: "Grade Type for Transfer In Test"
+          code: "GTTRIN"
+          sequence: 10
+
+      - step: "Setup - create grade 3"
+        action: "create"
+        model: "school_grade"
+        save_as: "grade_3"
+        values:
+          name: "Grade 3 for Transfer In"
+          code: "G3TRIN"
+          sequence: 30
+          type_id: "REC: grade_type.id"
+
+      - step: "Setup - create grade 4"
+        action: "create"
+        model: "school_grade"
+        save_as: "grade_4"
+        values:
+          name: "Grade 4 for Transfer In"
+          code: "G4TRIN"
+          sequence: 40
+          type_id: "REC: grade_type.id"
+
+      - step: "Setup - create school"
+        action: "create"
+        model: "school"
+        save_as: "school"
+        values:
+          name: "School for Transfer In Test"
+          code: "SCHTRIN"
+          grade_type_id: "REC: grade_type.id"
+
+      - step: "Setup - create grade class for grade 3"
+        action: "create"
+        model: "school_grade_class"
+        save_as: "grade_class_3"
+        values:
+          name: "Class A Grade 3 Transfer In"
+          code: "CLAG3TRIN"
+          school_id: "REC: school.id"
+          grade_id: "REC: grade_3.id"
+
+      - step: "Setup - create grade class for grade 4"
+        action: "create"
+        model: "school_grade_class"
+        save_as: "grade_class_4"
+        values:
+          name: "Class A Grade 4 Transfer In"
+          code: "CLAG4TRIN"
+          school_id: "REC: school.id"
+          grade_id: "REC: grade_4.id"
+
+      - step: "Setup - create academic year"
+        action: "create"
+        model: "school_academic_year"
+        save_as: "academic_year"
+        values:
+          name: "2024/2025 Transfer In Test"
+          code: "AYTRIN"
+          date_start: "2024-07-01"
+          date_end: "2025-06-30"
+
+      - step: "Setup - create academic term 1 (first term)"
+        action: "create"
+        model: "school_academic_term"
+        save_as: "academic_term_1"
+        values:
+          name: "Semester 1 Transfer In Test"
+          code: "SMTRIN1"
+          date_start: "2024-07-01"
+          date_end: "2024-12-31"
+          year_id: "REC: academic_year.id"
+          enrollment_state: "close"
+
+      - step: "Setup - create academic term 2 (non-first term, enrollment open)"
+        action: "create"
+        model: "school_academic_term"
+        save_as: "academic_term_2"
+        values:
+          name: "Semester 2 Transfer In Test"
+          code: "SMTRIN2"
+          date_start: "2025-01-01"
+          date_end: "2025-06-30"
+          year_id: "REC: academic_year.id"
+          enrollment_state: "open"
+
+      - step: "Assert academic term 2 is not the first term"
+        action: "assert"
+        target: "academic_term_2"
+        asserts:
+          first_term:
+            type: "value"
+            expected: false
+
+      - step: "Setup - create transfer-in student contact"
+        action: "create"
+        model: "res.partner"
+        save_as: "contact_transfer_in"
+        values:
+          name: "Transfer In Student Contact"
+          phone: "081234500001"
+          email: "transferin@test.com"
+
+      - step: "Setup - create transfer-in student"
+        action: "create"
+        model: "school_student"
+        save_as: "student_transfer_in"
+        values:
+          name: "Transfer In Student"
+          code: "STUTRIN01"
+          contact_id: "REC: contact_transfer_in.id"
+          school_id: "REC: school.id"
+          initial_grade_id: "REC: grade_3.id"
+          is_transfer_in: true
+          origin_school: "Origin School Example"
+          transfer_date: "2025-01-05"
+
+      - step: "Assert transfer-in fields stored correctly"
+        action: "assert"
+        target: "student_transfer_in"
+        asserts:
+          is_transfer_in:
+            type: "value"
+            expected: true
+          origin_school:
+            type: "value"
+            expected: "Origin School Example"
+          transfer_date:
+            type: "value"
+            expected: 2025-01-05
+          state:
+            type: "value"
+            expected: "draft"
+
+      - step: "Setup - create regular (non transfer-in) student contact"
+        action: "create"
+        model: "res.partner"
+        save_as: "contact_regular"
+        values:
+          name: "Regular Student Contact"
+          phone: "081234500002"
+          email: "regularstudent@test.com"
+
+      - step: "Setup - create regular student with current grade 3"
+        action: "create"
+        model: "school_student"
+        save_as: "student_regular"
+        values:
+          name: "Regular Student"
+          code: "STUREG01"
+          contact_id: "REC: contact_regular.id"
+          school_id: "REC: school.id"
+          initial_grade_id: "REC: grade_3.id"
+          is_transfer_in: false
+
+      - step: "Assert regular student current grade is grade 3"
+        action: "assert"
+        target: "student_regular"
+        asserts:
+          current_grade_id:
+            type: "m2o"
+            expected: "REC: grade_3"
+
+      - step: "Create enrollment for transfer-in student on grade 4, non-first term"
+        action: "create"
+        model: "school_enrollment"
+        save_as: "enrollment_transfer_in"
+        values:
+          date: "2025-01-06"
+          academic_year_id: "REC: academic_year.id"
+          academic_term_id: "REC: academic_term_2.id"
+          school_id: "REC: school.id"
+          grade_id: "REC: grade_4.id"
+          grade_class_id: "REC: grade_class_4.id"
+          student_id: "REC: student_transfer_in.id"
+
+      - step:
+          "Assert allowed_student_ids for grade 4 is exactly the transfer-in student
+          (regular student excluded)"
+        action: "assert"
+        target: "enrollment_transfer_in"
+        asserts:
+          allowed_student_ids:
+            type: "m2m"
+            check: "exact"
+            expected_records:
+              - "REC: student_transfer_in"
+
+      - step: "Create second draft enrollment for transfer-in student on grade 3"
+        action: "create"
+        model: "school_enrollment"
+        save_as: "enrollment_transfer_in_other_grade"
+        values:
+          date: "2025-01-06"
+          academic_year_id: "REC: academic_year.id"
+          academic_term_id: "REC: academic_term_2.id"
+          school_id: "REC: school.id"
+          grade_id: "REC: grade_3.id"
+          grade_class_id: "REC: grade_class_3.id"
+          student_id: "REC: student_transfer_in.id"
+
+      - step: "Assert transfer-in student is also allowed on a different grade"
+        action: "assert"
+        target: "enrollment_transfer_in_other_grade"
+        asserts:
+          allowed_student_ids:
+            type: "m2m"
+            check: "contains"
+            expected_records:
+              - "REC: student_transfer_in"
+
+      - step: "Confirm transfer-in enrollment"
+        action: "call"
+        target: "enrollment_transfer_in"
+        method: "action_confirm"
+        as_user: "base.user_admin"
+        asserts:
+          state:
+            type: "value"
+            expected: "confirm"
+
+      - step: "Approve and open transfer-in enrollment"
+        action: "call"
+        target: "enrollment_transfer_in"
+        method: "action_approve_approval"
+        as_user: "base.user_admin"
+        asserts:
+          state:
+            type: "value"
+            expected: "open"
+
+      - step: "Assert transfer-in student current grade follows enrollment grade"
+        action: "assert"
+        target: "student_transfer_in"
+        asserts:
+          current_grade_id:
+            type: "m2o"
+            expected: "REC: grade_4"

--- a/ssi_school/tests/test_school_student_transfer_in.py
+++ b/ssi_school/tests/test_school_student_transfer_in.py
@@ -1,0 +1,22 @@
+# Copyright 2026 OpenSynergy Indonesia
+# Copyright 2026 PT. Simetri Sinergi Indonesia
+# License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl).
+
+from odoo_yaml_test import YamlTransactionCase
+
+from odoo.tests import tagged
+
+
+@tagged("post_install", "-at_install")
+class TestSchoolStudentTransferIn(YamlTransactionCase):
+    """Cover transfer-in enrollment for ``school_student``/``school_enrollment``.
+
+    Verifies that a student flagged ``is_transfer_in`` can be enrolled into
+    any grade of any term (not only the grade matched by the computed
+    current/next grade), and that a regular student's eligibility is
+    unaffected.
+    """
+
+    def test_transfer_in_allowed_on_non_first_term_middle_grade(self):
+        """Run the transfer-in enrollment eligibility scenario."""
+        self.run_yaml_scenario("test_data_student_transfer_in.yaml")

--- a/ssi_school/views/school_student.xml
+++ b/ssi_school/views/school_student.xml
@@ -229,6 +229,13 @@
                     </group>
                     <field name="enrollment_ids" />
                 </page>
+                <page name="transfer_in" string="Transfer In">
+                    <group name="transfer_in_1" colspan="4" col="2">
+                        <field name="is_transfer_in" />
+                        <field name="origin_school" />
+                        <field name="transfer_date" />
+                    </group>
+                </page>
                 <page name="family" string="Family">
                     <group name="family_1" colspan="4" col="2">
                         <field name="father_id" />


### PR DESCRIPTION
## Ringkasan

Menangani enrollment siswa transfer-in (mutasi masuk) yang perlu di-enroll pada grade
mana pun di term mana pun, tidak hanya grade yang cocok dengan `next_grade_id`/
`current_grade_id` hasil compute otomatis.

* Tambah field `is_transfer_in` (Boolean), `origin_school` (Char), `transfer_date`
  (Date) pada `school_student`, dengan `help` berbahasa Inggris, ditampilkan pada
  form (tab baru "Transfer In").
* Perluas `_compute_allowed_student_ids` (`school_enrollment.py`) agar siswa
  transfer-in (`state=draft`, `school_id` cocok, `is_transfer_in=True`) selalu
  muncul di `allowed_student_ids`, digabungkan (union) dengan kriteria kelayakan
  reguler yang sudah ada. Siswa reguler tidak berubah perilakunya.
* Setelah enrollment transfer-in *open*, `current_grade_id` siswa mengikuti
  `grade_id` enrollment lewat compute existing berbasis riwayat enrollment
  (tidak ada perubahan pada compute itu sendiri).
* Tambah unit test skenario `odoo-yaml-test`
  (`tests/test_data_student_transfer_in.yaml` +
  `tests/test_school_student_transfer_in.py`), mencakup: field tersimpan benar,
  transfer-in muncul di allowed_student_ids grade tengah pada term non-first,
  transfer-in juga bisa dipilih pada grade lain, `current_grade_id` mengikuti
  grade enrollment setelah open, dan regresi siswa reguler yang TIDAK ikut
  muncul di grade yang tidak sesuai `current_grade_id`-nya.

## Test plan

- [x] `verify-module.sh` / `vs-head.sh` (validator `module`) — 0 temuan baru
- [x] `validate-unit-test.sh` / `vs-head.sh` (validator `unit-test`) — 0 temuan baru
- [x] `pre-commit-gate.sh` (keenam validator) — GATE OK
- [ ] CI GitHub (unit test `odoo-yaml-test` dijalankan di CI)

Closes open-synergy/ssi-school#82

🤖 Generated with [Claude Code](https://claude.com/claude-code)