### PR TITLE
[UPD] ssi_school_student_leave_operating_unit: tuntaskan temuan validator unit-test

### DIFF
--- a/ssi_school_student_leave_operating_unit/tests/test_school_student_leave_operating_unit.py
+++ b/ssi_school_student_leave_operating_unit/tests/test_school_student_leave_operating_unit.py
@@ -11,5 +11,17 @@ from odoo.tests import tagged
 class TestSchoolStudentLeaveOperatingUnit(
     YamlTransactionCase
 ):  # pylint: disable=too-few-public-methods
+    """Test the ``operating_unit_id`` field on ``school_student_leave``.
+
+    Covers the field added by this glue module and confirms it is
+    stored as given when a student leave is created.
+    """
+
     def test_school_student_leave_operating_unit(self):
+        """Confirm ``operating_unit_id`` persists on student leave.
+
+        Runs the scenario that creates a student leave with an
+        explicit operating unit, then searches for the record by
+        that same ``operating_unit_id`` to confirm it was stored.
+        """
         self.run_yaml_scenario("test_data_school_student_leave_operating_unit.yaml")


### PR DESCRIPTION
## Ringkasan

Menuntaskan temuan validator `unit-test` (`setiap-class-method-test-punya-docstring`, 2 butir) pada modul `ssi_school_student_leave_operating_unit`, sesuai sapuan `audit-sweep.sh 14.0` (12 Agustus 2026, sidik jari `cd59d55f834343cb`).

* Tambahkan docstring pada class test `TestSchoolStudentLeaveOperatingUnit` dan method `test_school_student_leave_operating_unit()` di `tests/test_school_student_leave_operating_unit.py`, gaya reST bahasa Inggris ≤ 79 karakter.
* Tidak ada perubahan perilaku fungsional — skenario YAML existing tidak disentuh.

## Verifikasi

```
#VALIDATOR name=unit-test target=/home/andhit-r/odoo-code/ssi-school/ssi_school_student_leave_operating_unit series=14.0 error=0 warn=0 defer=0 excepted=0 status=OK
#GATE repo=ssi-school modules=1 failed=0 skipped=0 status=OK
```

Closes #293