### PR TITLE
[UPD] ssi_school_admission_lead_operating_unit: docstring test

### DIFF
--- a/ssi_school_admission_lead_operating_unit/tests/test_crm_lead_create_admission_operating_unit.py
+++ b/ssi_school_admission_lead_operating_unit/tests/test_crm_lead_create_admission_operating_unit.py
@@ -11,7 +11,21 @@ from odoo.tests import tagged
 class TestCrmLeadCreateAdmissionOperatingUnit(
     YamlTransactionCase
 ):  # pylint: disable=too-few-public-methods
+    """Test operating unit propagation from ``crm.lead`` to admission.
+
+    Covers both admission creation wizards opened from a lead
+    (``crm.lead.create_admission_form`` and ``crm.lead.create_admission``):
+    the wizard must default ``operating_unit_id`` from the originating
+    lead, and the resulting admission document must carry that same
+    operating unit.
+    """
+
     def test_crm_lead_create_admission_operating_unit(self):
+        """Run the lead-to-admission operating unit propagation scenarios.
+
+        Asserts that the admission form and the admission created from a
+        lead inherit ``operating_unit_id`` from that lead.
+        """
         self.run_yaml_scenario(
             "test_data_crm_lead_create_admission_operating_unit.yaml"
         )


### PR DESCRIPTION
Menuntaskan temuan validator `unit-test` pada modul `ssi_school_admission_lead_operating_unit`.

## Perubahan

* Docstring class `TestCrmLeadCreateAdmissionOperatingUnit` — menjelaskan cakupan propagasi operating unit dari `crm.lead` ke dokumen admission.
* Docstring method `test_crm_lead_create_admission_operating_unit` — menjelaskan skenario YAML yang dijalankan.

Format docstring: bahasa Inggris, gaya reST, <= 79 karakter per baris. Tidak ada test, assertion, atau skenario YAML yang diubah, dihapus, atau dilonggarkan — perubahan murni penambahan docstring.

## Validator

```
#VALIDATOR name=unit-test target=ssi_school_admission_lead_operating_unit series=14.0 error=0 warn=1 defer=0 excepted=0 status=OK
```

Peringatan `!` (`setiap-action-method-diuji-transisi-state-nya`) berada di luar lingkup issue ini per kontrak validator section 5b.

Closes #266