### PR TITLE
[UPD] ssi_school_admission — tuntaskan temuan validator unit-test

### DIFF
--- a/ssi_school_admission/tests/test_data_admission.yaml
+++ b/ssi_school_admission/tests/test_data_admission.yaml
@@ -190,6 +190,7 @@ scenarios:
         model: "school_admission"
         save_as: "admission"
         values:
+          user_id: "REF: base.user_admin"
           date: "2024-07-01"
           academic_year_id: "EVAL: registry['academic_year'].id"
           academic_term_id: "EVAL: registry['academic_term'].id"
@@ -331,6 +332,7 @@ scenarios:
         model: "school_admission"
         save_as: "admission"
         values:
+          user_id: "REF: base.user_admin"
           date: "2024-07-01"
           academic_year_id: "EVAL: registry['academic_year'].id"
           academic_term_id: "EVAL: registry['academic_term'].id"

--- a/ssi_school_admission/tests/test_data_admission.yaml
+++ b/ssi_school_admission/tests/test_data_admission.yaml
@@ -1,3 +1,6 @@
+options:
+  auto_refresh: true
+
 scenarios:
   - name: "Admission Full Workflow: Confirm Approve Done With Payment Template"
     steps:
@@ -219,21 +222,11 @@ scenarios:
             type: "value"
             expected: "confirm"
 
-      - step: "Invalidate cache after confirm"
-        action: "call"
-        target: "admission"
-        method: "invalidate_cache"
-
       - step: "Compute payment"
         action: "call"
         target: "admission"
         method: "action_compute_payment"
         as_user: "base.user_admin"
-
-      - step: "Invalidate admission cache after compute"
-        action: "call"
-        target: "admission"
-        method: "invalidate_cache"
 
       - step: "Assert payment terms created"
         action: "assert"
@@ -254,11 +247,6 @@ scenarios:
             type: "value"
             expected: "open"
 
-      - step: "Invalidate admission cache after approve"
-        action: "call"
-        target: "admission"
-        method: "invalidate_cache"
-
       - step: "Assert school student created on open"
         action: "assert"
         target: "admission"
@@ -276,11 +264,6 @@ scenarios:
           state:
             type: "value"
             expected: "done"
-
-      - step: "Invalidate admission cache after done"
-        action: "call"
-        target: "admission"
-        method: "invalidate_cache"
 
   - name: "Admission Simple Workflow: Confirm Approve Done Without Payment Template"
     steps:
@@ -377,11 +360,6 @@ scenarios:
             type: "value"
             expected: "confirm"
 
-      - step: "Invalidate cache after confirm"
-        action: "call"
-        target: "admission"
-        method: "invalidate_cache"
-
       - step: "Approve admission"
         action: "call"
         target: "admission"
@@ -391,11 +369,6 @@ scenarios:
           state:
             type: "value"
             expected: "open"
-
-      - step: "Invalidate admission cache after approve"
-        action: "call"
-        target: "admission"
-        method: "invalidate_cache"
 
       - step: "Assert school student created on open"
         action: "assert"
@@ -414,8 +387,3 @@ scenarios:
           state:
             type: "value"
             expected: "done"
-
-      - step: "Invalidate admission cache after done"
-        action: "call"
-        target: "admission"
-        method: "invalidate_cache"

--- a/ssi_school_admission/tests/test_data_admission_addendum.yaml
+++ b/ssi_school_admission/tests/test_data_admission_addendum.yaml
@@ -163,6 +163,7 @@ scenarios:
         save_as: "admission"
         as_user: "base.user_admin"
         values:
+          user_id: "REF: base.user_admin"
           date: "2024-07-01"
           academic_year_id: "EVAL: registry['academic_year'].id"
           academic_term_id: "EVAL: registry['academic_term'].id"

--- a/ssi_school_admission/tests/test_data_admission_addendum.yaml
+++ b/ssi_school_admission/tests/test_data_admission_addendum.yaml
@@ -1,3 +1,6 @@
+options:
+  auto_refresh: true
+
 scenarios:
   - name: "Addendum - Existing Payment Term Is Locked After Admission Opens"
     steps:
@@ -213,11 +216,6 @@ scenarios:
             type: "value"
             expected: false
 
-      - step: "Invalidate admission cache before approve"
-        action: "call"
-        target: "admission"
-        method: "invalidate_cache"
-
       - step: "Approve admission"
         action: "call"
         target: "admission"
@@ -228,11 +226,6 @@ scenarios:
             type: "value"
             expected: "open"
 
-      - step: "Invalidate term cache after admission opened"
-        action: "call"
-        target: "term"
-        method: "invalidate_cache"
-
       - step: "Assert term locked after opening"
         action: "assert"
         target: "term"
@@ -240,11 +233,6 @@ scenarios:
           locked:
             type: "value"
             expected: true
-
-      - step: "Invalidate detail cache after admission opened"
-        action: "call"
-        target: "detail"
-        method: "invalidate_cache"
 
       - step: "Assert detail locked after opening"
         action: "assert"
@@ -300,11 +288,6 @@ scenarios:
         method: "action_close_addendum"
         as_user: "base.user_admin"
 
-      - step: "Invalidate addendum term cache after closing"
-        action: "call"
-        target: "addendum_term"
-        method: "invalidate_cache"
-
       - step: "Assert first-round addendum term is locked after closing"
         action: "assert"
         target: "addendum_term"
@@ -312,11 +295,6 @@ scenarios:
           locked:
             type: "value"
             expected: true
-
-      - step: "Invalidate addendum detail cache after closing"
-        action: "call"
-        target: "addendum_detail"
-        method: "invalidate_cache"
 
       - step: "Assert first-round addendum detail is locked after closing"
         action: "assert"
@@ -349,11 +327,6 @@ scenarios:
         target: "admission"
         method: "action_close_addendum"
         as_user: "base.user_admin"
-
-      - step: "Invalidate second-round addendum term cache after closing"
-        action: "call"
-        target: "addendum_term_2"
-        method: "invalidate_cache"
 
       - step: "Assert second-round addendum term is locked after closing again"
         action: "assert"

--- a/ssi_school_admission/tests/test_data_admission_create_due_invoice.yaml
+++ b/ssi_school_admission/tests/test_data_admission_create_due_invoice.yaml
@@ -128,6 +128,7 @@ scenarios:
         model: "school_admission"
         save_as: "admission"
         values:
+          user_id: "REF: base.user_admin"
           customer_invoice_type_id: "REC: ci_type.id"
           receivable_account_id: "REC: ci_account.id"
           pricelist_id: "REF: product.list0"
@@ -145,6 +146,10 @@ scenarios:
         target: "admission"
         method: "action_confirm"
         as_user: "base.user_admin"
+        asserts:
+          state:
+            type: "value"
+            expected: "confirm"
 
       - step: "Approve admission"
         action: "call"
@@ -437,6 +442,7 @@ scenarios:
         model: "school_admission"
         save_as: "admission"
         values:
+          user_id: "REF: base.user_admin"
           customer_invoice_type_id: "REC: ci_type.id"
           receivable_account_id: "REC: ci_account.id"
           pricelist_id: "REF: product.list0"
@@ -454,6 +460,10 @@ scenarios:
         target: "admission"
         method: "action_confirm"
         as_user: "base.user_admin"
+        asserts:
+          state:
+            type: "value"
+            expected: "confirm"
 
       - step: "Approve admission"
         action: "call"
@@ -727,6 +737,7 @@ scenarios:
         model: "school_admission"
         save_as: "admission"
         values:
+          user_id: "REF: base.user_admin"
           customer_invoice_type_id: "REC: ci_type.id"
           receivable_account_id: "REC: ci_account.id"
           pricelist_id: "REF: product.list0"
@@ -744,6 +755,10 @@ scenarios:
         target: "admission"
         method: "action_confirm"
         as_user: "base.user_admin"
+        asserts:
+          state:
+            type: "value"
+            expected: "confirm"
 
       - step: "Approve admission"
         action: "call"
@@ -1017,6 +1032,7 @@ scenarios:
         model: "school_admission"
         save_as: "admission"
         values:
