### PR TITLE
[UPD] ssi_school_health: tuntaskan temuan validator unit-test

### DIFF
--- a/ssi_school_health/tests/test_data_school_health.yaml
+++ b/ssi_school_health/tests/test_data_school_health.yaml
@@ -1,3 +1,6 @@
+options:
+  auto_refresh: true
+
 scenarios:
   - name: "Height Created Via Student Belongs To Contact"
     steps:
@@ -121,10 +124,6 @@ scenarios:
               - 0
               - date: 2026-06-01
                 value: 150.0
-      - step: "Invalidate student cache before reading latest height"
-        action: "call"
-        target: "student"
-        method: "invalidate_cache"
       - step: "Assert latest height on student and contact"
         action: "assert"
         target: "student"
@@ -186,10 +185,6 @@ scenarios:
               - 0
               - date: 2026-06-01
                 value: 35.25
-      - step: "Invalidate student cache before reading latest weight"
-        action: "call"
-        target: "student"
-        method: "invalidate_cache"
       - step: "Assert latest weight on student and contact"
         action: "assert"
         target: "student"
@@ -251,10 +246,6 @@ scenarios:
               - 0
               - date: 2026-06-01
                 value: 50.0
-      - step: "Invalidate student cache before reading latest head circumference"
-        action: "call"
-        target: "student"
-        method: "invalidate_cache"
       - step: "Assert latest head circumference on student and contact"
         action: "assert"
         target: "student"
@@ -492,10 +483,6 @@ scenarios:
           code: "STUSHSW"
           contact_id: "REC: contact_a.id"
           school_id: "REC: school.id"
-      - step: "Invalidate student cache before reading initial height"
-        action: "call"
-        target: "student"
-        method: "invalidate_cache"
       - step: "Assert student height follows first contact"
         action: "assert"
         target: "student"
@@ -508,10 +495,6 @@ scenarios:
         target: "student"
         values:
           contact_id: "REC: contact_b.id"
-      - step: "Invalidate student cache before reading new height"
-        action: "call"
-        target: "student"
-        method: "invalidate_cache"
       - step: "Assert student height follows second contact"
         action: "assert"
         target: "student"

--- a/ssi_school_health/tests/test_school_health.py
+++ b/ssi_school_health/tests/test_school_health.py
@@ -9,5 +9,25 @@ from odoo.tests import tagged
 
 @tagged("post_install", "-at_install")
 class TestSchoolHealth(YamlTransactionCase):
+    """Test the health data a student reads from its linked contact.
+
+    Health measurements and health history are stored on the contact
+    (``res.partner``) and surfaced on ``school_student``. This class
+    covers both directions: records created through the student must
+    land on the contact, and the values reported by the student must
+    follow whichever contact it is currently linked to.
+    """
+
     def test_school_health(self):
+        """Test student health measurements, history and constraints.
+
+        Runs the YAML scenarios that create height, weight and head
+        circumference measurements through ``school_student`` and
+        assert that the most recent measurement is the one reported,
+        that allergy and disease history entries reflect on the
+        contact, that relinking the student to another contact changes
+        the reported health values, and that a zero height, a duplicate
+        allergen and a recovery date earlier than the diagnosis date
+        are all rejected.
+        """
         self.run_yaml_scenario("test_data_school_health.yaml")


### PR DESCRIPTION
Menuntaskan temuan validator `unit-test` pada modul `ssi_school_health` (seri 14.0).

## Perubahan

* **Docstring test** — `class TestSchoolHealth` dan `test_school_health()` kini
  berdocstring sesuai standar docstring modul Odoo SSI: bahasa Inggris, gaya reST,
  maksimal 79 karakter per baris, dan menyebut *apa* yang diuji (pengukuran tinggi/berat/
  lingkar kepala lewat student, riwayat alergi & penyakit yang terpantul ke kontak,
  perpindahan kontak, serta ketiga constraint negatifnya) — bukan sekadar mengulang nama
  method.
* **`invalidate_cache` manual dihapus** — lima step `action: call` bermethod
  `invalidate_cache` di `tests/test_data_school_health.yaml` diganti dengan
  `options: {auto_refresh: true}` tingkat berkas. `invalidate_cache` adalah method ORM yang
  dihapus di Odoo 17.0, sedangkan `auto_refresh` memanggil API cache yang benar per-seri
  sehingga YAML-nya identik lintas versi.

## Yang TIDAK berubah

Tidak ada skenario, step assertion, atau `expect_error` yang dihapus, dilonggarkan, atau
digeser nilai harapannya. Kesepuluh skenario tetap utuh; satu-satunya penghapusan adalah
kelima step `invalidate_cache` yang memang diperintahkan issue.

## Bukti validator (dijalankan setelah perubahan kode terakhir)

```
#VALIDATOR name=unit-test target=…/ssi_school_health series=14.0 error=0 warn=0 defer=0 excepted=0 status=OK
#GATE repo=ssi-school modules=1 failed=0 skipped=0 status=OK
```

Closes #272