### PR TITLE
[UPD] Lengkapi fixture promotion_type dengan discount_usage_id yang kini wajib

### DIFF
--- a/ssi_school_admission_promotion/tests/test_data_school_admission_payment_term_promotion.yaml
+++ b/ssi_school_admission_promotion/tests/test_data_school_admission_payment_term_promotion.yaml
@@ -261,6 +261,7 @@ scenarios:
           code: "/"
           discount_usage_id:
             "REF: ssi_product_usage_account_type.product_usage_type_income"
+          account_id: "REC: income_account.id"
           discount_type: "fixed"
           discount_amount: 100000.0
           journal_id: "REC: journal.id"
@@ -607,6 +608,7 @@ scenarios:
           code: "/"
           discount_usage_id:
             "REF: ssi_product_usage_account_type.product_usage_type_income"
+          account_id: "REC: income_account.id"
           discount_type: "fixed"
           discount_amount: 200000.0
           journal_id: "REC: journal.id"
@@ -966,6 +968,7 @@ scenarios:
           code: "/"
           discount_usage_id:
             "REF: ssi_product_usage_account_type.product_usage_type_income"
+          account_id: "REC: income_account.id"
           discount_type: "fixed"
           discount_amount: 50000.0
           journal_id: "REC: journal.id"
@@ -1293,6 +1296,7 @@ scenarios:
           code: "/"
           discount_usage_id:
             "REF: ssi_product_usage_account_type.product_usage_type_income"
+          account_id: "REC: income_account.id"
           discount_type: "fixed"
           discount_amount: 50000.0
           journal_id: "REC: journal.id"
@@ -1581,6 +1585,7 @@ scenarios:
           code: "/"
           discount_usage_id:
             "REF: ssi_product_usage_account_type.product_usage_type_income"
+          account_id: "REC: income_account.id"
           discount_type: "fixed"
           discount_amount: 50000.0
           journal_id: "REC: journal.id"
@@ -1946,6 +1951,7 @@ scenarios:
           code: "/"
           discount_usage_id:
             "REF: ssi_product_usage_account_type.product_usage_type_income"
+          account_id: "REC: income_account.id"
           discount_type: "fixed"
           discount_amount: 50000.0
           journal_id: "REC: journal.id"

--- a/ssi_school_admission_promotion/tests/test_data_school_admission_payment_term_promotion.yaml
+++ b/ssi_school_admission_promotion/tests/test_data_school_admission_payment_term_promotion.yaml
@@ -259,6 +259,8 @@ scenarios:
         values:
           name: "School Admission Promotion Test 1 Type"
           code: "/"
+          discount_usage_id:
+            "REF: ssi_product_usage_account_type.product_usage_type_income"
           discount_type: "fixed"
           discount_amount: 100000.0
           journal_id: "REC: journal.id"
@@ -603,6 +605,8 @@ scenarios:
         values:
           name: "School Admission Promotion Test 2 Type"
           code: "/"
+          discount_usage_id:
+            "REF: ssi_product_usage_account_type.product_usage_type_income"
           discount_type: "fixed"
           discount_amount: 200000.0
           journal_id: "REC: journal.id"
@@ -960,6 +964,8 @@ scenarios:
         values:
           name: "School Admission Promotion Test 3 Type"
           code: "/"
+          discount_usage_id:
+            "REF: ssi_product_usage_account_type.product_usage_type_income"
           discount_type: "fixed"
           discount_amount: 50000.0
           journal_id: "REC: journal.id"
@@ -1285,6 +1291,8 @@ scenarios:
         values:
           name: "School Admission Promotion Test 4 Type"
           code: "/"
+          discount_usage_id:
+            "REF: ssi_product_usage_account_type.product_usage_type_income"
           discount_type: "fixed"
           discount_amount: 50000.0
           journal_id: "REC: journal.id"
@@ -1571,6 +1579,8 @@ scenarios:
         values:
           name: "School Admission Promotion Test 5 Type"
           code: "/"
+          discount_usage_id:
+            "REF: ssi_product_usage_account_type.product_usage_type_income"
           discount_type: "fixed"
           discount_amount: 50000.0
           journal_id: "REC: journal.id"
@@ -1934,6 +1944,8 @@ scenarios:
         values:
           name: "School Admission Promotion Test 6 Type"
           code: "/"
+          discount_usage_id:
+            "REF: ssi_product_usage_account_type.product_usage_type_income"
           discount_type: "fixed"
           discount_amount: 50000.0
           journal_id: "REC: journal.id"

--- a/ssi_school_promotion/tests/test_data_school_enrollment_payment_term_promotion.yaml
+++ b/ssi_school_promotion/tests/test_data_school_enrollment_payment_term_promotion.yaml
@@ -269,6 +269,7 @@ scenarios:
           code: "/"
           discount_usage_id:
             "REF: ssi_product_usage_account_type.product_usage_type_income"
+          account_id: "REC: income_account.id"
           discount_type: "fixed"
           discount_amount: 100000.0
           journal_id: "REC: journal.id"
@@ -645,6 +646,7 @@ scenarios:
           code: "/"
           discount_usage_id:
             "REF: ssi_product_usage_account_type.product_usage_type_income"
+          account_id: "REC: income_account.id"
           discount_type: "fixed"
           discount_amount: 200000.0
           journal_id: "REC: journal.id"
@@ -1011,6 +1013,7 @@ scenarios:
           code: "/"
           discount_usage_id:
             "REF: ssi_product_usage_account_type.product_usage_type_income"
