### PR TITLE
[UPD] ssi_school_admission_lead - Tambah field family_card_number pada crm.lead

### DIFF
--- a/ssi_school_admission_lead/models/crm_lead.py
+++ b/ssi_school_admission_lead/models/crm_lead.py
@@ -2,7 +2,12 @@
 # Copyright 2024 PT. Simetri Sinergi Indonesia
 # License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl).
 
-from odoo import api, fields, models
+import re
+
+from odoo import _, api, fields, models
+from odoo.exceptions import ValidationError
+
+FAMILY_CARD_NUMBER_RE = re.compile(r"^\d{16}$")
 
 
 class CrmLead(models.Model):  # pylint: disable=too-few-public-methods
@@ -150,6 +155,16 @@ class CrmLead(models.Model):  # pylint: disable=too-few-public-methods
             "Method (manual/domain/code)."
         ),
     )
+    family_card_number = fields.Char(
+        string="Family Card Number",
+        tracking=True,
+        help=(
+            "Family Card Number (Nomor Kartu Keluarga/No. KK) of the "
+            "prospective student, captured on the lead itself. Left "
+            "empty, it stays valid; when filled, it must be exactly 16 "
+            "digits."
+        ),
+    )
 
     @api.depends("admission_form_id")
     def _compute_create_admission_form_ok(self):
@@ -192,6 +207,33 @@ class CrmLead(models.Model):  # pylint: disable=too-few-public-methods
                     python_code=record.company_id.previous_school_python_code,
                 )
             record.allowed_previous_school_ids = result