+          user_id: "REF: base.user_admin"
           customer_invoice_type_id: "REC: ci_type.id"
           receivable_account_id: "REC: ci_account.id"
           pricelist_id: "REF: product.list0"
@@ -1034,6 +1050,10 @@ scenarios:
         target: "admission"
         method: "action_confirm"
         as_user: "base.user_admin"
+        asserts:
+          state:
+            type: "value"
+            expected: "confirm"
 
       - step: "Approve admission"
         action: "call"
@@ -1308,6 +1328,7 @@ scenarios:
         model: "school_admission"
         save_as: "admission"
         values:
+          user_id: "REF: base.user_admin"
           customer_invoice_type_id: "REC: ci_type.id"
           receivable_account_id: "REC: ci_account.id"
           pricelist_id: "REF: product.list0"
@@ -1325,6 +1346,10 @@ scenarios:
         target: "admission"
         method: "action_confirm"
         as_user: "base.user_admin"
+        asserts:
+          state:
+            type: "value"
+            expected: "confirm"
 
       - step: "Approve admission"
         action: "call"
@@ -1556,6 +1581,7 @@ scenarios:
         model: "school_admission"
         save_as: "admission"
         values:
+          user_id: "REF: base.user_admin"
           customer_invoice_type_id: "REC: ci_type.id"
           receivable_account_id: "REC: ci_account.id"
           pricelist_id: "REF: product.list0"
@@ -1573,6 +1599,10 @@ scenarios:
         target: "admission"
         method: "action_confirm"
         as_user: "base.user_admin"
+        asserts:
+          state:
+            type: "value"
+            expected: "confirm"
 
       - step: "Approve admission"
         action: "call"
@@ -1615,6 +1645,7 @@ scenarios:
         model: "school_admission"
         save_as: "admission_draft"
         values:
+          user_id: "REF: base.user_admin"
           customer_invoice_type_id: "REC: ci_type.id"
           receivable_account_id: "REC: ci_account.id"
           pricelist_id: "REF: product.list0"
@@ -1796,6 +1827,7 @@ scenarios:
         model: "school_admission"
         save_as: "admission"
         values:
+          user_id: "REF: base.user_admin"
           customer_invoice_type_id: "REC: ci_type.id"
           receivable_account_id: "REC: ci_account.id"
           pricelist_id: "REF: product.list0"
@@ -1813,6 +1845,10 @@ scenarios:
         target: "admission"
         method: "action_confirm"
         as_user: "base.user_admin"
+        asserts:
+          state:
+            type: "value"
+            expected: "confirm"
 
       - step: "Approve admission"
         action: "call"

--- a/ssi_school_admission/tests/test_data_admission_create_due_invoice.yaml
+++ b/ssi_school_admission/tests/test_data_admission_create_due_invoice.yaml
@@ -1,3 +1,6 @@
+options:
+  auto_refresh: true
+
 scenarios:
   - name: "Create Due Invoice - No Range Invoices Only Due Terms"
     steps:
@@ -143,11 +146,6 @@ scenarios:
         method: "action_confirm"
         as_user: "base.user_admin"
 
-      - step: "Invalidate admission cache before approve"
-        action: "call"
-        target: "admission"
-        method: "invalidate_cache"
-
       - step: "Approve admission"
         action: "call"
         target: "admission"
@@ -157,11 +155,6 @@ scenarios:
           state:
             type: "value"
             expected: "open"
-
-      - step: "Invalidate admission cache after approve"
-        action: "call"
-        target: "admission"
-        method: "invalidate_cache"
 
       - step: "Assert admission is allowed to create due invoice"
         action: "assert"
@@ -462,11 +455,6 @@ scenarios:
         method: "action_confirm"
         as_user: "base.user_admin"
 
-      - step: "Invalidate admission cache before approve"
-        action: "call"
-        target: "admission"
-        method: "invalidate_cache"
-
       - step: "Approve admission"
         action: "call"
         target: "admission"
@@ -757,11 +745,6 @@ scenarios:
         method: "action_confirm"
         as_user: "base.user_admin"
 
-      - step: "Invalidate admission cache before approve"
-        action: "call"
-        target: "admission"
-        method: "invalidate_cache"
-
       - step: "Approve admission"
         action: "call"
         target: "admission"
@@ -1051,11 +1034,6 @@ scenarios:
         target: "admission"
         method: "action_confirm"
         as_user: "base.user_admin"
-
-      - step: "Invalidate admission cache before approve"
-        action: "call"
-        target: "admission"
-        method: "invalidate_cache"
 
       - step: "Approve admission"
         action: "call"
@@ -1348,11 +1326,6 @@ scenarios:
         method: "action_confirm"
         as_user: "base.user_admin"
 
-      - step: "Invalidate admission cache before approve"
-        action: "call"
-        target: "admission"
-        method: "invalidate_cache"
-
       - step: "Approve admission"
         action: "call"
         target: "admission"
@@ -1601,11 +1574,6 @@ scenarios:
         method: "action_confirm"
         as_user: "base.user_admin"
 
-      - step: "Invalidate admission cache before approve"
-        action: "call"
-        target: "admission"
-        method: "invalidate_cache"
-
       - step: "Approve admission"
         action: "call"
         target: "admission"
@@ -1845,11 +1813,6 @@ scenarios:
         target: "admission"
         method: "action_confirm"
         as_user: "base.user_admin"
-
-      - step: "Invalidate admission cache before approve"
-        action: "call"
-        target: "admission"
-        method: "invalidate_cache"
 
       - step: "Approve admission"
         action: "call"

--- a/ssi_school_admission/tests/test_data_admission_create_enrollment.yaml
+++ b/ssi_school_admission/tests/test_data_admission_create_enrollment.yaml
@@ -153,6 +153,7 @@ scenarios:
         model: "school_admission"
         save_as: "admission"
         values:
+          user_id: "REF: base.user_admin"
           date: "2024-07-01"
           academic_year_id: "REC: academic_year.id"
           academic_term_id: "REC: academic_term.id"

--- a/ssi_school_admission/tests/test_data_admission_create_enrollment.yaml
+++ b/ssi_school_admission/tests/test_data_admission_create_enrollment.yaml
@@ -1,3 +1,6 @@
+options:
+  auto_refresh: true
+
 scenarios:
   - name: "Wizard - Create Enrollment from School Admission"
     steps:
@@ -171,11 +174,6 @@ scenarios:
             type: "value"
             expected: "confirm"
 
-      - step: "Invalidate admission cache after confirm"
-        action: "call"
-        target: "admission"
-        method: "invalidate_cache"
-
       - step: "Approve admission (moves to open, creates school student)"
         action: "call"
         target: "admission"
@@ -185,11 +183,6 @@ scenarios:
           state:
             type: "value"
             expected: "open"
-
-      - step: "Invalidate admission cache after approve"
-        action: "call"
-        target: "admission"
-        method: "invalidate_cache"
 
       - step: "Assert admission has school student and is allowed to create enrollment"
         action: "assert"
@@ -225,11 +218,6 @@ scenarios:
         target: "wizard"
         method: "action_create_enrollment"
         as_user: "base.user_admin"
-
-      - step: "Invalidate admission cache after wizard call"
-        action: "call"
-        target: "admission"
-        method: "invalidate_cache"
 
       - step: "Search for created enrollment"
         action: "search"

--- a/ssi_school_admission/tests/test_data_admission_customer_invoice.yaml
+++ b/ssi_school_admission/tests/test_data_admission_customer_invoice.yaml
@@ -1,3 +1,6 @@
+options:
+  auto_refresh: true
+
 scenarios:
   - name: "Create Customer Invoice From Payment Term"
     steps:
@@ -198,21 +201,11 @@ scenarios:
         method: "action_confirm"
         as_user: "base.user_admin"
 
-      - step: "Invalidate admission cache before approve"
-        action: "call"
-        target: "admission"
-        method: "invalidate_cache"
-
       - step: "Approve admission"
         action: "call"
         target: "admission"
         method: "action_approve_approval"
         as_user: "base.user_admin"
