### PR TITLE
[UPD] ssi_school_incident_operating_unit: cakupan OU untuk school_academic_alert

### DIFF
--- a/ssi_school_incident_operating_unit/README.rst
+++ b/ssi_school_incident_operating_unit/README.rst
@@ -8,7 +8,9 @@ School Incident - Operating Unit
 
 Operating Unit support for SSI School Incident module.
 Adds operating unit access control for the transactional models
-school_incident and school_incident_weekly_review.
+school_incident, school_incident_weekly_review and school_academic_alert.
+The operating unit of a School Academic Alert is also propagated to the
+School Incident created from it.
 
 
 Work Instruction
@@ -23,6 +25,12 @@ Incident Weekly Review
 ------------------------
 
 * `Create School Incident Weekly Review <docs/school_incident_weekly_review/01-create.html>`_
+
+Academic Alert
+----------------
+
+* `Create School Academic Alert <docs/school_academic_alert/01-create.html>`_
+* `Create Incident from School Academic Alert <docs/school_academic_alert/15-create-incident.html>`_
 
 
 Bug Tracker

--- a/ssi_school_incident_operating_unit/__manifest__.py
+++ b/ssi_school_incident_operating_unit/__manifest__.py
@@ -25,9 +25,12 @@
         "security/ir_rule/school_incident.xml",
         # Security - transactional (school_incident_weekly_review)
         "security/ir_rule/school_incident_weekly_review.xml",
+        # Security - transactional (school_academic_alert)
+        "security/ir_rule/school_academic_alert.xml",
         # Views
         "views/school_incident.xml",
         "views/school_incident_weekly_review.xml",
+        "views/school_academic_alert.xml",
     ],
     "demo": [],
 }

--- a/ssi_school_incident_operating_unit/docs/school_academic_alert/01-create.md
+++ b/ssi_school_incident_operating_unit/docs/school_academic_alert/01-create.md
@@ -1,0 +1,18 @@
+# Create School Academic Alert
+
+> **Module:** ssi_school_incident_operating_unit\
+> **Extends:** ssi_school_incident — model `school_academic_alert`, action `01-create`
+
+## Additional Fields
+
+When this module is installed, the create form gains one field, visible only when the
+_Multi Operating Unit_ feature is enabled (Settings > Operating Unit):
+
+- **Operating Unit**: Automatically filled with the acting user's default operating
+  unit. Change if needed.
+
+## Modified — Record Visibility
+
+- The academic alert list is now filtered by operating unit (record rule): a user only
+  sees academic alerts belonging to operating units they are assigned to. Manager
+  (Principal) is also evaluated against this rule. This is not a Flow step.

--- a/ssi_school_incident_operating_unit/docs/school_academic_alert/15-create-incident.md
+++ b/ssi_school_incident_operating_unit/docs/school_academic_alert/15-create-incident.md
@@ -1,0 +1,14 @@
+# Create Incident from School Academic Alert
+
+> **Module:** ssi_school_incident_operating_unit\
+> **Extends:** ssi_school_incident — model `school_academic_alert`, action `15-create-incident`
+
+## Additional Post-Condition
+
+- The School Incident created by the **Create Incident** button now takes its
+  **Operating Unit** from this Academic Alert, not from the operating unit of the user
+  who pressed the button. An alert of Operating Unit A therefore always produces an
+  incident of Operating Unit A, even when the acting Officer belongs to another
+  operating unit.
+- Because the incident carries the alert's operating unit, it stays visible to the users
+  assigned to that operating unit under the incident record rule.

--- a/ssi_school_incident_operating_unit/models/__init__.py
+++ b/ssi_school_incident_operating_unit/models/__init__.py
@@ -3,6 +3,7 @@
 # License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl).
 
 from . import (  # noqa: F401
+    school_academic_alert,
     school_incident,
     school_incident_weekly_review,
 )