+
+    @api.constrains("family_card_number")
+    def _check_family_card_number(self):
+        """Enforce the Family Card Number (No. KK) format when filled.
+
+        An empty value is always accepted - the field is optional
+        capture data. When filled, it must be exactly 16 digits, the
+        standard length of an Indonesian Family Card Number.
+
+        :raises ValidationError: ``family_card_number`` is filled but is
+            not exactly 16 digits.
+        """
+        for record in self:
+            value = record.family_card_number
+            if value and not FAMILY_CARD_NUMBER_RE.match(value):
+                error_message = (
+                    _(
+                        """
+Context: Set Family Card Number
+Database ID: %s
+Problem: Family Card Number must be exactly 16 digits
+Solution: Enter a 16-digit numeric Family Card Number, or leave it empty
+"""
+                    )
+                    % (record.id,)
+                )
+                raise ValidationError(error_message)
 
     def action_create_admission_form(self):
         """Open the admission form of this lead, or the wizard creating it.

--- a/ssi_school_admission_lead/tests/__init__.py
+++ b/ssi_school_admission_lead/tests/__init__.py
@@ -3,6 +3,7 @@
 # License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl).
 
 from . import test_crm_lead_admission  # noqa: F401
+from . import test_crm_lead_family_card_number  # noqa: F401
 from . import test_crm_lead_previous_school  # noqa: F401
 from . import test_crm_lead_student_identity  # noqa: F401
 from . import test_crm_lead_view_architecture  # noqa: F401

--- a/ssi_school_admission_lead/tests/test_crm_lead_family_card_number.py
+++ b/ssi_school_admission_lead/tests/test_crm_lead_family_card_number.py
@@ -1,0 +1,16 @@
+# Copyright 2026 OpenSynergy Indonesia
+# Copyright 2026 PT. Simetri Sinergi Indonesia
+# License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl).
+
+from odoo_yaml_test import YamlTransactionCase
+
+from odoo.tests import tagged
+
+
+@tagged("post_install", "-at_install")
+class TestCrmLeadFamilyCardNumber(YamlTransactionCase):
+    """Covers the ``family_card_number`` capture field on ``crm.lead``."""
+
+    def test_crm_lead_family_card_number(self):
+        """Run the family card number format scenario."""
+        self.run_yaml_scenario("test_data_crm_lead_family_card_number.yaml")

--- a/ssi_school_admission_lead/tests/test_crm_lead_view_architecture.py
+++ b/ssi_school_admission_lead/tests/test_crm_lead_view_architecture.py
@@ -61,13 +61,15 @@ class TestCrmLeadViewArchitecture(YamlTransactionCase):
                 "nationality_id",
                 "allowed_previous_school_ids",
                 "previous_school_id",
+                "family_card_number",
                 "student_nickname",
                 "student_nisn",
                 "parent_relationship",
             ],
             "Prospective Student group should list student_id, student_birthdate, "
             "student_gender, birth_city, religion_id, nationality_id, "
-            "allowed_previous_school_ids, previous_school_id, student_nickname, "
+            "allowed_previous_school_ids, previous_school_id, "
+            "family_card_number, student_nickname, "
             "student_nisn, parent_relationship in that order",
         )
         previous_school_id_field = group.xpath(".//field[@name='previous_school_id']")[

--- a/ssi_school_admission_lead/tests/test_data_crm_lead_family_card_number.yaml
+++ b/ssi_school_admission_lead/tests/test_data_crm_lead_family_card_number.yaml
@@ -1,0 +1,92 @@
+options:
+  auto_refresh: true
+
+scenarios:
+  - name: "CRM Lead - Family Card Number with 16 digits is saved"
+    steps:
+      - step: "Write a 16-digit Family Card Number on the lead"
+        action: "create"
+        model: "crm.lead"
+        save_as: "lead"
+        values:
+          name: "Lead Family Card Number Valid"
+          family_card_number: "3374012345670001"
+
+      - step: "Assert the Family Card Number was stored as given"
+        action: "assert"
+        target: "lead"
+        refresh: true
+        asserts:
+          family_card_number:
+            type: "value"
+            expected: "3374012345670001"
+
+  - name: "CRM Lead - Family Card Number stays empty when not given"
+    steps:
+      - step: "Create lead without a Family Card Number"
+        action: "create"
+        model: "crm.lead"
+        save_as: "lead"
+        values:
+          name: "Lead Without Family Card Number"
+
+      - step: "Assert lead exists with an empty Family Card Number"
+        action: "assert"
+        target: "lead"
+        refresh: true
+        asserts:
+          id:
+            type: "value"
+            operator: "is_truthy"
+          family_card_number:
+            type: "value"
+            operator: "is_falsy"
+
+  - name: "CRM Lead - Family Card Number shorter than 16 digits is rejected"
+    steps:
+      - step: "Create lead with a 4-digit Family Card Number"
+        action: "create"
+        model: "crm.lead"
+        expect_error:
+          type: "ValidationError"
+        values:
+          name: "Lead Family Card Number Too Short"
+          family_card_number: "1234"
+
+  - name: "CRM Lead - Family Card Number with letters is rejected"
+    steps:
+      - step: "Create lead with a 16-character Family Card Number containing letters"
+        action: "create"
+        model: "crm.lead"
+        expect_error:
+          type: "ValidationError"
+        values:
+          name: "Lead Family Card Number Non Numeric"
+          family_card_number: "33740123456700AB"
+
+  - name: "CRM Lead - Writing an invalid Family Card Number on a valid lead is rejected"
+    steps:
+      - step: "Create lead with a valid 16-digit Family Card Number"
+        action: "create"
+        model: "crm.lead"
+        save_as: "lead"
+        values:
+          name: "Lead Family Card Number Write Invalid"
+          family_card_number: "3374012345670002"
+
+      - step: "Write a 5-digit Family Card Number on the previously valid lead"
+        action: "write"
+        target: "lead"
+        expect_error:
+          type: "ValidationError"
+        values:
+          family_card_number: "12345"
+
+      - step: "Assert the original valid value was not overwritten"
+        action: "assert"
+        target: "lead"
+        refresh: true
+        asserts:
+          family_card_number:
+            type: "value"
+            expected: "3374012345670002"

--- a/ssi_school_admission_lead/views/crm_lead.xml
+++ b/ssi_school_admission_lead/views/crm_lead.xml
@@ -24,6 +24,7 @@
                         name="previous_school_id"
                         domain="[('id', 'in', allowed_previous_school_ids)]"
                     />
+                <field name="family_card_number" />
             </xpath>
             <xpath
                     expr="//group[@name='school_lead_admission_target']//field[@name='school_id']"


### PR DESCRIPTION
## Ringkasan

Menambahkan field `family_card_number` (No. KK) pada `crm.lead` di modul
`ssi_school_admission_lead` sesuai spesifikasi SPMB Semarang Kebon Dalem Bagian 2.

- `family_card_number`: `Char`, `tracking=True`, tidak `required`, disimpan sendiri oleh
  `crm.lead` sebagai lapisan capture (pola sama seperti `nik`/`nisn` di #143)
- Validasi format lewat `@api.constrains`: hanya diterima kosong atau tepat 16 digit angka
- Field ditampilkan di form view `crm.lead` milik modul ini
- Unit test skenario `odoo-yaml-test` untuk kasus positif (16 digit valid, kosong) dan
  negatif (kurang dari 16 digit, mengandung huruf, write jadi tidak valid pada lead yang
  tadinya sah)
- `test_crm_lead_view_architecture.py` diperbarui untuk mencantumkan `family_card_number`
  dalam urutan field grup Prospective Student

Closes #144

## Test plan

- [x] `pre-commit-gate.sh` — GATE OK, 6 pemeriksaan, 0 pelanggaran baru
- [ ] CI GitHub Actions hijau (unit test dijalankan di CI, bukan lokal)