-
-      - step: "Invalidate admission cache after approve"
-        action: "call"
-        target: "admission"
-        method: "invalidate_cache"
 
       - step: "Assert the admission is open"
         action: "assert"
@@ -227,11 +220,6 @@ scenarios:
         target: "term"
         method: "action_create_invoice"
         as_user: "base.user_admin"
-
-      - step: "Invalidate cache after creating the customer invoice"
-        action: "call"
-        target: "term"
-        method: "invalidate_cache"
 
       - step: "Assert term is invoiced and linked to a customer invoice"
         action: "assert"
@@ -492,21 +480,11 @@ scenarios:
         method: "action_confirm"
         as_user: "base.user_admin"
 
-      - step: "Invalidate admission cache before approve"
-        action: "call"
-        target: "admission"
-        method: "invalidate_cache"
-
       - step: "Approve admission"
         action: "call"
         target: "admission"
         method: "action_approve_approval"
         as_user: "base.user_admin"
-
-      - step: "Invalidate admission cache after approve"
-        action: "call"
-        target: "admission"
-        method: "invalidate_cache"
 
       - step: "Assert the admission is open"
         action: "assert"
@@ -521,11 +499,6 @@ scenarios:
         target: "term"
         method: "action_create_invoice"
         as_user: "base.user_admin"
-
-      - step: "Invalidate cache after creating the customer invoice"
-        action: "call"
-        target: "term"
-        method: "invalidate_cache"
 
       - step: "Assert the admission asks for an automatic confirmation"
         action: "assert"
@@ -745,21 +718,11 @@ scenarios:
         method: "action_confirm"
         as_user: "base.user_admin"
 
-      - step: "Invalidate admission cache before approve"
-        action: "call"
-        target: "admission"
-        method: "invalidate_cache"
-
       - step: "Approve admission"
         action: "call"
         target: "admission"
         method: "action_approve_approval"
         as_user: "base.user_admin"
-
-      - step: "Invalidate admission cache after approve"
-        action: "call"
-        target: "admission"
-        method: "invalidate_cache"
 
       - step: "Assert the admission is open"
         action: "assert"
@@ -775,21 +738,11 @@ scenarios:
         method: "action_create_invoice"
         as_user: "base.user_admin"
 
-      - step: "Invalidate cache after creating the customer invoice"
-        action: "call"
-        target: "term"
-        method: "invalidate_cache"
-
       - step: "Disconnect the customer invoice from the payment term"
         action: "call"
         target: "term"
         method: "action_disconnect_invoice"
         as_user: "base.user_admin"
-
-      - step: "Invalidate cache after disconnecting the customer invoice"
-        action: "call"
-        target: "term"
-        method: "invalidate_cache"
 
       - step: "Assert the term is uninvoiced again"
         action: "assert"
@@ -1008,21 +961,11 @@ scenarios:
         method: "action_confirm"
         as_user: "base.user_admin"
 
-      - step: "Invalidate admission cache before approve"
-        action: "call"
-        target: "admission"
-        method: "invalidate_cache"
-
       - step: "Approve admission"
         action: "call"
         target: "admission"
         method: "action_approve_approval"
         as_user: "base.user_admin"
-
-      - step: "Invalidate admission cache after approve"
-        action: "call"
-        target: "admission"
-        method: "invalidate_cache"
 
       - step: "Assert the admission is open"
         action: "assert"
@@ -1038,21 +981,11 @@ scenarios:
         method: "action_create_invoice"
         as_user: "base.user_admin"
 
-      - step: "Invalidate cache after creating the customer invoice"
-        action: "call"
-        target: "term"
-        method: "invalidate_cache"
-
       - step: "Delete the draft customer invoice"
         action: "call"
         target: "term"
         method: "action_delete_invoice"
         as_user: "base.user_admin"
-
-      - step: "Invalidate cache after deleting the customer invoice"
-        action: "call"
-        target: "term"
-        method: "invalidate_cache"
 
       - step: "Assert the term is uninvoiced again"
         action: "assert"
@@ -1287,21 +1220,11 @@ scenarios:
         method: "action_confirm"
         as_user: "base.user_admin"
 
-      - step: "Invalidate admission cache before approve"
-        action: "call"
-        target: "admission"
-        method: "invalidate_cache"
-
       - step: "Approve admission"
         action: "call"
         target: "admission"
         method: "action_approve_approval"
         as_user: "base.user_admin"
-
-      - step: "Invalidate admission cache after approve"
-        action: "call"
-        target: "admission"
-        method: "invalidate_cache"
 
       - step: "Assert the admission is open"
         action: "assert"
@@ -1316,11 +1239,6 @@ scenarios:
         target: "term"
         method: "action_create_invoice"
         as_user: "base.user_admin"
-
-      - step: "Invalidate cache after creating the customer invoice"
-        action: "call"
-        target: "term"
-        method: "invalidate_cache"
 
       - step: "Get the generated customer invoice"
         action: "search"
@@ -1347,11 +1265,6 @@ scenarios:
         expect_error:
           type: "UserError"
           message_contains: "not draft anymore"
-
-      - step: "Invalidate cache after the rejected deletion"
-        action: "call"
-        target: "term"
-        method: "invalidate_cache"
 
       - step: "Assert the term is still linked to the customer invoice"
         action: "assert"
@@ -1563,21 +1476,11 @@ scenarios:
         method: "action_confirm"
         as_user: "base.user_admin"
 
-      - step: "Invalidate admission cache before approve"
-        action: "call"
-        target: "admission"
-        method: "invalidate_cache"
-
       - step: "Approve admission"
         action: "call"
         target: "admission"
         method: "action_approve_approval"
         as_user: "base.user_admin"
-
-      - step: "Invalidate admission cache after approve"
-        action: "call"
-        target: "admission"
-        method: "invalidate_cache"
 
       - step: "Assert the admission is open"
         action: "assert"
@@ -1593,11 +1496,6 @@ scenarios:
         method: "action_create_invoice"
         as_user: "base.user_admin"
 
-      - step: "Invalidate cache after creating the customer invoice"
-        action: "call"
-        target: "term"
-        method: "invalidate_cache"
-
       - step: "Cancelling the admission must be rejected"
         action: "call"
         target: "admission"
@@ -1605,11 +1503,6 @@ scenarios:
         as_user: "base.user_admin"
         expect_error:
           type: "UserError"
-
-      - step: "Invalidate cache after the rejected cancellation"
-        action: "call"
-        target: "admission"
-        method: "invalidate_cache"
 
       - step: "Assert the admission is still open"
         action: "assert"

--- a/ssi_school_admission/tests/test_data_admission_customer_invoice.yaml
+++ b/ssi_school_admission/tests/test_data_admission_customer_invoice.yaml
@@ -144,6 +144,7 @@ scenarios:
         model: "school_admission"
         save_as: "admission"
         values:
+          user_id: "REF: base.user_admin"
           date: "2024-07-01"
           academic_year_id: "REC: academic_year.id"
           academic_term_id: "REC: academic_term.id"
@@ -200,6 +201,10 @@ scenarios:
         target: "admission"
         method: "action_confirm"
         as_user: "base.user_admin"
+        asserts:
+          state:
+            type: "value"
+            expected: "confirm"
 
       - step: "Approve admission"
         action: "call"
@@ -423,6 +428,7 @@ scenarios:
         model: "school_admission"
         save_as: "admission"
         values:
+          user_id: "REF: base.user_admin"
           date: "2024-07-01"
           academic_year_id: "REC: academic_year.id"
           academic_term_id: "REC: academic_term.id"
@@ -479,6 +485,10 @@ scenarios:
         target: "admission"
         method: "action_confirm"
         as_user: "base.user_admin"
+        asserts:
+          state:
+            type: "value"
+            expected: "confirm"
 
       - step: "Approve admission"
         action: "call"
@@ -661,6 +671,7 @@ scenarios:
         model: "school_admission"
         save_as: "admission"
         values:
+          user_id: "REF: base.user_admin"
           date: "2024-07-01"
           academic_year_id: "REC: academic_year.id"
           academic_term_id: "REC: academic_term.id"