--- a/ssi_school_incident_operating_unit/models/school_academic_alert.py
+++ b/ssi_school_incident_operating_unit/models/school_academic_alert.py
@@ -1,0 +1,39 @@
+# Copyright 2026 OpenSynergy Indonesia
+# Copyright 2026 PT. Simetri Sinergi Indonesia
+# License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl).
+
+from odoo import models
+
+
+class SchoolAcademicAlert(models.Model):
+    """
+    Extends School Academic Alert with single operating unit support,
+    restricting each academic warning check to one operating unit and
+    propagating that operating unit to the school_incident document
+    generated from an Orange/Red alert level.
+    """
+
+    _name = "school_academic_alert"
+    _inherit = [
+        "school_academic_alert",
+        "mixin.single_operating_unit",
+    ]
+
+    def _prepare_incident_data(self, incident_type):
+        """Add this alert's operating unit to the incident values.
+
+        Without this override, the school_incident created by
+        ``action_create_incident`` falls back to the default of
+        ``mixin.single_operating_unit``, which is the operating unit of
+        the user pressing the button rather than the operating unit of
+        the academic alert itself. That silently hides the generated
+        incident from the alert's own operating unit.
+
+        :param incident_type: school_incident_type record used for the
+            generated incident
+        :return: incident creation values, with ``operating_unit_id``
+            taken from this academic alert
+        """
+        res = super()._prepare_incident_data(incident_type)
+        res["operating_unit_id"] = self.operating_unit_id.id
+        return res

--- a/ssi_school_incident_operating_unit/security/ir_rule/school_academic_alert.xml
+++ b/ssi_school_incident_operating_unit/security/ir_rule/school_academic_alert.xml
@@ -1,0 +1,29 @@
+<?xml version="1.0" encoding="utf-8" ?>
+<!-- Copyright 2026 OpenSynergy Indonesia
+     Copyright 2026 PT. Simetri Sinergi Indonesia
+     License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl). -->
+<odoo>
+
+<!-- Reuses school_incident_operating_unit_group from
+     security/res_groups/school_incident.xml: the base ssi_school_incident
+     module defines ONE shared data ownership category
+     (school_incident_data_ownership_module_category) for every
+     transactional model of the incident family, so this module keeps a
+     single "Operating Unit" group for all of them, exactly as
+     school_incident_weekly_review already does. -->
+<record id="school_academic_alert_ou" model="ir.rule">
+    <field
+            name="name"
+        >school_academic_alert - Responsible to operating unit data</field>
+    <field name="model_id" ref="ssi_school_incident.model_school_academic_alert" />
+    <field name="groups" eval="[(4, ref('school_incident_operating_unit_group'))]" />
+    <field
+            name="domain_force"
+        >[('operating_unit_id','in',[g.id for g in user.operating_unit_ids])]</field>
+    <field name="perm_unlink" eval="1" />
+    <field name="perm_write" eval="1" />
+    <field name="perm_read" eval="1" />
+    <field name="perm_create" eval="1" />
+</record>
+
+</odoo>

--- a/ssi_school_incident_operating_unit/tests/test_data_school_incident_operating_unit.yaml
+++ b/ssi_school_incident_operating_unit/tests/test_data_school_incident_operating_unit.yaml
@@ -411,3 +411,223 @@ scenarios:
           state:
             type: "value"
             expected: "draft"