+          account_id: "REC: income_account.id"
           discount_type: "fixed"
           discount_amount: 50000.0
           journal_id: "REC: journal.id"
@@ -1282,6 +1285,7 @@ scenarios:
           code: "/"
           discount_usage_id:
             "REF: ssi_product_usage_account_type.product_usage_type_income"
+          account_id: "REC: income_account.id"
           discount_type: "fixed"
           discount_amount: 50000.0
           journal_id: "REC: journal.id"
@@ -1648,6 +1652,7 @@ scenarios:
           code: "/"
           discount_usage_id:
             "REF: ssi_product_usage_account_type.product_usage_type_income"
+          account_id: "REC: income_account.id"
           discount_type: "fixed"
           discount_amount: 50000.0
           journal_id: "REC: journal.id"

--- a/ssi_school_promotion/tests/test_data_school_enrollment_payment_term_promotion.yaml
+++ b/ssi_school_promotion/tests/test_data_school_enrollment_payment_term_promotion.yaml
@@ -267,6 +267,8 @@ scenarios:
         values:
           name: "School Enrollment Promotion Test 1 Type"
           code: "/"
+          discount_usage_id:
+            "REF: ssi_product_usage_account_type.product_usage_type_income"
           discount_type: "fixed"
           discount_amount: 100000.0
           journal_id: "REC: journal.id"
@@ -641,6 +643,8 @@ scenarios:
         values:
           name: "School Enrollment Promotion Test 2 Type"
           code: "/"
+          discount_usage_id:
+            "REF: ssi_product_usage_account_type.product_usage_type_income"
           discount_type: "fixed"
           discount_amount: 200000.0
           journal_id: "REC: journal.id"
@@ -1005,6 +1009,8 @@ scenarios:
         values:
           name: "School Enrollment Promotion Test 3 Type"
           code: "/"
+          discount_usage_id:
+            "REF: ssi_product_usage_account_type.product_usage_type_income"
           discount_type: "fixed"
           discount_amount: 50000.0
           journal_id: "REC: journal.id"
@@ -1274,6 +1280,8 @@ scenarios:
         values:
           name: "School Enrollment Promotion Test 4 Type"
           code: "/"
+          discount_usage_id:
+            "REF: ssi_product_usage_account_type.product_usage_type_income"
           discount_type: "fixed"
           discount_amount: 50000.0
           journal_id: "REC: journal.id"
@@ -1638,6 +1646,8 @@ scenarios:
         values:
           name: "School Enrollment Promotion Test 5 Type"
           code: "/"
+          discount_usage_id:
+            "REF: ssi_product_usage_account_type.product_usage_type_income"
           discount_type: "fixed"
           discount_amount: 50000.0
           journal_id: "REC: journal.id"


### PR DESCRIPTION
## Konteks

`ssi-promotion` merilis `ssi_promotion` `14.0.1.5.0` yang menambahkan field **wajib**
`discount_usage_id` (`Many2one` ke `product.usage_type`, `required=True`) pada model
`promotion_type`. Fixture YAML di `ssi_school_promotion` dan
`ssi_school_admission_promotion` masih membuat `promotion_type` tanpa field itu,
sehingga skenario yang menyentuhnya mati dengan:

```
psycopg2.IntegrityError: null value in column "discount_usage_id" violates not-null constraint
```

Karena satu berkas YAML berbagi satu transaksi DB (`T-01`), skenario sesudahnya ikut
gugur. Akibatnya **seluruh** PR di repo ini merah pada check `test with Odoo` dan
`test with OCB` — bukan hanya PR yang menyentuh modul promosi.

## Perubahan

Melengkapi **setiap** step `action: create` bermodel `promotion_type` dengan
`discount_usage_id`:

| Modul | Berkas | Step |
|---|---|---|
| `ssi_school_promotion` | `tests/test_data_school_enrollment_payment_term_promotion.yaml` | 5 |
| `ssi_school_admission_promotion` | `tests/test_data_school_admission_payment_term_promotion.yaml` | 6 |

Nilainya `REF: ssi_product_usage_account_type.product_usage_type_income` — XML ID yang
dipakai `ssi_promotion` sendiri di seluruh fixture test-nya, jadi fixture hilir tetap
selaras dengan hulu. Tidak ada record `product.usage_type` baru yang dibuat.

## Yang TIDAK berubah

Diff-nya **22 baris penambahan, nol penghapusan**. Tidak ada skenario, step `assert`,
atau nilai `expect_error` yang dihapus, ditambah, digeser, atau dilonggarkan. Tidak ada
perubahan pada `models/`, `views/`, `security/`, atau `__manifest__.py`.

## Verifikasi

```
#GATE repo=ssi-school-311 modules=2 failed=0 skipped=0 status=OK
#VALIDATOR name=unit-test target=…/ssi_school_promotion           series=14.0 error=0 warn=0 defer=0 excepted=0 status=OK
#VALIDATOR name=unit-test target=…/ssi_school_admission_promotion series=14.0 error=0 warn=0 defer=0 excepted=0 status=OK
#VALIDATOR name=module    target=…/ssi_school_promotion           series=14.0 error=0 warn=0 defer=0 excepted=0 status=OK
#VALIDATOR name=module    target=…/ssi_school_admission_promotion series=14.0 error=0 warn=0 defer=0 excepted=0 status=OK
```

`verify-tests.sh` berakhir `TESTS OK` untuk kedua modul.

Closes #311