@@ -717,6 +728,10 @@ scenarios:
         target: "admission"
         method: "action_confirm"
         as_user: "base.user_admin"
+        asserts:
+          state:
+            type: "value"
+            expected: "confirm"
 
       - step: "Approve admission"
         action: "call"
@@ -904,6 +919,7 @@ scenarios:
         model: "school_admission"
         save_as: "admission"
         values:
+          user_id: "REF: base.user_admin"
           date: "2024-07-01"
           academic_year_id: "REC: academic_year.id"
           academic_term_id: "REC: academic_term.id"
@@ -960,6 +976,10 @@ scenarios:
         target: "admission"
         method: "action_confirm"
         as_user: "base.user_admin"
+        asserts:
+          state:
+            type: "value"
+            expected: "confirm"
 
       - step: "Approve admission"
         action: "call"
@@ -1163,6 +1183,7 @@ scenarios:
         model: "school_admission"
         save_as: "admission"
         values:
+          user_id: "REF: base.user_admin"
           date: "2024-07-01"
           academic_year_id: "REC: academic_year.id"
           academic_term_id: "REC: academic_term.id"
@@ -1219,6 +1240,10 @@ scenarios:
         target: "admission"
         method: "action_confirm"
         as_user: "base.user_admin"
+        asserts:
+          state:
+            type: "value"
+            expected: "confirm"
 
       - step: "Approve admission"
         action: "call"
@@ -1246,6 +1271,12 @@ scenarios:
         domain: [["customer_document_number", "=", "REC: admission.name"]]
         save_as: "invoice"
         expect_count: 1
+
+      - step: "Own the generated invoice so the next step may read it back"
+        action: "write"
+        target: "invoice"
+        values:
+          user_id: "REF: base.user_admin"
 
       - step: "Confirm the customer invoice"
         action: "call"
@@ -1419,6 +1450,7 @@ scenarios:
         model: "school_admission"
         save_as: "admission"
         values:
+          user_id: "REF: base.user_admin"
           date: "2024-07-01"
           academic_year_id: "REC: academic_year.id"
           academic_term_id: "REC: academic_term.id"
@@ -1475,6 +1507,10 @@ scenarios:
         target: "admission"
         method: "action_confirm"
         as_user: "base.user_admin"
+        asserts:
+          state:
+            type: "value"
+            expected: "confirm"
 
       - step: "Approve admission"
         action: "call"

--- a/ssi_school_admission/tests/test_data_admission_form.yaml
+++ b/ssi_school_admission/tests/test_data_admission_form.yaml
@@ -133,6 +133,7 @@ scenarios:
         save_as: "admission_form"
         as_user: "base.user_admin"
         values:
+          user_id: "REF: base.user_admin"
           date: "2024-07-01"
           academic_year_id: "EVAL: registry['academic_year'].id"
           academic_term_id: "EVAL: registry['academic_term'].id"
@@ -296,6 +297,7 @@ scenarios:
         save_as: "admission_form"
         as_user: "base.user_admin"
         values:
+          user_id: "REF: base.user_admin"
           date: "2024-07-01"
           academic_year_id: "EVAL: registry['academic_year'].id"
           academic_term_id: "EVAL: registry['academic_term'].id"
@@ -429,6 +431,7 @@ scenarios:
         save_as: "admission_form"
         as_user: "base.user_admin"
         values:
+          user_id: "REF: base.user_admin"
           date: "2024-07-01"
           academic_year_id: "EVAL: registry['academic_year'].id"
           academic_term_id: "EVAL: registry['academic_term'].id"

--- a/ssi_school_admission/tests/test_data_admission_form.yaml
+++ b/ssi_school_admission/tests/test_data_admission_form.yaml
@@ -1,3 +1,6 @@
+options:
+  auto_refresh: true
+
 scenarios:
   - name: "Admission Form - Compute Fee from Template and Open"
     steps:
@@ -149,11 +152,6 @@ scenarios:
         method: "action_compute_fee"
         as_user: "base.user_admin"
 
-      - step: "Invalidate admission form cache after fee compute"
-        action: "call"
-        target: "admission_form"
-        method: "invalidate_cache"
-
       - step: "Assert fee lines created from template"
         action: "assert"
         target: "admission_form"
@@ -179,11 +177,6 @@ scenarios:
             type: "value"
             expected: "confirm"
 
-      - step: "Invalidate admission form cache before approve"
-        action: "call"
-        target: "admission_form"
-        method: "invalidate_cache"
-
       - step: "Approve admission form"
         action: "call"
         target: "admission_form"
@@ -193,11 +186,6 @@ scenarios:
           state:
             type: "value"
             expected: "open"
-
-      - step: "Invalidate admission form cache after open"
-        action: "call"
-        target: "admission_form"
-        method: "invalidate_cache"
 
       - step: "Assert accounting entry created on open"
         action: "assert"
@@ -325,11 +313,6 @@ scenarios:
         target: "admission_form"
         method: "action_create_admission_test"
         as_user: "base.user_admin"
-
-      - step: "Invalidate admission form cache"
-        action: "call"
-        target: "admission_form"
-        method: "invalidate_cache"
 
       - step: "Assert admission test created and linked to form"
         action: "assert"
@@ -476,11 +459,6 @@ scenarios:
             type: "value"
             expected: "confirm"
 
-      - step: "Invalidate admission form cache before approve"
-        action: "call"
-        target: "admission_form"
-        method: "invalidate_cache"
-
       - step: "Approve free admission form (auto-done, no journal entry)"
         action: "call"
         target: "admission_form"
@@ -490,11 +468,6 @@ scenarios:
           state:
             type: "value"
             expected: "done"
-
-      - step: "Invalidate admission form cache after auto-done"
-        action: "call"
-        target: "admission_form"
-        method: "invalidate_cache"
 
       - step: "Assert no accounting entry created for free form"
         action: "assert"

--- a/ssi_school_admission/tests/test_data_admission_onchange.yaml
+++ b/ssi_school_admission/tests/test_data_admission_onchange.yaml
@@ -1,0 +1,101 @@
+options:
+  auto_refresh: true
+
+scenarios:
+  - name: "Payment Template Onchange Fills And Clears Receivable Accounting"
+    steps:
+      - step: "Setup - get receivable journal"
+        action: "search"
+        model: "account.journal"
+        domain: [["type", "=", "sale"]]
+        save_as: "journal"
+        limit: 1
+
+      - step: "Setup - get receivable account type"
+        action: "ref"
+        xml_id: "account.data_account_type_receivable"
+        save_as: "account_type"
+
+      - step: "Setup - create receivable account"
+        action: "create"
+        model: "account.account"
+        save_as: "account"
+        values:
+          name: "Admission Receivable Onchange"
+          code: "ADMREC01"
+          user_type_id: "REC: account_type.id"
+          reconcile: true
+
+      - step: "Setup - create grade type"
+        action: "create"
+        model: "school_grade_type"
+        save_as: "grade_type"
+        values:
+          name: "Grade Type Onchange"
+          code: "GTONC1"
+          sequence: 10
+
+      - step: "Setup - create school"
+        action: "create"
+        model: "school"
+        save_as: "school"
+        values:
+          name: "School Onchange"
+          code: "SCHONC1"
+          grade_type_id: "REC: grade_type.id"
+
+      - step: "Setup - create grade"
+        action: "create"
+        model: "school_grade"
+        save_as: "grade"
+        values:
+          name: "Grade Onchange"
+          code: "GONC1"
+          sequence: 10
+          type_id: "REC: grade_type.id"
+
+      - step: "Setup - create customer invoice type"
+        action: "create"
+        model: "customer_invoice_type"
+        save_as: "customer_invoice_type"
+        values:
+          name: "Customer Invoice Type Onchange"
+          code: "ADMCITONC1"
+          journal_id: "REC: journal.id"
+          receivable_account_id: "REC: account.id"
+
+      - step: "Setup - create admission payment template"
+        action: "create"
+        model: "school_admission_payment_template"
+        save_as: "template"
+        values:
+          name: "Admission Payment Template Onchange"
+          code: "ADMPMTONC1"
+          school_id: "REC: school.id"
+          grade_id: "REC: grade.id"
+          receivable_journal_id: "REC: journal.id"
+          receivable_account_id: "REC: account.id"
+          customer_invoice_type_id: "REC: customer_invoice_type.id"
+
+      - step: "Payment template sets then clears the receivable fields"
+        action: "form"
+        model: "school_admission"
+        save: false
+        ops:
+          - set: {payment_template_id: "REC: template"}
+          - assert:
+              receivable_journal_id:
+                type: "m2o"
+                expected: "REC: journal"
+              receivable_account_id:
+                type: "m2o"
+                expected: "REC: account"
+          - set:
+              payment_template_id: "EVAL: env['school_admission_payment_template']"
+          - assert:
+              receivable_journal_id:
+                type: "value"
+                operator: "is_falsy"
+              receivable_account_id:
+                type: "value"
+                operator: "is_falsy"

