### PR TITLE
[UPD] ssi_school: backfill rantai previous/next grade via migrasi

### DIFF
--- a/ssi_school/__manifest__.py
+++ b/ssi_school/__manifest__.py
@@ -3,7 +3,7 @@
 # License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl).
 {
     "name": "School",
-    "version": "14.0.5.13.0",
+    "version": "14.0.5.13.1",
     "website": "https://simetri-sinergi.id",
     # pylint: disable=line-too-long
     "author": "PT. Simetri Sinergi Indonesia, OpenSynergy Indonesia, Odoo Community Association (OCA)",  # noqa: B950

--- a/ssi_school/migrations/14.0.5.13.1/post-migrate.py
+++ b/ssi_school/migrations/14.0.5.13.1/post-migrate.py
@@ -1,0 +1,62 @@
+# Copyright 2026 OpenSynergy Indonesia
+# Copyright 2026 PT. Simetri Sinergi Indonesia
+# License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl).
+"""Backfill the ``school_grade`` previous/next chain on existing databases.
+
+``school_grade.previous_grade_id`` and ``school_grade.next_grade_id`` are
+plain stored fields maintained by code, not computes, so Odoo never
+rebuilds them on module update. ``_recompute_next_previous`` is only
+reached from ``create``, ``write`` and ``unlink`` of ``school_grade``.
+
+Before open-synergy/ssi-school#79 that method walked every grade of the
+database as a single ordered list, so the last grade of one ``type_id``
+was linked to the first grade of the next one. The fix scoped the chain
+per ``type_id``, but it only repairs a database once somebody happens to
+edit a grade: an instance that already stored a cross-type chain keeps it
+forever, and it propagates into
+``school_enrollment._set_result_to_passed`` (``promote_to_grade_id``) and
+``school_student._compute_next_grade_id`` -- students get "promoted" into
+another education level instead of graduating.
+
+This script replays ``_recompute_next_previous`` once, so every instance
+upgraded to this version ends up with a chain scoped per ``type_id``
+without any manual intervention.
+
+See open-synergy/ssi-school#79 and open-synergy/ssi-school#184.
+"""
+
+import logging
+
+from odoo import SUPERUSER_ID, api
+
+_logger = logging.getLogger(__name__)
+
+
+def migrate(cr, version):
+    """Relink every grade chain so that it stays inside its grade type.
+
+    Entry point called by Odoo after this version is loaded. Does nothing
+    on a fresh install (``version`` is falsy), since there is no legacy
+    chain to repair there. Otherwise the per-``type_id`` algorithm
+    introduced by open-synergy/ssi-school#79 is replayed over the whole
+    ``school_grade`` table, which is why this runs as ``post-`` and calls
+    the ORM instead of SQL: that algorithm stays the single source of
+    truth.
+
+    :param cr: database cursor
+    :param version: version the module is upgraded from, or a falsy value
+        on a fresh install
+    :return: nothing; rewrites ``previous_grade_id`` and
+        ``next_grade_id`` on every ``school_grade`` row
+    """
+    if not version:
+        # Fresh install: no legacy chain to repair.
+        return
+    env = api.Environment(cr, SUPERUSER_ID, {})
+    grade_model = env["school_grade"]
+    grade_model._recompute_next_previous()
+    _logger.info(
+        "Rebuilt the previous/next chain of %s school_grade record(s), "
+        "scoped per type_id.",
+        grade_model.search_count([]),
+    )

--- a/ssi_school/tests/__init__.py
+++ b/ssi_school/tests/__init__.py
@@ -8,6 +8,7 @@ from . import (  # noqa: F401
     test_hr_employee,
     test_school_grade_type,
     test_school_grade,
+    test_school_grade_recompute,
     test_school_branch,
     test_school,
     test_school_integrity,

--- a/ssi_school/tests/test_data_grade_recompute.yaml
+++ b/ssi_school/tests/test_data_grade_recompute.yaml
@@ -1,0 +1,248 @@
+options:
+  auto_refresh: true
+scenarios:
+  - name: "Recompute Repairs Cross Type Chain"
+    steps:
+      - step: "Create grade type A"
+        action: "create"
+        model: "school_grade_type"
+        save_as: "type_a"
+        values:
+          name: "Recompute Type A"
+          code: "RCTA"
+          sequence: 10
+      - step: "Create grade type B"
+        action: "create"
+        model: "school_grade_type"
+        save_as: "type_b"
+        values:
+          name: "Recompute Type B"
+          code: "RCTB"
+          sequence: 20
+      - step: "Create grade A1 (first of type A)"
+        action: "create"
+        model: "school_grade"
+        save_as: "grade_a1"
+        values:
+          name: "Recompute A1"
+          code: "RCA1"
+          sequence: 10
+          type_id: "REC: type_a.id"
+      - step: "Create grade A2 (last of type A)"
+        action: "create"
+        model: "school_grade"
+        save_as: "grade_a2"
+        values:
+          name: "Recompute A2"
+          code: "RCA2"
+          sequence: 20
+          type_id: "REC: type_a.id"
+      - step: "Create grade B1 (first of type B)"
+        action: "create"
+        model: "school_grade"
+        save_as: "grade_b1"
+        values:
+          name: "Recompute B1"
+          code: "RCB1"
+          sequence: 10
+          type_id: "REC: type_b.id"
+      - step: "Create grade B2 (last of type B)"
+        action: "create"
+        model: "school_grade"
+        save_as: "grade_b2"
+        values:
+          name: "Recompute B2"
+          code: "RCB2"
+          sequence: 20
+          type_id: "REC: type_b.id"
+      - step:
+          "Forge the legacy cross type link on the last grade of type A (readonly only
+          guards the UI, the ORM may still write)"
+        action: "write"
+        target: "grade_a2"
+        values:
+          next_grade_id: "REC: grade_b1.id"
+      - step: "Forge the legacy cross type link on the first grade of type B"
+        action: "write"
+        target: "grade_b1"
+        values:
+          previous_grade_id: "REC: grade_a2.id"
+      - step: "Assert the forged cross type link is really in place"
+        action: "assert"
+        target: "grade_a2"
+        asserts:
+          next_grade_id:
+            type: "m2o"
+            expected: "REC: grade_b1"
+      - step: "Recompute the whole chain"
+        action: "call"
+        target: "grade_a1"
+        method: "_recompute_next_previous"
+      - step: "Assert the last grade of type A no longer points into type B"
+        action: "assert"
+        target: "grade_a2"
+        asserts:
+          next_grade_id:
+            type: "value"
+            operator: "is_falsy"
+      - step: "Assert the first grade of type B no longer points into type A"
+        action: "assert"
+        target: "grade_b1"
+        asserts:
+          previous_grade_id:
+            type: "value"
+            operator: "is_falsy"
+      - step: "Assert the chain inside type A is intact"
+        action: "assert"
+        target: "grade_a1"
+        asserts:
+          previous_grade_id:
+            type: "value"
+            operator: "is_falsy"
+          next_grade_id:
+            type: "m2o"
+            expected: "REC: grade_a2"
+      - step: "Assert the predecessor of the last grade of type A is intact"
+        action: "assert"
+        target: "grade_a2"
+        asserts:
+          previous_grade_id:
+            type: "m2o"
+            expected: "REC: grade_a1"
+      - step: "Assert the chain inside type B is intact"
+        action: "assert"
+        target: "grade_b1"
+        asserts:
+          next_grade_id:
+            type: "m2o"
+            expected: "REC: grade_b2"
+      - step: "Assert the last grade of type B closes its own chain"
+        action: "assert"
+        target: "grade_b2"
+        asserts:
+          previous_grade_id:
+            type: "m2o"
+            expected: "REC: grade_b1"
+          next_grade_id:
+            type: "value"
+            operator: "is_falsy"
+
+  - name: "Recompute Is Idempotent"
+    steps:
+      - step: "Create grade type C"
+        action: "create"
+        model: "school_grade_type"
+        save_as: "type_c"
+        values:
+          name: "Recompute Type C"
+          code: "RCTC"
+          sequence: 30
+      - step: "Create grade C1"
+        action: "create"
+        model: "school_grade"
+        save_as: "grade_c1"
+        values:
+          name: "Recompute C1"
+          code: "RCC1"
+          sequence: 10
+          type_id: "REC: type_c.id"
+      - step: "Create grade C2"
+        action: "create"
+        model: "school_grade"
+        save_as: "grade_c2"
+        values:
+          name: "Recompute C2"
+          code: "RCC2"
+          sequence: 20
+          type_id: "REC: type_c.id"
+      - step: "Create grade C3"
+        action: "create"
+        model: "school_grade"
+        save_as: "grade_c3"
+        values:
+          name: "Recompute C3"
+          code: "RCC3"
+          sequence: 30
+          type_id: "REC: type_c.id"
+      - step: "Recompute a first time"
+        action: "call"
+        target: "grade_c1"
+        method: "_recompute_next_previous"
+      - step: "Assert the chain after the first recompute"
+        action: "assert"
+        target: "grade_c2"
+        asserts:
+          previous_grade_id:
+            type: "m2o"
+            expected: "REC: grade_c1"
+          next_grade_id:
+            type: "m2o"
+            expected: "REC: grade_c3"
+      - step: "Recompute a second time"
+        action: "call"
+        target: "grade_c1"
+        method: "_recompute_next_previous"
+      - step: "Assert the middle grade kept both links"
+        action: "assert"
+        target: "grade_c2"
+        asserts:
+          previous_grade_id:
+            type: "m2o"
+            expected: "REC: grade_c1"
+          next_grade_id:
+            type: "m2o"
+            expected: "REC: grade_c3"
+      - step: "Assert the first grade kept its boundary"
+        action: "assert"
+        target: "grade_c1"
+        asserts:
+          previous_grade_id:
+            type: "value"
+            operator: "is_falsy"
+          next_grade_id:
+            type: "m2o"
+            expected: "REC: grade_c2"
+      - step: "Assert the last grade kept its boundary"
+        action: "assert"
+        target: "grade_c3"
+        asserts:
+          previous_grade_id:
+            type: "m2o"
+            expected: "REC: grade_c2"
+          next_grade_id:
+            type: "value"
+            operator: "is_falsy"
+
+  - name: "Recompute Leaves A Lone Grade Unlinked"
+    steps:
+      - step: "Create grade type D"
+        action: "create"
+        model: "school_grade_type"
+        save_as: "type_d"
+        values:
+          name: "Recompute Type D"
+          code: "RCTD"
+          sequence: 40
+      - step: "Create the only grade of type D"
+        action: "create"
+        model: "school_grade"
+        save_as: "grade_d1"
+        values:
+          name: "Recompute D1"
+          code: "RCD1"
+          sequence: 10
+          type_id: "REC: type_d.id"
+      - step: "Recompute the whole chain"
+        action: "call"
+        target: "grade_d1"
+        method: "_recompute_next_previous"
+      - step: "Assert the lone grade borrows no neighbour from another grade type"
+        action: "assert"
+        target: "grade_d1"
+        asserts:
+          previous_grade_id:
+            type: "value"
+            operator: "is_falsy"
+          next_grade_id:
+            type: "value"
+            operator: "is_falsy"

--- a/ssi_school/tests/test_school_grade_recompute.py
+++ b/ssi_school/tests/test_school_grade_recompute.py
@@ -1,0 +1,27 @@
+# Copyright 2026 OpenSynergy Indonesia
+# Copyright 2026 PT. Simetri Sinergi Indonesia
+# License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl).
+
+from odoo_yaml_test import YamlTransactionCase
+
+from odoo.tests import tagged
+
+
+@tagged("post_install", "-at_install")
+class TestSchoolGradeRecompute(
+    YamlTransactionCase
+):  # pylint: disable=too-few-public-methods
+    """Cover ``school_grade._recompute_next_previous`` as a repair pass.
+
+    The migration shipped with version ``14.0.5.13.1`` replays that
+    method on databases whose chain was built before
+    open-synergy/ssi-school#79, when it spanned every grade type at once.
+    The scenarios check the three properties the repair relies on:
+    a cross-type link is cut, a chain that is already correct survives
+    being recomputed twice, and a grade type holding a single grade never
+    borrows a neighbour from another type.
+    """
+
+    def test_grade_recompute(self):
+        """Run the previous/next grade chain repair scenarios."""
+        self.run_yaml_scenario("test_data_grade_recompute.yaml")


### PR DESCRIPTION
Closes #184

## Masalah

`school_grade.previous_grade_id` / `next_grade_id` adalah field tersimpan yang dipelihara kode, bukan compute, jadi Odoo tidak pernah membangunnya ulang saat modul di-update. `_recompute_next_previous()` hanya terjangkau dari `create`/`write`/`unlink` `school_grade`.

Sebelum #79, method itu menyusuri seluruh grade sebagai satu daftar terurut, sehingga grade terakhir sebuah `type_id` tertaut ke grade pertama `type_id` berikutnya. #79 sudah memperbaiki algoritmanya (ber-scope per `type_id`), tetapi instance yang terlanjur menyimpan rantai lintas-jenjang **tetap salah selamanya** — sampai kebetulan ada orang mengedit salah satu grade.

Rantai salah itu merambat ke `school_enrollment._set_result_to_passed` (`promote_to_grade_id`) dan `school_student._compute_next_grade_id`: siswa "dipromosikan" ke jenjang lain alih-alih lulus.

## Perubahan

* `ssi_school/migrations/14.0.5.13.1/post-migrate.py` — memanggil ulang `_recompute_next_previous()` **sekali** saat update, lewat ORM (`api.Environment(cr, SUPERUSER_ID, {})`), bukan SQL: algoritma per-type tetap sumber kebenaran tunggal. Guard `if not version: return` untuk install baru, dan jumlah baris tersentuh dicatat ke log.
* `version` manifest `14.0.5.13.0` → `14.0.5.13.1`, menyertai nama direktori migrasi.
* Skenario uji `odoo-yaml-test` baru untuk `_recompute_next_previous()`: memutus tautan lintas `type_id` yang dipaksakan lewat ORM, idempotensi dua pemanggilan berturut-turut, dan grade type ber-satu-grade yang kedua tautannya tetap kosong.

## Catatan versi — penyimpangan yang disengaja dari `## Keputusan Desain`

Issue menulis direktori `migrations/14.0.5.9.1/` dan bump `14.0.5.9.0` → `14.0.5.9.1`. Manifest sudah berada di `14.0.5.13.0` saat item ini dikerjakan (bot menaikkannya empat kali sejak issue ditulis), jadi menuruti angka itu apa adanya berarti **menurunkan** versi — dan instance yang sudah di 5.13.0 tak akan pernah menjalankan direktori 5.9.1, persis menggagalkan sasaran issue.

Yang dieksekusi adalah **aturannya** (`version` naik bersama nama direktori migrasi, preseden `7724cae`), bukan contoh instansiasinya yang basi. Sudah dicatat & disetujui di https://github.com/open-synergy/ssi-school/issues/184#issuecomment-5302436285.

## Merge

Karena `version` dinaikkan manual bersama direktori migrasi: **`/ocabot merge nobump`** — bukan `patch`, agar tidak dobel bump.