### PR TITLE
[UPD] ssi_school_student_withdrawal: tuntaskan temuan validator unit-test

### DIFF
--- a/ssi_school_student_withdrawal/tests/test_data_school_student_withdrawal.yaml
+++ b/ssi_school_student_withdrawal/tests/test_data_school_student_withdrawal.yaml
@@ -1,3 +1,6 @@
+options:
+  auto_refresh: true
+
 scenarios:
   - name: "Student Withdrawal - Resignation Full Workflow"
     steps:
@@ -103,11 +106,6 @@ scenarios:
             type: "value"
             expected: "confirm"
 
-      - step: "Invalidate enrollment cache before approve"
-        action: "call"
-        target: "enrollment"
-        method: "invalidate_cache"
-
       - step: "Approve enrollment"
         action: "call"
         target: "enrollment"
@@ -150,11 +148,6 @@ scenarios:
             type: "value"
             expected: "confirm"
 
-      - step: "Invalidate withdrawal cache before approve"
-        action: "call"
-        target: "withdrawal"
-        method: "invalidate_cache"
-
       - step: "Approve withdrawal"
         action: "call"
         target: "withdrawal"
@@ -164,11 +157,6 @@ scenarios:
           state:
             type: "value"
             expected: "done"
-
-      - step: "Invalidate withdrawal cache after approve"
-        action: "call"
-        target: "withdrawal"
-        method: "invalidate_cache"
 
       - step: "Assert withdrawal number generated on done"
         action: "assert"
@@ -292,11 +280,6 @@ scenarios:
             type: "value"
             expected: "confirm"
 
-      - step: "Invalidate enrollment cache before approve"
-        action: "call"
-        target: "enrollment"
-        method: "invalidate_cache"
-
       - step: "Approve enrollment"
         action: "call"
         target: "enrollment"
@@ -335,11 +318,6 @@ scenarios:
           state:
             type: "value"
             expected: "confirm"
-
-      - step: "Invalidate withdrawal cache before approve"
-        action: "call"
-        target: "withdrawal"
-        method: "invalidate_cache"
 
       - step: "Approve withdrawal"
         action: "call"
@@ -473,11 +451,6 @@ scenarios:
             type: "value"
             expected: "confirm"
 
-      - step: "Invalidate enrollment cache before approve"
-        action: "call"
-        target: "enrollment"
-        method: "invalidate_cache"
-
       - step: "Approve enrollment"
         action: "call"
         target: "enrollment"
@@ -509,11 +482,6 @@ scenarios:
             type: "value"
             expected: "confirm"
 
-      - step: "Invalidate withdrawal cache before approve"
-        action: "call"
-        target: "withdrawal"
-        method: "invalidate_cache"
-
       - step: "Approve withdrawal"
         action: "call"
         target: "withdrawal"
@@ -532,3 +500,295 @@ scenarios:
           - ["state", "=", "dropped"]
         save_as: "check_student_dropped"
         expect_count: 1