+
+  - name: "School Academic Alert Operating Unit - Alert stores its operating unit"
+    steps:
+      - step: "Setup - create grade type"
+        action: "create"
+        model: "school_grade_type"
+        save_as: "grade_type"
+        values:
+          name: "Grade Type Academic Alert OU Test"
+          code: "GTOUAA1"
+          sequence: 10
+
+      - step: "Setup - create school"
+        action: "create"
+        model: "school"
+        save_as: "school"
+        values:
+          name: "School Academic Alert OU Test"
+          code: "SCHOUAA1"
+          grade_type_id: "EVAL: registry['grade_type'].id"
+
+      - step: "Setup - create student contact"
+        action: "create"
+        model: "res.partner"
+        save_as: "student_contact"
+        values:
+          name: "Student Academic Alert OU Test Contact"
+
+      - step: "Setup - create student"
+        action: "create"
+        model: "school_student"
+        save_as: "student"
+        values:
+          name: "Student Academic Alert OU Test"
+          code: "STUOUAA1"
+          contact_id: "EVAL: registry['student_contact'].id"
+          school_id: "EVAL: registry['school'].id"
+
+      - step: "Create academic alert with an operating unit"
+        action: "create"
+        model: "school_academic_alert"
+        save_as: "alert"
+        values:
+          date_alert: 2026-07-05
+          student_id: "EVAL: registry['student'].id"
+          subject_note: "Mathematics, Science"
+          operating_unit_id: "REF: operating_unit.main_operating_unit"
+
+      - step: "Assert the academic alert carries the operating unit"
+        action: "assert"
+        target: "alert"
+        asserts:
+          operating_unit_id:
+            type: "value"
+            operator: "is_truthy"
+          state:
+            type: "value"
+            expected: "draft"
+
+      - step: "Assert the operating unit is the one that was set"
+        action: "assert"
+        target: "alert"
+        asserts:
+          operating_unit_id:
+            type: "m2o"
+            expected_xml_id: "operating_unit.main_operating_unit"
+
+  - name:
+      "School Academic Alert Operating Unit - Generated incident keeps the alert's
+      operating unit"
+    steps:
+      - step: "Setup - create partner for Operating Unit A"
+        action: "create"
+        model: "res.partner"
+        save_as: "ou_a_partner"
+        values:
+          name: "Academic Alert Operating Unit A Partner"
+
+      - step: "Setup - create Operating Unit A (owner of the alert)"
+        action: "create"
+        model: "operating.unit"
+        save_as: "ou_a"
+        values:
+          name: "Academic Alert Operating Unit A"
+          code: "OUINCAA"
+          company_id: "REF: base.main_company"
+          partner_id: "EVAL: registry['ou_a_partner'].id"
+
+      - step: "Setup - create partner for Operating Unit B"
+        action: "create"
+        model: "res.partner"
+        save_as: "ou_b_partner"
+        values:
+          name: "Academic Alert Operating Unit B Partner"
+
+      - step: "Setup - create Operating Unit B (the acting user's own unit)"
+        action: "create"
+        model: "operating.unit"
+        save_as: "ou_b"
+        values:
+          name: "Academic Alert Operating Unit B"
+          code: "OUINCAB"
+          company_id: "REF: base.main_company"
+          partner_id: "EVAL: registry['ou_b_partner'].id"
+
+      # The acting user deliberately defaults to Operating Unit B while the
+      # alert belongs to Operating Unit A. Without the propagation override
+      # in models/school_academic_alert.py, the incident created below would
+      # silently take this user's default (B) instead of the alert's own
+      # operating unit (A) -- that is exactly the defect this scenario
+      # guards. base.group_user is required for basic ORM functionality
+      # (see the note in the first scenario of this file).
+      - step: "Setup - create officer user whose default operating unit is B"
+        action: "create"
+        model: "res.users"
+        save_as: "user_ou_b"
+        values:
+          name: "Academic Alert Officer OU-B"
+          login: "test_academic_alert_ou_b@ssi-school.test"
+          company_id: "REF: base.main_company"
+          groups_id:
+            - - 6
+              - 0
+              - - "REF: base.group_user"
+                - "REF: ssi_school_incident.school_incident_officer_group"
+                - "REF:
+                  ssi_school_incident_operating_unit.school_incident_operating_unit_group"
+          assigned_operating_unit_ids:
+            - - 6
+              - 0
+              - - "EVAL: registry['ou_b'].id"
+          default_operating_unit_id: "EVAL: registry['ou_b'].id"
+
+      - step: "Setup - create grade type"
+        action: "create"
+        model: "school_grade_type"
+        save_as: "grade_type"
+        values:
+          name: "Grade Type Academic Alert OU Propagation Test"
+          code: "GTOUAA2"
+          sequence: 10
+
+      - step: "Setup - create school"
+        action: "create"
+        model: "school"
+        save_as: "school"
+        values:
+          name: "School Academic Alert OU Propagation Test"
+          code: "SCHOUAA2"
+          grade_type_id: "EVAL: registry['grade_type'].id"
+
+      - step: "Setup - create student contact"
+        action: "create"
+        model: "res.partner"
+        save_as: "student_contact"
+        values:
+          name: "Student Academic Alert OU Propagation Contact"
+
+      - step: "Setup - create student"
+        action: "create"
+        model: "school_student"
+        save_as: "student"
+        values:
+          name: "Student Academic Alert OU Propagation"
+          code: "STUOUAA2"
+          contact_id: "EVAL: registry['student_contact'].id"
+          school_id: "EVAL: registry['school'].id"
+
+      - step: "Create academic alert owned by Operating Unit A"
+        action: "create"
+        model: "school_academic_alert"
+        save_as: "alert"
+        values:
+          date_alert: 2026-07-06
+          student_id: "EVAL: registry['student'].id"
+          subject_note: "Mathematics, Science, English"
+          evaluation_context: "trigger_count = 3"
+          operating_unit_id: "EVAL: registry['ou_a'].id"
+
+      - step: "Evaluate the alert so it reaches the Orange level"
+        action: "call"
+        target: "alert"
+        method: "action_evaluate"
+        asserts:
+          color:
+            type: "value"
+            expected: "orange"
+
+      # The odoo-yaml-test "as_user" key only accepts an XML ID, so it cannot
+      # address the res.users record created earlier in this scenario;
+      # with_user() is used inside an EVAL leaf instead (same technique as
+      # the school_incident scenarios above). The surrounding search asserts
+      # in one step both that the incident was created and that it carries
+      # Operating Unit A -- the alert's unit -- and not Operating Unit B,
+      # which is what the acting user would have contributed by default.
+      - step:
+          "Create the incident as the Operating Unit B user (incident must keep
+          Operating Unit A)"
+        action: "search"
+        model: "school_incident"
+        domain:
+          - - "id"
+            - "="
+            - >-
+              EVAL:
+              env['school_academic_alert'].browse(registry['alert'].id).with_user(registry['user_ou_b']).action_create_incident()['res_id']
+          - ["operating_unit_id", "=", "EVAL: registry['ou_a'].id"]
+        save_as: "incident"
+        expect_count: 1
+
+      - step: "Assert the generated incident is the academic one for this student"
+        action: "assert"
+        target: "incident"
+        asserts:
+          student_id:
+            type: "m2o"
+            expected: "REC: student"
+          incident_type_id:
+            type: "m2o"
+            expected_xml_id: "ssi_school_incident.school_incident_type_academic"