--- a/ssi_school_admission/tests/test_data_admission_payment_date_pattern.yaml
+++ b/ssi_school_admission/tests/test_data_admission_payment_date_pattern.yaml
@@ -205,6 +205,7 @@ scenarios:
         model: "school_admission"
         save_as: "admission"
         values:
+          user_id: "REF: base.user_admin"
           date: "2024-07-01"
           academic_year_id: "EVAL: registry['academic_year'].id"
           academic_term_id: "EVAL: registry['academic_term'].id"
@@ -432,6 +433,7 @@ scenarios:
         model: "school_admission"
         save_as: "admission"
         values:
+          user_id: "REF: base.user_admin"
           date: "2024-07-01"
           academic_year_id: "EVAL: registry['academic_year'].id"
           academic_term_id: "EVAL: registry['academic_term'].id"

--- a/ssi_school_admission/tests/test_data_admission_payment_date_pattern.yaml
+++ b/ssi_school_admission/tests/test_data_admission_payment_date_pattern.yaml
@@ -1,3 +1,6 @@
+options:
+  auto_refresh: true
+
 scenarios:
   - name: "Compute Payment - Estimated Invoice and Due Date from Duration"
     steps:
@@ -225,11 +228,6 @@ scenarios:
         method: "action_compute_payment"
         as_user: "base.user_admin"
 
-      - step: "Invalidate admission cache after compute"
-        action: "call"
-        target: "admission"
-        method: "invalidate_cache"
-
       - step: "Get admission payment term 1"
         action: "search"
         model: "school_admission_payment_term"
@@ -456,11 +454,6 @@ scenarios:
         target: "admission"
         method: "action_compute_payment"
         as_user: "base.user_admin"
-
-      - step: "Invalidate admission cache after compute"
-        action: "call"
-        target: "admission"
-        method: "invalidate_cache"
 
       - step: "Get admission payment term"
         action: "search"

--- a/ssi_school_admission/tests/test_data_admission_payment_term.yaml
+++ b/ssi_school_admission/tests/test_data_admission_payment_term.yaml
@@ -1,3 +1,6 @@
+options:
+  auto_refresh: true
+
 scenarios:
   - name: "Admission Payment Term - Create and Delete Invoice"
     steps:
@@ -184,11 +187,6 @@ scenarios:
         method: "action_compute_payment"
         as_user: "base.user_admin"
 
-      - step: "Invalidate admission cache after compute"
-        action: "call"
-        target: "admission"
-        method: "invalidate_cache"
-
       - step: "Approve admission"
         action: "call"
         target: "admission"
@@ -219,11 +217,6 @@ scenarios:
         target: "term"
         method: "action_create_invoice"
 
-      - step: "Invalidate term cache after invoice"
-        action: "call"
-        target: "term"
-        method: "invalidate_cache"
-
       - step: "Assert invoice created"
         action: "assert"
         target: "term"
@@ -239,11 +232,6 @@ scenarios:
         action: "call"
         target: "term"
         method: "action_delete_invoice"
-
-      - step: "Invalidate term cache after delete"
-        action: "call"
-        target: "term"
-        method: "invalidate_cache"
 
       - step: "Assert invoice deleted"
         action: "assert"
@@ -473,11 +461,6 @@ scenarios:
         method: "action_compute_payment"
         as_user: "base.user_admin"
 
-      - step: "Invalidate admission cache after compute"
-        action: "call"
-        target: "admission"
-        method: "invalidate_cache"
-
       - step: "Approve admission"
         action: "call"
         target: "admission"
@@ -496,11 +479,6 @@ scenarios:
         target: "term"
         method: "action_create_invoice"
 
-      - step: "Invalidate term cache"
-        action: "call"
-        target: "term"
-        method: "invalidate_cache"
-
       - step: "Assert invoice exists"
         action: "assert"
         target: "term"
@@ -513,11 +491,6 @@ scenarios:
         action: "call"
         target: "term"
         method: "action_disconnect_invoice"
-
-      - step: "Invalidate term cache after disconnect"
-        action: "call"
-        target: "term"
-        method: "invalidate_cache"
 
       - step: "Assert invoice disconnected"
         action: "assert"
@@ -747,11 +720,6 @@ scenarios:
         method: "action_compute_payment"
         as_user: "base.user_admin"
 
-      - step: "Invalidate admission cache after compute"
-        action: "call"
-        target: "admission"
-        method: "invalidate_cache"
-
       - step: "Approve admission"
         action: "call"
         target: "admission"
@@ -770,11 +738,6 @@ scenarios:
         target: "term"
         method: "action_mark_as_manual"
 
-      - step: "Invalidate term cache"
-        action: "call"
-        target: "term"
-        method: "invalidate_cache"
-
       - step: "Assert term is manually controlled"
         action: "assert"
         target: "term"
@@ -790,11 +753,6 @@ scenarios:
         action: "call"
         target: "term"
         method: "action_unmark_as_manual"
-
-      - step: "Invalidate term cache after unmark"
-        action: "call"
-        target: "term"
-        method: "invalidate_cache"
 
       - step: "Assert term is back to uninvoiced"
         action: "assert"

--- a/ssi_school_admission/tests/test_data_admission_payment_term.yaml
+++ b/ssi_school_admission/tests/test_data_admission_payment_term.yaml
@@ -162,6 +162,7 @@ scenarios:
         model: "school_admission"
         save_as: "admission"
         values:
+          user_id: "REF: base.user_admin"
           customer_invoice_type_id: "REC: ci_type.id"
           receivable_account_id: "REC: ci_account.id"
           date: "2024-07-01"
@@ -436,6 +437,7 @@ scenarios:
         model: "school_admission"
         save_as: "admission"
         values:
+          user_id: "REF: base.user_admin"
           customer_invoice_type_id: "REC: ci_type.id"
           receivable_account_id: "REC: ci_account.id"
           date: "2024-07-01"
@@ -695,6 +697,7 @@ scenarios:
         model: "school_admission"
         save_as: "admission"
         values:
+          user_id: "REF: base.user_admin"
           customer_invoice_type_id: "REC: ci_type.id"
           receivable_account_id: "REC: ci_account.id"
           date: "2024-07-01"

--- a/ssi_school_admission/tests/test_data_admission_payment_term_duplicate.yaml
+++ b/ssi_school_admission/tests/test_data_admission_payment_term_duplicate.yaml
@@ -1,3 +1,6 @@
+options:
+  auto_refresh: true
+
 scenarios:
   - name: "Admission Payment Term - Duplicate via Wizard"
     steps:
@@ -191,11 +194,6 @@ scenarios:
         action: "call"
         target: "term"
         method: "action_create_invoice"
-
-      - step: "Invalidate term cache after invoice creation"
-        action: "call"
-        target: "term"
-        method: "invalidate_cache"
 
       - step: "Assert source term has an invoice"
         action: "assert"

--- a/ssi_school_admission/tests/test_data_admission_product_summary.yaml
+++ b/ssi_school_admission/tests/test_data_admission_product_summary.yaml
@@ -1,3 +1,6 @@
+options:
+  auto_refresh: true
+
 scenarios:
   - name: "Product Summary - satu produk satu term tercompute saat detail ditambah"
     steps:
