### PR TITLE
[UPD] ssi_school_admission_operating_unit: ganti invalidate_cache manual dengan auto_refresh

### DIFF
--- a/ssi_school_admission_operating_unit/tests/test_data_school_admission_create_enrollment_operating_unit.yaml
+++ b/ssi_school_admission_operating_unit/tests/test_data_school_admission_create_enrollment_operating_unit.yaml
@@ -1,3 +1,6 @@
+options:
+  auto_refresh: true
+
 scenarios:
   - name:
       "Enrollment Wizard OU - enrollment inherits the admission's operating unit,
@@ -140,11 +143,6 @@ scenarios:
             type: "value"
             expected: "confirm"
 
-      - step: "Invalidate admission cache after confirm"
-        action: "call"
-        target: "admission"
-        method: "invalidate_cache"
-
       - step: "Approve admission (moves to open, creates the school student)"
         action: "call"
         target: "admission"
@@ -154,11 +152,6 @@ scenarios:
           state:
             type: "value"
             expected: "open"
-
-      - step: "Invalidate admission cache after approve"
-        action: "call"
-        target: "admission"
-        method: "invalidate_cache"
 
       - step: "Assert admission is ready to create its enrollment"
         action: "assert"
@@ -185,11 +178,6 @@ scenarios:
         target: "wizard"
         method: "action_create_enrollment"
         as_user: "base.user_admin"
-
-      - step: "Invalidate admission cache after wizard call"
-        action: "call"
-        target: "admission"
-        method: "invalidate_cache"
 
       - step: "Search for the created enrollment"
         action: "search"
@@ -345,11 +333,6 @@ scenarios:
             type: "value"
             expected: "confirm"
 
-      - step: "Invalidate admission cache after confirm"
-        action: "call"
-        target: "admission"
-        method: "invalidate_cache"
-
       - step: "Approve admission"
         action: "call"
         target: "admission"
@@ -359,11 +342,6 @@ scenarios:
           state:
             type: "value"
             expected: "open"
-
-      - step: "Invalidate admission cache after approve"
-        action: "call"
-        target: "admission"
-        method: "invalidate_cache"
 
       - step: "Create wizard to create the enrollment"
         action: "create"
@@ -379,11 +357,6 @@ scenarios:
         target: "wizard"
         method: "action_create_enrollment"
         as_user: "base.user_admin"
-
-      - step: "Invalidate admission cache after first wizard call"
-        action: "call"
-        target: "admission"
-        method: "invalidate_cache"
 
       - step: "Search for the created enrollment"
         action: "search"
@@ -412,11 +385,6 @@ scenarios:
         target: "wizard"
         method: "action_create_enrollment"
         as_user: "base.user_admin"
-
-      - step: "Invalidate enrollment cache after second wizard call"
-        action: "call"
-        target: "created_enrollment"
-        method: "invalidate_cache"
 
       - step:
           "Assert the manually set operating unit was not overwritten by the repeated
@@ -538,11 +506,6 @@ scenarios:
             type: "value"
             expected: "confirm"
 
-      - step: "Invalidate admission cache after confirm"
-        action: "call"
-        target: "admission"
-        method: "invalidate_cache"
-
       - step: "Approve admission"
         action: "call"
         target: "admission"
@@ -552,11 +515,6 @@ scenarios:
           state:
             type: "value"
             expected: "open"
-
-      - step: "Invalidate admission cache after approve"
-        action: "call"
-        target: "admission"
-        method: "invalidate_cache"
 
       - step: "Create wizard to create the enrollment"
         action: "create"
@@ -572,11 +530,6 @@ scenarios:
         target: "wizard"
         method: "action_create_enrollment"
         as_user: "base.user_admin"
-
-      - step: "Invalidate admission cache after wizard call"
-        action: "call"
-        target: "admission"
-        method: "invalidate_cache"
 
       - step: "Assert the admission is now linked to an enrollment"
         action: "assert"


### PR DESCRIPTION
Menuntaskan temuan validator `unit-test` pada modul `ssi_school_admission_operating_unit`.

## Perubahan

- Menghapus **10** step `action: call` bermethod `invalidate_cache` manual di
  `tests/test_data_school_admission_create_enrollment_operating_unit.yaml`.
- Menyalakan `options: {auto_refresh: true}` pada berkas YAML tersebut.

`invalidate_cache` adalah method ORM yang dihapus di Odoo 17.0 (deprecated sejak 16.0);
`auto_refresh` memanggil API cache yang benar per-seri sehingga YAML-nya identik lintas versi.

Tiap titik yang tadinya di-invalidate manual kini tercakup otomatis: `action: call` ber-`asserts`,
`action: assert`, dan `action: search` semuanya memicu refresh saat `auto_refresh` menyala.

## Yang TIDAK berubah

Tidak ada skenario, step assertion, atau `expect_count` yang dihapus, digeser, maupun dilonggarkan.
Diff-nya murni penghapusan 10 blok `invalidate_cache` + 3 baris `options`.

## Validator

```
#VALIDATOR name=unit-test target=.../ssi_school_admission_operating_unit series=14.0 error=0 warn=0 defer=0 excepted=0 status=OK
#GATE repo=ssi-school modules=1 failed=0 skipped=0 status=OK
```

Closes #268