### PR TITLE
[UPD] ssi_school_admission: tambahkan web_tour ke depends

### DIFF
--- a/ssi_school_admission/__manifest__.py
+++ b/ssi_school_admission/__manifest__.py
@@ -27,6 +27,7 @@
         "ssi_m2o_configurator_mixin",
         "base_automation",
         "base_duration",
+        "web_tour",
     ],
     "data": [
         "ir_module_category/school_admission_form.xml",


### PR DESCRIPTION
Menuntaskan temuan validator `tour` pada modul `ssi_school_admission` seri 14.0.

Menggantikan PR #310 yang ditutup tanpa merge (branch tanggalnya dipakai perbaikan CI #311/#312). Isi perubahannya identik, kini di-rebase di atas merge #312.

## Perubahan

* `__manifest__.py`: menambahkan `"web_tour"` ke daftar `depends`.

Modul ini mendaftarkan tour tetapi belum menyatakan ketergantungan pada modul penyedia registry tour. Pada database yang belum memasang `web_tour` lewat modul lain, asset tour tidak pernah ter-load dan tour gagal dengan cara yang menyesatkan — tampak seperti bug selector, padahal dependensinya yang hilang.

Tidak ada berkas di bawah `static/` atau `tests/` yang diubah; tidak ada test/tour/assertion yang dihapus atau dilonggarkan.

## Verifikasi

```
#GATE repo=ssi-school-259 modules=1 failed=0 skipped=0 status=OK
#VALIDATOR name=tour target=ssi_school_admission series=14.0 error=0 warn=0 defer=0 excepted=0 status=OK
```

Sebelum perbaikan: `error=1 status=FAILED` dengan `#FINDING tier=error key=manifest-depends-pada-web-tour|depends-web-tour`.

Closes #259