--- a/ssi_school_incident_operating_unit/tests/test_school_incident_operating_unit.py
+++ b/ssi_school_incident_operating_unit/tests/test_school_incident_operating_unit.py
@@ -11,5 +11,19 @@ from odoo.tests import tagged
 class TestSchoolIncidentOperatingUnit(
     YamlTransactionCase
 ):  # pylint: disable=too-few-public-methods
+    """
+    Test the operating unit coverage added by
+    ``ssi_school_incident_operating_unit`` to the school incident family.
+    """
+
     def test_school_incident_operating_unit(self):
+        """Run the operating unit scenarios of this module.
+
+        Covers the operating unit default of ``school_incident`` and
+        ``school_incident_weekly_review``, the operating unit stored on
+        ``school_academic_alert``, and the propagation of that operating
+        unit to the ``school_incident`` generated from the alert.
+
+        :return: None
+        """
         self.run_yaml_scenario("test_data_school_incident_operating_unit.yaml")

--- a/ssi_school_incident_operating_unit/views/school_academic_alert.xml
+++ b/ssi_school_incident_operating_unit/views/school_academic_alert.xml
@@ -1,0 +1,67 @@
+<?xml version="1.0" encoding="utf-8" ?>
+<!-- Copyright 2026 OpenSynergy Indonesia
+     Copyright 2026 PT. Simetri Sinergi Indonesia
+     License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl). -->
+<odoo>
+
+<record id="school_academic_alert_view_tree_ou" model="ir.ui.view">
+    <field name="name">school_academic_alert tree - operating unit</field>
+    <field name="model">school_academic_alert</field>
+    <field
+            name="inherit_id"
+            ref="ssi_school_incident.school_academic_alert_view_tree"
+        />
+    <field name="arch" type="xml">
+        <data>
+            <xpath expr="//field[@name='company_id']" position="after">
+                <field
+                        name="operating_unit_id"
+                        groups="operating_unit.group_multi_operating_unit"
+                        optional="hide"
+                    />
+            </xpath>
+        </data>
+    </field>
+</record>
+
+<record id="school_academic_alert_view_form_ou" model="ir.ui.view">
+    <field name="name">school_academic_alert form - operating unit</field>
+    <field name="model">school_academic_alert</field>
+    <field
+            name="inherit_id"
+            ref="ssi_school_incident.school_academic_alert_view_form"
+        />
+    <field name="arch" type="xml">
+        <data>
+            <xpath expr="//field[@name='company_id']" position="after">
+                <field
+                        name="operating_unit_id"
+                        groups="operating_unit.group_multi_operating_unit"
+                    />
+            </xpath>
+        </data>
+    </field>
+</record>
+
+<record id="school_academic_alert_view_search_ou" model="ir.ui.view">
+    <field name="name">school_academic_alert search - operating unit</field>
+    <field name="model">school_academic_alert</field>
+    <field
+            name="inherit_id"
+            ref="ssi_school_incident.school_academic_alert_view_search"
+        />
+    <field name="arch" type="xml">
+        <data>
+            <xpath expr="//group[@name='group_by']" position="inside">
+                <filter
+                        name="grp_ou"
+                        string="Operating Unit"
+                        context="{'group_by':'operating_unit_id'}"
+                        groups="operating_unit.group_multi_operating_unit"
+                    />
+            </xpath>
+        </data>
+    </field>
+</record>
+
+</odoo>


