### PR TITLE
[UPD] ssi_school_student_withdrawal_operating_unit - tuntaskan temuan validator unit-test

### DIFF
--- a/ssi_school_student_withdrawal_operating_unit/tests/test_school_student_withdrawal_operating_unit.py
+++ b/ssi_school_student_withdrawal_operating_unit/tests/test_school_student_withdrawal_operating_unit.py
@@ -11,7 +11,20 @@ from odoo.tests import tagged
 class TestSchoolStudentWithdrawalOperatingUnit(
     YamlTransactionCase
 ):  # pylint: disable=too-few-public-methods
+    """Test suite for the ``operating_unit_id`` field on withdrawals.
+
+    Exercises the ``school_student_withdrawal`` model added by this
+    glue module, checking that an explicitly assigned Operating Unit
+    is persisted on the created record.
+    """
+
     def test_school_student_withdrawal_operating_unit(self):
+        """Run the YAML scenario covering Operating Unit storage.
+
+        Creates a school student withdrawal with an explicit
+        ``operating_unit_id`` and asserts the value is stored as-is
+        on the record.
+        """
         self.run_yaml_scenario(
             "test_data_school_student_withdrawal_operating_unit.yaml"
         )


### PR DESCRIPTION
## Ringkasan

Menambahkan docstring pada class test dan method `test_*` di
`tests/test_school_student_withdrawal_operating_unit.py` sehingga validator
`unit-test` (`assets/validate-unit-test.sh`) berstatus `OK` untuk modul
`ssi_school_student_withdrawal_operating_unit` pada seri 14.0.

Tidak ada skenario, assertion, maupun perilaku fungsional yang diubah — hanya
docstring yang ditambahkan (bahasa Inggris, gaya reST, ≤ 79 karakter per
baris), sesuai `## Keputusan Desain` pada issue.

## Detail

- Temuan sebelumnya: `setiap-class-method-test-punya-docstring` (2 butir) —
  class `TestSchoolStudentWithdrawalOperatingUnit` dan method
  `test_school_student_withdrawal_operating_unit()`.
- Setelah perubahan: `validate-unit-test.sh` mencetak
  `error=0 warn=0 defer=0 excepted=0 status=OK`.

Closes #298