+
+  - name: "Student Withdrawal - Confirm Blocked When Student Not Enrolled"
+    steps:
+      - step: "Setup - create grade type"
+        action: "create"
+        model: "school_grade_type"
+        save_as: "grade_type"
+        values:
+          name: "Grade Type for Withdrawal Test 4"
+          code: "GTSW4"
+          sequence: 10
+
+      - step: "Setup - create school"
+        action: "create"
+        model: "school"
+        save_as: "school"
+        values:
+          name: "School for Withdrawal Test 4"
+          code: "SCHSW4"
+          grade_type_id: "EVAL: registry['grade_type'].id"
+
+      - step: "Setup - create grade"
+        action: "create"
+        model: "school_grade"
+        save_as: "grade"
+        values:
+          name: "Grade for Withdrawal Test 4"
+          code: "GSW4"
+          sequence: 10
+          type_id: "EVAL: registry['grade_type'].id"
+
+      - step: "Setup - create grade class"
+        action: "create"
+        model: "school_grade_class"
+        save_as: "grade_class"
+        values:
+          name: "Class Withdrawal Test 4"
+          code: "CLSW4"
+          school_id: "EVAL: registry['school'].id"
+          grade_id: "EVAL: registry['grade'].id"
+          capacity: 30
+
+      - step: "Setup - create academic year"
+        action: "create"
+        model: "school_academic_year"
+        save_as: "academic_year"
+        values:
+          name: "Year Withdrawal Test 4"
+          code: "AYSW4"
+          date_start: "2024-07-01"
+          date_end: "2025-06-30"
+
+      - step: "Setup - create academic term"
+        action: "create"
+        model: "school_academic_term"
+        save_as: "academic_term"
+        values:
+          name: "Term Withdrawal Test 4"
+          code: "TMSW4"
+          date_start: "2024-07-01"
+          date_end: "2024-12-31"
+          year_id: "EVAL: registry['academic_year'].id"
+          enrollment_state: "open"
+
+      - step: "Setup - create student contact"
+        action: "create"
+        model: "res.partner"
+        save_as: "contact"
+        values:
+          name: "Student Contact Withdrawal Test 4"
+
+      - step: "Setup - create student"
+        action: "create"
+        model: "school_student"
+        save_as: "student"
+        values:
+          name: "Student Withdrawal Test 4"
+          code: "STUSW4"
+          contact_id: "EVAL: registry['contact'].id"
+          school_id: "EVAL: registry['school'].id"
+
+      - step: "Setup - create enrollment"
+        action: "create"
+        model: "school_enrollment"
+        save_as: "enrollment"
+        values:
+          date: "2024-07-01"
+          academic_year_id: "EVAL: registry['academic_year'].id"
+          academic_term_id: "EVAL: registry['academic_term'].id"
+          school_id: "EVAL: registry['school'].id"
+          grade_id: "EVAL: registry['grade'].id"
+          grade_class_id: "EVAL: registry['grade_class'].id"
+          student_id: "EVAL: registry['student'].id"
+          currency_id: "EVAL: env.company.currency_id.id"
+
+      - step: "Confirm enrollment"
+        action: "call"
+        target: "enrollment"
+        method: "action_confirm"
+        as_user: "base.user_admin"
+        asserts:
+          state:
+            type: "value"
+            expected: "confirm"
+
+      - step: "Approve enrollment"
+        action: "call"
+        target: "enrollment"
+        method: "action_approve_approval"
+        as_user: "base.user_admin"
+        asserts:
+          state:
+            type: "value"
+            expected: "open"
+
+      - step: "Graduate the student"
+        action: "call"
+        target: "student"
+        method: "action_set_to_graduate"
+        as_user: "base.user_admin"
+        asserts:
+          state:
+            type: "value"
+            expected: "graduate"
+
+      - step: "Create withdrawal draft for graduated student"
+        action: "create"
+        model: "school_student_withdrawal"
+        save_as: "withdrawal"
+        values:
+          date: "2024-08-01"
+          student_id: "EVAL: registry['student'].id"
+          reason_type: "dropout"
+
+      - step: "Assert withdrawal created in draft"
+        action: "assert"
+        target: "withdrawal"
+        asserts:
+          state:
+            type: "value"
+            expected: "draft"
+
+      - step: "Confirming the withdrawal must be rejected"
+        action: "write"
+        target: "withdrawal"
+        expect_error:
+          type: "ValidationError"
+          message_contains: "not in Enrolled, On Leave, or Suspended"
+        values:
+          state: "confirm"
+
+  - name: "Student Withdrawal - Only One Active Withdrawal Per Student"
+    steps:
+      - step: "Setup - create grade type"
+        action: "create"
+        model: "school_grade_type"
+        save_as: "grade_type"
+        values:
+          name: "Grade Type for Withdrawal Test 5"
+          code: "GTSW5"
+          sequence: 10
+
+      - step: "Setup - create school"
+        action: "create"
+        model: "school"
+        save_as: "school"
+        values:
+          name: "School for Withdrawal Test 5"
+          code: "SCHSW5"
+          grade_type_id: "EVAL: registry['grade_type'].id"
+
+      - step: "Setup - create grade"
+        action: "create"
+        model: "school_grade"
+        save_as: "grade"
+        values:
+          name: "Grade for Withdrawal Test 5"
+          code: "GSW5"
+          sequence: 10
+          type_id: "EVAL: registry['grade_type'].id"
+
+      - step: "Setup - create grade class"
+        action: "create"
+        model: "school_grade_class"
+        save_as: "grade_class"
+        values:
+          name: "Class Withdrawal Test 5"
+          code: "CLSW5"
+          school_id: "EVAL: registry['school'].id"
+          grade_id: "EVAL: registry['grade'].id"
+          capacity: 30
+
+      - step: "Setup - create academic year"
+        action: "create"
+        model: "school_academic_year"
+        save_as: "academic_year"
+        values:
+          name: "Year Withdrawal Test 5"
+          code: "AYSW5"
+          date_start: "2024-07-01"
+          date_end: "2025-06-30"
+
+      - step: "Setup - create academic term"
+        action: "create"
+        model: "school_academic_term"
+        save_as: "academic_term"
+        values:
+          name: "Term Withdrawal Test 5"
+          code: "TMSW5"
+          date_start: "2024-07-01"
+          date_end: "2024-12-31"
+          year_id: "EVAL: registry['academic_year'].id"
+          enrollment_state: "open"
+
+      - step: "Setup - create student contact"
+        action: "create"
+        model: "res.partner"
+        save_as: "contact"
+        values:
+          name: "Student Contact Withdrawal Test 5"
+
+      - step: "Setup - create student"
+        action: "create"
+        model: "school_student"
+        save_as: "student"
+        values:
+          name: "Student Withdrawal Test 5"
+          code: "STUSW5"
+          contact_id: "EVAL: registry['contact'].id"
+          school_id: "EVAL: registry['school'].id"
+
+      - step: "Setup - create enrollment"
+        action: "create"
+        model: "school_enrollment"
+        save_as: "enrollment"
+        values:
+          date: "2024-07-01"
+          academic_year_id: "EVAL: registry['academic_year'].id"
+          academic_term_id: "EVAL: registry['academic_term'].id"
+          school_id: "EVAL: registry['school'].id"
+          grade_id: "EVAL: registry['grade'].id"
+          grade_class_id: "EVAL: registry['grade_class'].id"
+          student_id: "EVAL: registry['student'].id"
+          currency_id: "EVAL: env.company.currency_id.id"
+
+      - step: "Confirm enrollment"
+        action: "call"
+        target: "enrollment"
+        method: "action_confirm"
+        as_user: "base.user_admin"
+        asserts:
+          state:
+            type: "value"
+            expected: "confirm"
+
+      - step: "Approve enrollment"
+        action: "call"
+        target: "enrollment"
+        method: "action_approve_approval"
+        as_user: "base.user_admin"
+        asserts:
+          state:
+            type: "value"
+            expected: "open"
+
+      - step: "Create first withdrawal draft"
+        action: "create"
+        model: "school_student_withdrawal"
+        save_as: "withdrawal"
+        values:
+          date: "2024-08-01"
+          student_id: "EVAL: registry['student'].id"
+          reason_type: "dropout"
+
+      - step: "Assert first withdrawal created in draft"
+        action: "assert"
+        target: "withdrawal"
+        asserts:
+          state:
+            type: "value"
+            expected: "draft"
+
+      - step: "Creating a second withdrawal for the same student must be rejected"
+        action: "create"
+        model: "school_student_withdrawal"
+        expect_error:
+          type: "ValidationError"
+          message_contains: "is already draft or"
+        values:
+          date: "2024-08-01"
+          student_id: "EVAL: registry['student'].id"
+          reason_type: "resignation"