### PR DESCRIPTION
Closes #94

## Ringkasan

Menambahkan cakupan Operating Unit untuk model `school_academic_alert` pada modul glue
`ssi_school_incident_operating_unit`, konsisten dengan `school_incident` dan
`school_incident_weekly_review` yang sudah dicakup modul ini.

## Perubahan

- `models/school_academic_alert.py` (baru) — `_inherit = ["school_academic_alert", "mixin.single_operating_unit"]`
- `security/ir_rule/school_academic_alert.xml` (baru) — record rule OU, memakai group OU
  bersama `school_incident_operating_unit_group`
- `views/school_academic_alert.xml` (baru) — `operating_unit_id` di form & tree
  (`optional="hide"`) setelah `company_id`, filter group-by `grp_ou` di search view
- `__manifest__.py` — path security & view baru masuk `data`; `depends` tidak berubah
- Propagasi OU: override `_prepare_incident_data()` supaya School Incident yang dibuat
  lewat tombol **Create Incident** memakai Operating Unit milik alert, bukan OU default
  user penekan tombol (`odoo-development` → `integrations/operating-unit.md` §Propagasi,
  Pola A)
- Unit test: 2 skenario `odoo-yaml-test` baru — OU tersimpan pada alert, dan incident hasil
  generate mewarisi OU alert saat dibuat oleh user ber-OU default berbeda
- IK ekstensi `docs/school_academic_alert/{01-create,15-create-incident}.md` + `README.rst`

## Catatan

Tidak ada berkas `res_groups` baru: modul basis `ssi_school_incident` hanya punya satu
kategori data ownership untuk seluruh keluarga incident, sehingga modul ini memakai satu
group OU bersama — sama seperti `school_incident_weekly_review` yang sudah dicakup.

Model `school_incident` dan `school_incident_weekly_review` tidak disentuh.

## Verifikasi

```
#GATE repo=ssi-school-94 modules=1 failed=0 skipped=0 status=OK
#VALIDATOR name=module    target=ssi_school_incident_operating_unit series=14.0 error=0 warn=0 defer=0 excepted=0 status=OK
#VALIDATOR name=unit-test target=ssi_school_incident_operating_unit series=14.0 error=0 warn=0 defer=0 excepted=0 status=OK
```

Unit test dijalankan di CI GitHub, tidak di lokal.