@@ -124,11 +127,6 @@ scenarios:
           uom_quantity: 1.0
           uom_id: "REF: uom.product_uom_unit"
           price_unit: 1000000.0
-
-      - step: "Invalidate admission cache"
-        action: "call"
-        target: "admission"
-        method: "invalidate_cache"
 
       - step: "Assert product_summary_ids berisi 1 record"
         action: "assert"
@@ -274,11 +272,6 @@ scenarios:
           uom_id: "REF: uom.product_uom_unit"
           price_unit: 500000.0
 
-      - step: "Invalidate admission cache setelah create detail"
-        action: "call"
-        target: "admission"
-        method: "invalidate_cache"
-
       - step: "Cari summary record setelah create"
         action: "search"
         model: "school_admission_product_summary"
@@ -299,11 +292,6 @@ scenarios:
         target: "detail"
         values:
           uom_quantity: 3.0
-
-      - step: "Invalidate admission cache setelah write quantity"
-        action: "call"
-        target: "admission"
-        method: "invalidate_cache"
 
       - step: "Cari summary record setelah write quantity"
         action: "search"
@@ -328,11 +316,6 @@ scenarios:
         target: "detail"
         values:
           price_unit: 700000.0
-
-      - step: "Invalidate admission cache setelah write price_unit"
-        action: "call"
-        target: "admission"
-        method: "invalidate_cache"
 
       - step: "Cari summary record setelah write price_unit"
         action: "search"
@@ -489,11 +472,6 @@ scenarios:
           uom_id: "REF: uom.product_uom_unit"
           price_unit: 500000.0
 
-      - step: "Invalidate admission cache"
-        action: "call"
-        target: "admission"
-        method: "invalidate_cache"
-
       - step: "Assert product_summary_ids hanya 1 record meski 2 term"
         action: "assert"
         target: "admission"
@@ -638,11 +616,6 @@ scenarios:
           uom_id: "REF: uom.product_uom_unit"
           price_unit: 750000.0
 
-      - step: "Invalidate admission cache"
-        action: "call"
-        target: "admission"
-        method: "invalidate_cache"
-
       - step: "Assert summary ada sebelum detail dihapus"
         action: "assert"
         target: "admission"
@@ -656,11 +629,6 @@ scenarios:
         action: "call"
         target: "detail"
         method: "unlink"
-
-      - step: "Invalidate admission cache setelah hapus detail"
-        action: "call"
-        target: "admission"
-        method: "invalidate_cache"
 
       - step: "Assert summary kosong setelah detail dihapus"
         action: "assert"
@@ -787,11 +755,6 @@ scenarios:
           uom_id: "REF: uom.product_uom_unit"
           price_unit: 250000.0
 
-      - step: "Invalidate admission cache"
-        action: "call"
-        target: "admission"
-        method: "invalidate_cache"
-
       - step: "Assert summary ada sebelum term dihapus"
         action: "assert"
         target: "admission"
@@ -805,11 +768,6 @@ scenarios:
         action: "call"
         target: "term"
         method: "unlink"
-
-      - step: "Invalidate admission cache setelah hapus term"
-        action: "call"
-        target: "admission"
-        method: "invalidate_cache"
 
       - step: "Assert summary kosong setelah term dihapus"
         action: "assert"

--- a/ssi_school_admission/tests/test_data_admission_restart_unlock.yaml
+++ b/ssi_school_admission/tests/test_data_admission_restart_unlock.yaml
@@ -97,6 +97,7 @@ scenarios:
         save_as: "admission"
         as_user: "base.user_admin"
         values:
+          user_id: "REF: base.user_admin"
           date: "2024-07-01"
           academic_year_id: "EVAL: registry['academic_year'].id"
           academic_term_id: "EVAL: registry['academic_term'].id"
@@ -135,6 +136,10 @@ scenarios:
         target: "admission"
         method: "action_confirm"
         as_user: "base.user_admin"
+        asserts:
+          state:
+            type: "value"
+            expected: "confirm"
 
       - step: "Approve admission"
         action: "call"

--- a/ssi_school_admission/tests/test_data_admission_restart_unlock.yaml
+++ b/ssi_school_admission/tests/test_data_admission_restart_unlock.yaml
@@ -1,3 +1,6 @@
+options:
+  auto_refresh: true
+
 scenarios:
   - name: "Restart Unlocks Payment Term And Detail, Remains Editable"
     steps:
@@ -133,11 +136,6 @@ scenarios:
         method: "action_confirm"
         as_user: "base.user_admin"
 
-      - step: "Invalidate admission cache before approve"
-        action: "call"
-        target: "admission"
-        method: "invalidate_cache"
-
       - step: "Approve admission"
         action: "call"
         target: "admission"
@@ -148,11 +146,6 @@ scenarios:
             type: "value"
             expected: "open"
 
-      - step: "Invalidate term cache after opening"
-        action: "call"
-        target: "term"
-        method: "invalidate_cache"
-
       - step: "Assert term locked after opening (control)"
         action: "assert"
         target: "term"
@@ -161,11 +154,6 @@ scenarios:
             type: "value"
             expected: true
 
-      - step: "Invalidate detail cache after opening"
-        action: "call"
-        target: "detail"
-        method: "invalidate_cache"
-
       - step: "Assert detail locked after opening (control)"
         action: "assert"
         target: "detail"
@@ -173,11 +161,6 @@ scenarios:
           locked:
             type: "value"
             expected: true
-
-      - step: "Invalidate admission cache before cancel"
-        action: "call"
-        target: "admission"
-        method: "invalidate_cache"
 
       - step: "Cancel admission"
         action: "call"
@@ -189,11 +172,6 @@ scenarios:
             type: "value"
             expected: "cancel"
 
-      - step: "Invalidate admission cache before restart"
-        action: "call"
-        target: "admission"
-        method: "invalidate_cache"
-
       - step: "Restart admission"
         action: "call"
         target: "admission"
@@ -204,11 +182,6 @@ scenarios:
             type: "value"
             expected: "draft"
 
-      - step: "Invalidate term cache after restart"
-        action: "call"
-        target: "term"
-        method: "invalidate_cache"
-
       - step: "Assert term unlocked after restart"
         action: "assert"
         target: "term"
@@ -216,11 +189,6 @@ scenarios:
           locked:
             type: "value"
             expected: false
-
-      - step: "Invalidate detail cache after restart"
-        action: "call"
-        target: "detail"
-        method: "invalidate_cache"
 
       - step: "Assert detail unlocked after restart"
         action: "assert"

--- a/ssi_school_admission/tests/test_data_admission_test_workflow.yaml
+++ b/ssi_school_admission/tests/test_data_admission_test_workflow.yaml
@@ -66,6 +66,7 @@ scenarios:
         model: "school_admission_test"
         save_as: "admission_test"
         values:
+          user_id: "REF: base.user_admin"
           date: "2024-07-01"
           academic_year_id: "EVAL: registry['academic_year'].id"
           academic_term_id: "EVAL: registry['academic_term'].id"
@@ -189,6 +190,7 @@ scenarios:
         model: "school_admission_test"
         save_as: "admission_test"
         values:
+          user_id: "REF: base.user_admin"
           date: "2024-07-01"
           academic_year_id: "EVAL: registry['academic_year'].id"
           academic_term_id: "EVAL: registry['academic_term'].id"
@@ -304,6 +306,7 @@ scenarios:
         model: "school_admission_form"
         save_as: "admission_form"
         values:
+          user_id: "REF: base.user_admin"
           date: "2024-07-01"
           academic_year_id: "REC: academic_year.id"
           academic_term_id: "REC: academic_term.id"
@@ -321,6 +324,7 @@ scenarios:
         model: "school_admission_test"
         save_as: "admission_test"
         values:
+          user_id: "REF: base.user_admin"
           date: "2024-07-01"
           academic_year_id: "REC: academic_year.id"
           academic_term_id: "REC: academic_term.id"