--- a/ssi_school_student_withdrawal/tests/test_school_student_withdrawal.py
+++ b/ssi_school_student_withdrawal/tests/test_school_student_withdrawal.py
@@ -4,143 +4,15 @@
 
 from odoo_yaml_test import YamlTransactionCase
 
-from odoo.exceptions import ValidationError
 from odoo.tests import tagged
 
 
 @tagged("post_install", "-at_install")
 class TestSchoolStudentWithdrawal(YamlTransactionCase):
+    """Cover the ``school_student_withdrawal`` full workflow, the
+    student-state and single-active-withdrawal constraints, through
+    the YAML scenario file."""
+
     def test_school_student_withdrawal(self):
+        """Run every scenario in test_data_school_student_withdrawal.yaml."""
         self.run_yaml_scenario("test_data_school_student_withdrawal.yaml")
-
-    def _setup_open_enrollment(self, suffix):
-        """Create grade type/school/grade/grade class/year/term/student
-        and an enrollment already brought to open state, ready to be
-        used as the base fixture for a withdrawal test."""
-        grade_type = self.env["school_grade_type"].create(
-            {
-                "name": "Grade Type Withdrawal %s" % suffix,
-                "code": "GTSW%s" % suffix,
-                "sequence": 10,
-            }
-        )
-        school = self.env["school"].create(
-            {
-                "name": "School Withdrawal %s" % suffix,
-                "code": "SCHSW%s" % suffix,
-                "grade_type_id": grade_type.id,
-            }
-        )
-        grade = self.env["school_grade"].create(
-            {
-                "name": "Grade Withdrawal %s" % suffix,
-                "code": "GSW%s" % suffix,
-                "sequence": 10,
-                "type_id": grade_type.id,
-            }
-        )
-        grade_class = self.env["school_grade_class"].create(
-            {
-                "name": "Class Withdrawal %s" % suffix,
-                "code": "CLSW%s" % suffix,
-                "school_id": school.id,
-                "grade_id": grade.id,
-                "capacity": 30,
-            }
-        )
-        year = self.env["school_academic_year"].create(
-            {
-                "name": "Year Withdrawal %s" % suffix,
-                "code": "AYSW%s" % suffix,
-                "date_start": "2024-07-01",
-                "date_end": "2025-06-30",
-            }
-        )
-        term = self.env["school_academic_term"].create(
-            {
-                "name": "Term Withdrawal %s" % suffix,
-                "code": "TMSW%s" % suffix,
-                "date_start": "2024-07-01",
-                "date_end": "2024-12-31",
-                "year_id": year.id,
-                "enrollment_state": "open",
-            }
-        )
-        contact = self.env["res.partner"].create(
-            {"name": "Contact Withdrawal %s" % suffix}
-        )
-        student = self.env["school_student"].create(
-            {
-                "name": "Student Withdrawal %s" % suffix,
-                "code": "STUSW%s" % suffix,
-                "contact_id": contact.id,
-                "school_id": school.id,
-            }
-        )
-        enrollment = self.env["school_enrollment"].create(
-            {
-                "date": "2024-07-01",
-                "academic_year_id": year.id,
-                "academic_term_id": term.id,
-                "school_id": school.id,
-                "grade_id": grade.id,
-                "grade_class_id": grade_class.id,
-                "student_id": student.id,
-                "currency_id": self.env.company.currency_id.id,
-            }
-        )
-        admin = self.env.ref("base.user_admin")
-        enrollment.with_user(admin).action_confirm()
-        enrollment.invalidate_cache()
-        enrollment.with_user(admin).action_approve_approval()
-        self.assertEqual(enrollment.state, "open")
-        return {
-            "grade_type": grade_type,
-            "school": school,
-            "grade": grade,
-            "grade_class": grade_class,
-            "year": year,
-            "term": term,
-            "student": student,
-            "enrollment": enrollment,
-        }
-
-    def test_constrain_student_not_enrolled_blocks_confirm(self):
-        """Confirming a withdrawal for a student who is not in
-        Enrolled/On Leave/Suspended state (e.g. already Graduate) must
-        be rejected."""
-        data = self._setup_open_enrollment("G1")
-        data["student"].action_set_to_graduate()
-        self.assertEqual(data["student"].state, "graduate")
-
-        withdrawal = self.env["school_student_withdrawal"].create(
-            {
-                "date": "2024-08-01",
-                "student_id": data["student"].id,
-                "reason_type": "dropout",
-            }
-        )
-        with self.assertRaises(ValidationError):
-            withdrawal.write({"state": "confirm"})
-
-    def test_constrain_single_active_withdrawal_for_same_student(self):
-        """Only one draft/confirm withdrawal is allowed per student at
-        a time; creating a second draft for the same student (which
-        re-triggers the constraint, the same way a later confirm
-        would) must be rejected."""
-        data = self._setup_open_enrollment("M1")
-        self.env["school_student_withdrawal"].create(
-            {
-                "date": "2024-08-01",
-                "student_id": data["student"].id,
-                "reason_type": "dropout",
-            }
-        )
-        with self.assertRaises(ValidationError):
-            self.env["school_student_withdrawal"].create(
-                {
-                    "date": "2024-08-01",
-                    "student_id": data["student"].id,
-                    "reason_type": "resignation",
-                }
-            )


