### PR TITLE
[UPD] ssi_school_admission_lead: ganti invalidate_cache manual dengan auto_refresh

### DIFF
--- a/ssi_school_admission_lead/tests/test_data_admission_lead.yaml
+++ b/ssi_school_admission_lead/tests/test_data_admission_lead.yaml
@@ -1,3 +1,6 @@
+options:
+  auto_refresh: true
+
 scenarios:
   - name: "CRM Lead - Create Admission Form via Wizard"
     steps:
@@ -145,11 +148,6 @@ scenarios:
         target: "wizard"
         method: "action_confirm"
         as_user: "base.user_admin"
-
-      - step: "Invalidate lead cache"
-        action: "call"
-        target: "lead"
-        method: "invalidate_cache"
 
       - step: "Assert admission form created and linked to lead"
         action: "assert"


### PR DESCRIPTION
Menuntaskan temuan validator `unit-test` pada modul `ssi_school_admission_lead` (seri 14.0).

## Perubahan

* Hapus step manual `action: call` bermethod `invalidate_cache` di `tests/test_data_admission_lead.yaml`.
* Nyalakan `options: {auto_refresh: true}` pada berkas YAML tersebut.

Method ORM `invalidate_cache` dihapus di Odoo 17.0 (deprecated sejak 16.0), sedangkan `auto_refresh` memanggil API cache yang benar per-seri sehingga skenario YAML-nya identik lintas versi.

Dua temuan lain yang disebut issue (`setiap-class-method-test-punya-docstring` 12 butir dan `test-python-murni-menyebut-kode-pemicu-p-dan-keterbatasan-l-` 1 butir) sudah tidak muncul lagi pada HEAD `14.0` saat ini — sudah tertutup oleh pekerjaan sebelumnya. Tidak ada test, assertion, atau skenario yang dihapus, di-skip, atau dilonggarkan.

## Validator

```
#VALIDATOR name=unit-test target=.../ssi_school_admission_lead series=14.0 error=0 warn=2 defer=0 excepted=0 status=OK
```

Dua peringatan (`!`) yang tersisa — cakupan `@api.onchange` dan `action_open_admission_test` — berada di luar lingkup item ini sesuai kontrak validator §5b dan section `## Tidak termasuk` issue.

```
#GATE repo=ssi-school-264 modules=1 failed=0 skipped=0 status=OK
```

Closes #264