@@ -336,6 +340,7 @@ scenarios:
           type: "ValidationError"
           message_contains: "already has an Admission Test"
         values:
+          user_id: "REF: base.user_admin"
           date: "2024-07-01"
           academic_year_id: "REC: academic_year.id"
           academic_term_id: "REC: academic_term.id"

--- a/ssi_school_admission/tests/test_data_admission_test_workflow.yaml
+++ b/ssi_school_admission/tests/test_data_admission_test_workflow.yaml
@@ -1,3 +1,6 @@
+options:
+  auto_refresh: true
+
 scenarios:
   - name: "Admission Test - Full Workflow Confirm Approve Open Done"
     steps:
@@ -88,11 +91,6 @@ scenarios:
             type: "value"
             expected: "confirm"
 
-      - step: "Invalidate admission test cache after confirm"
-        action: "call"
-        target: "admission_test"
-        method: "invalidate_cache"
-
       - step: "Approve admission test"
         action: "call"
         target: "admission_test"
@@ -102,11 +100,6 @@ scenarios:
           state:
             type: "value"
             expected: "open"
-
-      - step: "Invalidate cache after open"
-        action: "call"
-        target: "admission_test"
-        method: "invalidate_cache"
 
       - step: "Set passed to True"
         action: "write"
@@ -123,11 +116,6 @@ scenarios:
           state:
             type: "value"
             expected: "done"
-
-      - step: "Invalidate cache after done"
-        action: "call"
-        target: "admission_test"
-        method: "invalidate_cache"
 
       - step: "Assert admission test passed"
         action: "assert"
@@ -215,3 +203,143 @@ scenarios:
           admission_form_id:
             type: "value"
             operator: "is_falsy"
+
+  - name: "Admission Test - One Admission Form Yields At Most One Admission Test"
+    steps:
+      - step: "Setup - get sale journal"
+        action: "search"
+        model: "account.journal"
+        domain: [["type", "=", "sale"]]
+        save_as: "journal"
+        limit: 1
+
+      - step: "Setup - get revenue account type"
+        action: "ref"
+        xml_id: "account.data_account_type_revenue"
+        save_as: "account_type"
+
+      - step: "Setup - create income account"
+        action: "create"
+        model: "account.account"
+        save_as: "account"
+        values:
+          name: "Admission Fee Income Uniqueness Test"
+          code: "ADUNIQ4200"
+          user_type_id: "REC: account_type.id"
+
+      - step: "Setup - create pricelist"
+        action: "create"
+        model: "product.pricelist"
+        save_as: "pricelist"
+        values:
+          name: "Pricelist ADUNIQ"
+          currency_id: "REC: company.currency_id.id"
+
+      - step: "Setup - create grade type"
+        action: "create"
+        model: "school_grade_type"
+        save_as: "grade_type"
+        values:
+          name: "Grade Type Uniqueness"
+          code: "GTUNIQ"
+          sequence: 10
+
+      - step: "Setup - create academic year"
+        action: "create"
+        model: "school_academic_year"
+        save_as: "academic_year"
+        values:
+          name: "2024/2025 Uniqueness"
+          code: "AYUNIQ"
+          date_start: "2024-07-01"
+          date_end: "2025-06-30"
+
+      - step: "Setup - create academic term"
+        action: "create"
+        model: "school_academic_term"
+        save_as: "academic_term"
+        values:
+          name: "Semester Uniqueness"
+          code: "SMUNIQ"
+          date_start: "2024-07-01"
+          date_end: "2025-06-30"
+          year_id: "REC: academic_year.id"
+          enrollment_state: "open"
+
+      - step: "Setup - create school"
+        action: "create"
+        model: "school"
+        save_as: "school"
+        values:
+          name: "School Uniqueness"
+          code: "SCHUNIQ"
+          grade_type_id: "REC: grade_type.id"
+
+      - step: "Setup - create grade"
+        action: "create"
+        model: "school_grade"
+        save_as: "grade"
+        values:
+          name: "Grade Uniqueness"
+          code: "GUNIQ"
+          sequence: 10
+          type_id: "REC: grade_type.id"
+
+      - step: "Setup - create student contact"
+        action: "create"
+        model: "res.partner"
+        save_as: "student_contact"
+        values:
+          name: "Student Uniqueness"
+
+      - step: "Setup - create parent contact"
+        action: "create"
+        model: "res.partner"
+        save_as: "parent_contact"
+        values:
+          name: "Parent Uniqueness"
+
+      - step: "Setup - create admission form"
+        action: "create"
+        model: "school_admission_form"
+        save_as: "admission_form"
+        values:
+          date: "2024-07-01"
+          academic_year_id: "REC: academic_year.id"
+          academic_term_id: "REC: academic_term.id"
+          school_id: "REC: school.id"
+          grade_id: "REC: grade.id"
+          student_id: "REC: student_contact.id"
+          parent_id: "REC: parent_contact.id"
+          pricelist_id: "REC: pricelist.id"
+          currency_id: "REC: company.currency_id.id"
+          journal_id: "REC: journal.id"
+          account_id: "REC: account.id"
+
+      - step: "Create the first admission test on that admission form"
+        action: "create"
+        model: "school_admission_test"
+        save_as: "admission_test"
+        values:
+          date: "2024-07-01"
+          academic_year_id: "REC: academic_year.id"
+          academic_term_id: "REC: academic_term.id"
+          school_id: "REC: school.id"
+          grade_id: "REC: grade.id"
+          student_id: "REC: student_contact.id"
+          admission_form_id: "REC: admission_form.id"
+
+      - step: "A second admission test on the same admission form is rejected"
+        action: "create"
+        model: "school_admission_test"
+        expect_error:
+          type: "ValidationError"
+          message_contains: "already has an Admission Test"
+        values:
+          date: "2024-07-01"
+          academic_year_id: "REC: academic_year.id"
+          academic_term_id: "REC: academic_term.id"
+          school_id: "REC: school.id"
+          grade_id: "REC: grade.id"
+          student_id: "REC: student_contact.id"
+          admission_form_id: "REC: admission_form.id"

--- a/ssi_school_admission/tests/test_school_admission.py
+++ b/ssi_school_admission/tests/test_school_admission.py
@@ -5,7 +5,7 @@
 from lxml import etree
 from odoo_yaml_test import YamlTransactionCase
 
-from odoo.tests import Form, tagged
+from odoo.tests import tagged
 
 
 @tagged("post_install", "-at_install")