### PR DESCRIPTION
## Ringkasan

Menuntaskan seluruh temuan validator `unit-test` (`assets/validate-unit-test.sh`) pada
modul `ssi_school_student_withdrawal`, sesuai backlog #296.

- Tambah docstring pada class test & method `test_school_student_withdrawal()` di
  `tests/test_school_student_withdrawal.py`.
- Pindahkan `test_constrain_student_not_enrolled_blocks_confirm()` dan
  `test_constrain_single_active_withdrawal_for_same_student()` dari Python murni ke
  2 skenario YAML baru (`expect_error: ValidationError`) — keduanya menguji
  `@api.constrains` biasa (bukan constraint tingkat database `_sql_constraints`),
  jadi tidak memenuhi pemicu `P1`-`P12` untuk tetap Python. Berkas `.py` sekarang
  hanya memanggil `run_yaml_scenario`.
- Hapus 6 step manual `invalidate_cache` di
  `tests/test_data_school_student_withdrawal.yaml`, diganti
  `options: {auto_refresh: true}` pada level berkas (`invalidate_cache` adalah
  method ORM yang dihapus di Odoo 17.0).

Tidak ada perubahan perilaku fungsional/produksi — hanya `tests/`. Seluruh skenario
lama tetap lulus setelah dipindahkan/di-refresh, dan cakupan `expect_error` untuk
kedua `@api.constrains` kini terisi (menghilangkan peringatan terkait juga).

## Verifikasi

```
#VALIDATOR name=unit-test target=.../ssi_school_student_withdrawal series=14.0 error=0 warn=0 defer=0 excepted=0 status=OK
#GATE repo=ssi-school modules=1 failed=0 skipped=0 status=OK
```

Closes #296