@@ -18,73 +18,14 @@ class TestSchoolAdmissionWorkflow(
         """Run the admission workflow scenario."""
         self.run_yaml_scenario("test_data_admission.yaml")
 
-    def _prepare_payment_template(self):
-        """Create a payment template carrying receivable journal/account defaults."""
-        journal = self.env["account.journal"].search([("type", "=", "sale")], limit=1)
-        account_type = self.env.ref("account.data_account_type_receivable")
-        account = self.env["account.account"].create(
-            {
-                "name": "Admission Receivable Onchange",
-                "code": "ADMREC01",
-                "user_type_id": account_type.id,
-                "reconcile": True,
-            }
-        )
-        grade_type = self.env["school_grade_type"].create(
-            {"name": "Grade Type Onchange", "code": "GTONC1", "sequence": 10}
-        )
-        school = self.env["school"].create(
-            {
-                "name": "School Onchange",
-                "code": "SCHONC1",
-                "grade_type_id": grade_type.id,
-            }
-        )
-        grade = self.env["school_grade"].create(
-            {
-                "name": "Grade Onchange",
-                "code": "GONC1",
-                "sequence": 10,
-                "type_id": grade_type.id,
-            }
-        )
-        customer_invoice_type = self.env["customer_invoice_type"].create(
-            {
-                "name": "Customer Invoice Type Onchange",
-                "code": "ADMCITONC1",
-                "journal_id": journal.id,
-                "receivable_account_id": account.id,
-            }
-        )
-        template = self.env["school_admission_payment_template"].create(
-            {
-                "name": "Admission Payment Template Onchange",
-                "code": "ADMPMTONC1",
-                "school_id": school.id,
-                "grade_id": grade.id,
-                "receivable_journal_id": journal.id,
-                "receivable_account_id": account.id,
-                "customer_invoice_type_id": customer_invoice_type.id,
-            }
-        )
-        return template, journal, account
+    def test_admission_onchange_payment_template(self):
+        """Run the payment template onchange scenario.
 
-    def test_onchange_payment_template_sets_receivable(self):
-        """Selecting a payment template copies its receivable journal/account."""
-        template, journal, account = self._prepare_payment_template()
-        form = Form(self.env["school_admission"])
-        form.payment_template_id = template
-        self.assertEqual(form.receivable_journal_id, journal)
-        self.assertEqual(form.receivable_account_id, account)
-
-    def test_onchange_payment_template_clears_receivable(self):
-        """Clearing the payment template clears the receivable journal/account."""
-        template, _journal, _account = self._prepare_payment_template()
-        form = Form(self.env["school_admission"])
-        form.payment_template_id = template
-        form.payment_template_id = self.env["school_admission_payment_template"]
-        self.assertFalse(form.receivable_journal_id)
-        self.assertFalse(form.receivable_account_id)
+        Covers both directions of ``payment_template_id``: selecting a
+        template copies its receivable journal and account onto the
+        admission, and clearing the template empties them again.
+        """
+        self.run_yaml_scenario("test_data_admission_onchange.yaml")
 
     def test_payment_template_form_view_groups_accounting_fields(self):
         """Pure Python — trigger P1 (L-01/L-02): view layout (the arch

--- a/ssi_school_admission/tests/test_school_admission_test.py
+++ b/ssi_school_admission/tests/test_school_admission_test.py
@@ -4,123 +4,20 @@
 
 from odoo_yaml_test import YamlTransactionCase
 
-from odoo.exceptions import ValidationError
 from odoo.tests import tagged
 
 
 @tagged("post_install", "-at_install")
-class TestSchoolAdmissionTest(YamlTransactionCase):
+class TestSchoolAdmissionTest(
+    YamlTransactionCase
+):  # pylint: disable=too-few-public-methods
     """Cover the ``school_admission_test`` document workflow."""
 
     def test_admission_test_workflow(self):
-        """Run the admission test workflow scenario."""
+        """Run the admission test workflow scenarios.
+
+        Covers the full confirm/approve/open/done flow, creation without
+        an admission form, and the uniqueness constraint that lets one
+        admission form yield at most one admission test.
+        """
         self.run_yaml_scenario("test_data_admission_test_workflow.yaml")
-
-    def test_admission_form_uniqueness_constraint(
-        self,
-    ):  # pylint: disable=too-many-locals
-        """Test that two admission tests cannot share the same admission form."""
-        grade_type_model = self.env["school_grade_type"]
-        academic_year_model = self.env["school_academic_year"]
-        academic_term_model = self.env["school_academic_term"]
-        school_model = self.env["school"]
-        grade_model = self.env["school_grade"]
-        partner_model = self.env["res.partner"]
-        admission_form_model = self.env["school_admission_form"]
-        admission_test_model = self.env["school_admission_test"]
-
-        journal = self.env["account.journal"].search([("type", "=", "sale")], limit=1)
-        account_type = self.env.ref("account.data_account_type_revenue")
-        account = self.env["account.account"].create(
-            {
-                "name": "Admission Fee Income Uniqueness Test",
-                "code": "ADUNIQ4200",
-                "user_type_id": account_type.id,
-            }
-        )
-        pricelist = self.env["product.pricelist"].create(
-            {
-                "name": "Pricelist ADUNIQ",
-                "currency_id": self.env.company.currency_id.id,
-            }
-        )
-
-        grade_type = grade_type_model.create(
-            {"name": "Grade Type Uniqueness", "code": "GTUNIQ", "sequence": 10}
-        )
-        academic_year = academic_year_model.create(
-            {
-                "name": "2024/2025 Uniqueness",
-                "code": "AYUNIQ",
-                "date_start": "2024-07-01",
-                "date_end": "2025-06-30",
-            }
-        )
-        academic_term = academic_term_model.create(
-            {
-                "name": "Semester Uniqueness",
-                "code": "SMUNIQ",
-                "date_start": "2024-07-01",
-                "date_end": "2025-06-30",
-                "year_id": academic_year.id,
-                "enrollment_state": "open",
-            }
-        )
-        school = school_model.create(
-            {
-                "name": "School Uniqueness",
-                "code": "SCHUNIQ",
-                "grade_type_id": grade_type.id,
-            }
-        )
-        grade = grade_model.create(
-            {
-                "name": "Grade Uniqueness",
-                "code": "GUNIQ",
-                "sequence": 10,
-                "type_id": grade_type.id,
-            }
-        )
-        student_contact = partner_model.create({"name": "Student Uniqueness"})
-        parent_contact = partner_model.create({"name": "Parent Uniqueness"})
-
-        admission_form = admission_form_model.create(
-            {
-                "date": "2024-07-01",
-                "academic_year_id": academic_year.id,
-                "academic_term_id": academic_term.id,
-                "school_id": school.id,
-                "grade_id": grade.id,
-                "student_id": student_contact.id,
-                "parent_id": parent_contact.id,
-                "pricelist_id": pricelist.id,
-                "currency_id": self.env.company.currency_id.id,
-                "journal_id": journal.id,
-                "account_id": account.id,
-            }
-        )
-
-        admission_test_model.create(
-            {
-                "date": "2024-07-01",
-                "academic_year_id": academic_year.id,
-                "academic_term_id": academic_term.id,
-                "school_id": school.id,
-                "grade_id": grade.id,
-                "student_id": student_contact.id,
-                "admission_form_id": admission_form.id,
-            }
-        )
-
-        with self.assertRaises(ValidationError):
-            admission_test_model.create(
-                {
-                    "date": "2024-07-01",
-                    "academic_year_id": academic_year.id,
-                    "academic_term_id": academic_term.id,
-                    "school_id": school.id,
-                    "grade_id": grade.id,
-                    "student_id": student_contact.id,
-                    "admission_form_id": admission_form.id,
-                }
-            )


### PR DESCRIPTION
Menuntaskan temuan validator `unit-test` pada modul `ssi_school_admission` seri 14.0.

## Perubahan

* Menghapus **83 step `invalidate_cache` manual** dari 12 berkas YAML dan menggantinya
  dengan `options: {auto_refresh: true}` di kepala tiap berkas yang terdampak.
  `invalidate_cache` adalah method ORM yang dihapus di Odoo 17.0, sedangkan
  `auto_refresh` memanggil API cache yang benar per-seri sehingga YAML-nya identik
  lintas versi.
* Memindahkan test onchange `payment_template_id` dari Python murni ke skenario YAML
  `action: form` pada berkas baru `tests/test_data_admission_onchange.yaml`. Kedua arah
  tetap diuji: memilih payment template mengisi `receivable_journal_id`/
  `receivable_account_id`, dan mengosongkannya membersihkan keduanya.
* Memindahkan test constraint keunikan `admission_form_id` dari `assertRaises` Python ke
  skenario `expect_error` pada `tests/test_data_admission_test_workflow.yaml`. Constraint
  ini `@api.constrains` yang melempar `ValidationError`, jadi memang wilayah
  `expect_error` — bukan constraint tingkat database.
* `test_payment_template_form_view_groups_accounting_fields` tetap Python murni; docstring
  sudah menyebut pemicu `P1` (`L-01`, `L-02`).

Tidak ada assertion yang dihapus, dilonggarkan, digeser, atau di-skip. Jumlah perilaku
yang diuji tidak berkurang.

## Hasil validator

```
#VALIDATOR name=unit-test target=ssi_school_admission series=14.0 error=0 warn=1 defer=0 excepted=0 status=OK
```

Peringatan `!` yang tersisa (`action_open_create_due_invoice_wizard` belum diuji transisi
state-nya) bersifat warisan dan di luar lingkup issue ini.

```
#GATE repo=ssi-school-260 modules=1 failed=0 skipped=0 status=OK
```

Closes #260