### PR TITLE
[UPD] ssi_school_student_leave: tuntaskan temuan validator unit-test

### DIFF
--- a/ssi_school_student_leave/tests/test_data_school_student_leave.yaml
+++ b/ssi_school_student_leave/tests/test_data_school_student_leave.yaml
@@ -271,6 +271,12 @@ scenarios:
           academic_term_id: "EVAL: registry['academic_term'].id"
           expected_return_date: "2024-09-01"
           reason: "Medical leave."
+          # Required because later steps read this document back as
+          # base.user_admin: school_student_leave_internal_user_rule
+          # only exposes records the reading user owns, and the
+          # default responsible would otherwise be the superuser
+          # that created it.
+          user_id: "REF: base.user_admin"
 
       - step: "Confirm leave"
         action: "call"
@@ -437,6 +443,12 @@ scenarios:
           academic_term_id: "EVAL: registry['academic_term'].id"
           expected_return_date: "2024-09-01"
           reason: "Personal leave."
+          # Required because later steps read this document back as
+          # base.user_admin: school_student_leave_internal_user_rule
+          # only exposes records the reading user owns, and the
+          # default responsible would otherwise be the superuser
+          # that created it.
+          user_id: "REF: base.user_admin"
 
       - step: "Confirm leave"
         action: "call"

--- a/ssi_school_student_leave/tests/test_data_school_student_leave.yaml
+++ b/ssi_school_student_leave/tests/test_data_school_student_leave.yaml
@@ -1,3 +1,6 @@
+options:
+  auto_refresh: true
+
 scenarios:
   - name: "Create Student Leave Draft"
     steps:
@@ -102,11 +105,6 @@ scenarios:
           state:
             type: "value"
             expected: "confirm"
-
-      - step: "Invalidate enrollment cache before approve"
-        action: "call"
-        target: "enrollment"
-        method: "invalidate_cache"
 
       - step: "Approve enrollment"
         action: "call"
@@ -249,11 +247,6 @@ scenarios:
         method: "action_confirm"
         as_user: "base.user_admin"
 
-      - step: "Invalidate enrollment cache before approve"
-        action: "call"
-        target: "enrollment"
-        method: "invalidate_cache"
-
       - step: "Approve enrollment"
         action: "call"
         target: "enrollment"
@@ -285,11 +278,6 @@ scenarios:
             type: "value"
             expected: "confirm"
 
-      - step: "Invalidate leave cache before approve"
-        action: "call"
-        target: "leave"
-        method: "invalidate_cache"
-
       - step: "Approve leave (auto-completes to done)"
         action: "call"
         target: "leave"
@@ -299,11 +287,6 @@ scenarios:
           state:
             type: "value"
             expected: "done"
-
-      - step: "Invalidate leave cache after approve"
-        action: "call"
-        target: "leave"
-        method: "invalidate_cache"
 
       - step: "Assert leave number generated on done"
         action: "assert"
@@ -426,11 +409,6 @@ scenarios:
         method: "action_confirm"
         as_user: "base.user_admin"
 
-      - step: "Invalidate enrollment cache before approve"
-        action: "call"
-        target: "enrollment"
-        method: "invalidate_cache"
-
       - step: "Approve enrollment"
         action: "call"
         target: "enrollment"
@@ -457,11 +435,6 @@ scenarios:
         target: "leave"
         method: "action_confirm"
         as_user: "base.user_admin"
-
-      - step: "Invalidate leave cache before approve"
-        action: "call"
-        target: "leave"
-        method: "invalidate_cache"
 
       - step: "Approve leave (auto-completes to done)"
         action: "call"
@@ -504,3 +477,296 @@ scenarios:
           state:
             type: "value"
             expected: "done"
+
+  - name: "Confirm Leave With Non Enrolled Student Is Rejected"
+    steps:
+      - step: "Setup - create grade type"
+        action: "create"
+        model: "school_grade_type"
+        save_as: "grade_type"
+        values:
+          name: "Grade Type for Leave Test 4"
+          code: "GTSLY4"
+          sequence: 10
+
+      - step: "Setup - create school"
+        action: "create"
+        model: "school"
+        save_as: "school"
+        values:
+          name: "School for Leave Test 4"
+          code: "SCHSLY4"
+          grade_type_id: "EVAL: registry['grade_type'].id"
+
+      - step: "Setup - create grade"
+        action: "create"
+        model: "school_grade"
+        save_as: "grade"
+        values:
+          name: "Grade for Leave Test 4"
+          code: "GSLY4"
+          sequence: 10
+          type_id: "EVAL: registry['grade_type'].id"
+
+      - step: "Setup - create grade class"
+        action: "create"
+        model: "school_grade_class"
+        save_as: "grade_class"
+        values:
+          name: "Class Leave Test 4"
+          code: "CLSLY4"
+          school_id: "EVAL: registry['school'].id"
+          grade_id: "EVAL: registry['grade'].id"
+          capacity: 30
+
+      - step: "Setup - create academic year"
+        action: "create"
+        model: "school_academic_year"
+        save_as: "academic_year"
+        values:
+          name: "Year Leave Test 4"
+          code: "AYSLY4"
+          date_start: "2024-07-01"
+          date_end: "2025-06-30"
+
+      - step: "Setup - create academic term"
+        action: "create"
+        model: "school_academic_term"
+        save_as: "academic_term"
+        values:
+          name: "Term Leave Test 4"
+          code: "TMSLY4"
+          date_start: "2024-07-01"
+          date_end: "2024-12-31"
+          year_id: "EVAL: registry['academic_year'].id"
+          enrollment_state: "open"
+
+      - step: "Setup - create student contact"
+        action: "create"
+        model: "res.partner"
+        save_as: "contact"
+        values:
+          name: "Student Contact Leave Test 4"
+
+      - step: "Setup - create student"
+        action: "create"
+        model: "school_student"
+        save_as: "student"
+        values:
+          name: "Student Leave Test 4"
+          code: "STUSLY4"
+          contact_id: "EVAL: registry['contact'].id"
+          school_id: "EVAL: registry['school'].id"
+
+      - step: "Setup - create enrollment"
+        action: "create"
+        model: "school_enrollment"
+        save_as: "enrollment"
+        values:
+          date: "2024-07-01"
+          academic_year_id: "EVAL: registry['academic_year'].id"
+          academic_term_id: "EVAL: registry['academic_term'].id"
+          school_id: "EVAL: registry['school'].id"
+          grade_id: "EVAL: registry['grade'].id"
+          grade_class_id: "EVAL: registry['grade_class'].id"
+          student_id: "EVAL: registry['student'].id"
+          currency_id: "EVAL: env.company.currency_id.id"
+
+      - step: "Confirm enrollment"
+        action: "call"
+        target: "enrollment"
+        method: "action_confirm"
+        as_user: "base.user_admin"
+
+      - step: "Approve enrollment"
+        action: "call"
+        target: "enrollment"
+        method: "action_approve_approval"
+        as_user: "base.user_admin"
+        asserts:
+          state:
+            type: "value"
+            expected: "open"
+
+      - step: "Graduate the student so it leaves the enrol state"
+        action: "call"
+        target: "student"
+        method: "action_set_to_graduate"
+
+      - step: "Assert student is graduated"
+        action: "assert"
+        target: "student"
+        asserts:
+          state:
+            type: "value"
+            expected: "graduate"
+
+      - step: "Create student leave draft for the graduated student"
+        action: "create"
+        model: "school_student_leave"
+        save_as: "leave"
+        values:
+          date: "2024-08-01"
+          student_id: "EVAL: registry['student'].id"
+          academic_term_id: "EVAL: registry['academic_term'].id"
+          expected_return_date: "2024-09-01"
+          reason: "Leave requested after graduation."
+
+      - step: "Confirming the leave must be rejected"
+        action: "write"
+        target: "leave"
+        expect_error:
+          type: "ValidationError"
+          message_contains: "is not in enrol state"
+        values:
+          state: "confirm"
+
+      - step: "Assert leave stays in draft after the rejection"
+        action: "assert"
+        target: "leave"
+        asserts:
+          state:
+            type: "value"
+            expected: "draft"
+
+  - name: "Second Active Leave For Same Student Is Rejected"
+    steps:
+      - step: "Setup - create grade type"
+        action: "create"
+        model: "school_grade_type"
+        save_as: "grade_type"
+        values:
+          name: "Grade Type for Leave Test 5"
+          code: "GTSLY5"
+          sequence: 10
+
+      - step: "Setup - create school"
+        action: "create"
+        model: "school"
+        save_as: "school"
+        values:
+          name: "School for Leave Test 5"
+          code: "SCHSLY5"
+          grade_type_id: "EVAL: registry['grade_type'].id"
+
+      - step: "Setup - create grade"
+        action: "create"
+        model: "school_grade"
+        save_as: "grade"
+        values:
+          name: "Grade for Leave Test 5"
+          code: "GSLY5"
+          sequence: 10
+          type_id: "EVAL: registry['grade_type'].id"
+
+      - step: "Setup - create grade class"
+        action: "create"
+        model: "school_grade_class"
+        save_as: "grade_class"
+        values:
+          name: "Class Leave Test 5"
+          code: "CLSLY5"
+          school_id: "EVAL: registry['school'].id"
+          grade_id: "EVAL: registry['grade'].id"
+          capacity: 30
+
+      - step: "Setup - create academic year"
+        action: "create"
+        model: "school_academic_year"
+        save_as: "academic_year"
+        values:
+          name: "Year Leave Test 5"
+          code: "AYSLY5"
+          date_start: "2024-07-01"
+          date_end: "2025-06-30"
+
+      - step: "Setup - create academic term"
+        action: "create"
+        model: "school_academic_term"
+        save_as: "academic_term"
+        values:
+          name: "Term Leave Test 5"
+          code: "TMSLY5"
+          date_start: "2024-07-01"
+          date_end: "2024-12-31"
+          year_id: "EVAL: registry['academic_year'].id"
+          enrollment_state: "open"
+
+      - step: "Setup - create student contact"
+        action: "create"
+        model: "res.partner"
+        save_as: "contact"
+        values:
+          name: "Student Contact Leave Test 5"
+
+      - step: "Setup - create student"
+        action: "create"
+        model: "school_student"
+        save_as: "student"
+        values:
+          name: "Student Leave Test 5"
+          code: "STUSLY5"
+          contact_id: "EVAL: registry['contact'].id"
+          school_id: "EVAL: registry['school'].id"
+
+      - step: "Setup - create enrollment"
+        action: "create"
+        model: "school_enrollment"
+        save_as: "enrollment"
+        values:
+          date: "2024-07-01"
+          academic_year_id: "EVAL: registry['academic_year'].id"
+          academic_term_id: "EVAL: registry['academic_term'].id"
+          school_id: "EVAL: registry['school'].id"
+          grade_id: "EVAL: registry['grade'].id"
+          grade_class_id: "EVAL: registry['grade_class'].id"
+          student_id: "EVAL: registry['student'].id"
+          currency_id: "EVAL: env.company.currency_id.id"
+
+      - step: "Confirm enrollment"
+        action: "call"
+        target: "enrollment"
+        method: "action_confirm"
+        as_user: "base.user_admin"
+
+      - step: "Approve enrollment"
+        action: "call"
+        target: "enrollment"
+        method: "action_approve_approval"
+        as_user: "base.user_admin"
+        asserts:
+          state:
+            type: "value"
+            expected: "open"
+
+      - step: "Create the first student leave draft"
+        action: "create"
+        model: "school_student_leave"
+        save_as: "first_leave"
+        values:
+          date: "2024-08-01"
+          student_id: "EVAL: registry['student'].id"
+          academic_term_id: "EVAL: registry['academic_term'].id"
+          expected_return_date: "2024-09-01"
+          reason: "First leave request."
+
+      - step: "Creating a second active leave must be rejected"
+        action: "create"
+        model: "school_student_leave"
+        expect_error:
+          type: "ValidationError"
+          message_contains: "is already draft or waiting"
+        values:
+          date: "2024-08-01"
+          student_id: "EVAL: registry['student'].id"
+          academic_term_id: "EVAL: registry['academic_term'].id"
+          expected_return_date: "2024-09-01"
+          reason: "Second leave request."
+
+      - step: "Assert only one leave exists for this student"
+        action: "search"
+        model: "school_student_leave"
+        domain:
+          - ["student_id", "=", "EVAL: registry['student'].id"]
+        save_as: "leaves_of_student"
+        expect_count: 1

--- a/ssi_school_student_leave/tests/test_data_school_student_leave.yaml
+++ b/ssi_school_student_leave/tests/test_data_school_student_leave.yaml
@@ -246,6 +246,10 @@ scenarios:
         target: "enrollment"
         method: "action_confirm"
         as_user: "base.user_admin"
+        asserts:
+          state:
+            type: "value"
+            expected: "confirm"
 
       - step: "Approve enrollment"
         action: "call"
@@ -408,6 +412,10 @@ scenarios:
         target: "enrollment"
         method: "action_confirm"
         as_user: "base.user_admin"
+        asserts:
+          state:
+            type: "value"
+            expected: "confirm"
 
       - step: "Approve enrollment"
         action: "call"
@@ -435,6 +443,10 @@ scenarios:
         target: "leave"
         method: "action_confirm"
         as_user: "base.user_admin"
+        asserts:
+          state:
+            type: "value"
+            expected: "confirm"
 
       - step: "Approve leave (auto-completes to done)"
         action: "call"
@@ -577,6 +589,10 @@ scenarios:
         target: "enrollment"
         method: "action_confirm"
         as_user: "base.user_admin"
+        asserts:
+          state:
+            type: "value"
+            expected: "confirm"
 
       - step: "Approve enrollment"
         action: "call"
@@ -728,6 +744,10 @@ scenarios:
         target: "enrollment"
         method: "action_confirm"
         as_user: "base.user_admin"
+        asserts:
+          state:
+            type: "value"
+            expected: "confirm"
 
       - step: "Approve enrollment"
         action: "call"

--- a/ssi_school_student_leave/tests/test_school_student_leave.py
+++ b/ssi_school_student_leave/tests/test_school_student_leave.py
@@ -4,138 +4,24 @@
 
 from odoo_yaml_test import YamlTransactionCase
 
-from odoo.exceptions import ValidationError
 from odoo.tests import tagged
 
 
 @tagged("post_install", "-at_install")
 class TestSchoolStudentLeave(YamlTransactionCase):
+    """Test the Student Leave of Absence document.
+
+    Runs the YAML scenarios covering the full leave life cycle: the
+    draft document created for an enrolled student, the confirm and
+    approve workflow that auto-completes the leave to done and moves
+    the student to the on_leave state, the return that re-enrolls the
+    student, and the two constraints that reject a leave for a student
+    who is not enrolled and a second active leave for the same student.
+    """
+
     def test_school_student_leave(self):
+        """Run every Student Leave scenario defined in the YAML file.
+
+        :return: None
+        """
         self.run_yaml_scenario("test_data_school_student_leave.yaml")
-
-    def _setup_open_enrollment(self, suffix):
-        """Create grade type/school/grade/grade class/year/term/student
-        and an enrollment already brought to open state, ready to be
-        used as the base fixture for a student leave test."""
-        grade_type = self.env["school_grade_type"].create(
-            {
-                "name": "Grade Type Leave %s" % suffix,
-                "code": "GTSL%s" % suffix,
-                "sequence": 10,
-            }
-        )
-        school = self.env["school"].create(
-            {
-                "name": "School Leave %s" % suffix,
-                "code": "SCHSL%s" % suffix,
-                "grade_type_id": grade_type.id,
-            }
-        )
-        grade = self.env["school_grade"].create(
-            {
-                "name": "Grade Leave %s" % suffix,
-                "code": "GSL%s" % suffix,
-                "sequence": 10,
-                "type_id": grade_type.id,
-            }
-        )
-        grade_class = self.env["school_grade_class"].create(
-            {
-                "name": "Class Leave %s" % suffix,
-                "code": "CLSL%s" % suffix,
-                "school_id": school.id,
-                "grade_id": grade.id,
-                "capacity": 30,
-            }
-        )
-        year = self.env["school_academic_year"].create(
-            {
-                "name": "Year Leave %s" % suffix,
-                "code": "AYSL%s" % suffix,
-                "date_start": "2024-07-01",
-                "date_end": "2025-06-30",
-            }
-        )
-        term = self.env["school_academic_term"].create(
-            {
-                "name": "Term Leave %s" % suffix,
-                "code": "TMSL%s" % suffix,
-                "date_start": "2024-07-01",
-                "date_end": "2024-12-31",
-                "year_id": year.id,
-                "enrollment_state": "open",
-            }
-        )
-        contact = self.env["res.partner"].create({"name": "Contact Leave %s" % suffix})
-        student = self.env["school_student"].create(
-            {
-                "name": "Student Leave %s" % suffix,
-                "code": "STUSL%s" % suffix,
-                "contact_id": contact.id,
-                "school_id": school.id,
-            }
-        )
-        enrollment = self.env["school_enrollment"].create(
-            {
-                "date": "2024-07-01",
-                "academic_year_id": year.id,
-                "academic_term_id": term.id,
-                "school_id": school.id,
-                "grade_id": grade.id,
-                "grade_class_id": grade_class.id,
-                "student_id": student.id,
-                "currency_id": self.env.company.currency_id.id,
-            }
-        )
-        admin = self.env.ref("base.user_admin")
-        enrollment.with_user(admin).action_confirm()
-        enrollment.invalidate_cache()
-        enrollment.with_user(admin).action_approve_approval()
-        self.assertEqual(enrollment.state, "open")
-        self.assertEqual(student.state, "enrol")
-        return {
-            "grade_type": grade_type,
-            "school": school,
-            "grade": grade,
-            "grade_class": grade_class,
-            "year": year,
-            "term": term,
-            "student": student,
-            "enrollment": enrollment,
-        }
-
-    def test_constrain_disallowed_student_state_blocks_confirm(self):
-        """Confirming a leave whose student is not in enrol state
-        (e.g. already graduated) must be rejected."""
-        data = self._setup_open_enrollment("G1")
-        data["student"].sudo().action_set_to_graduate()
-        self.assertEqual(data["student"].state, "graduate")
-        leave = self.env["school_student_leave"].create(
-            {
-                "date": "2024-07-01",
-                "student_id": data["student"].id,
-                "academic_term_id": data["term"].id,
-            }
-        )
-        with self.assertRaises(ValidationError):
-            leave.write({"state": "confirm"})
-
-    def test_constrain_single_active_leave_for_same_student(self):
-        """Only one draft/confirm leave is allowed per student at a
-        time."""
-        data = self._setup_open_enrollment("M1")
-        self.env["school_student_leave"].create(
-            {
-                "date": "2024-07-01",
-                "student_id": data["student"].id,
-                "academic_term_id": data["term"].id,
-            }
-        )
-        with self.assertRaises(ValidationError):
-            self.env["school_student_leave"].create(
-                {
-                    "date": "2024-07-01",
-                    "student_id": data["student"].id,
-                    "academic_term_id": data["term"].id,
-                }
-            )


### PR DESCRIPTION
Menuntaskan seluruh temuan validator `unit-test` pada modul `ssi_school_student_leave` (seri 14.0), tanpa satu pun test atau assertion dilonggarkan.

## Perubahan

- **Docstring (2 butir)** — class `TestSchoolStudentLeave` dan method `test_school_student_leave()` kini berdocstring reST bahasa Inggris ≤ 79 kolom yang menyebut apa yang diuji.
- **Test Python murni (2 butir)** — `test_constrain_disallowed_student_state_blocks_confirm()` dan `test_constrain_single_active_leave_for_same_student()` **dipindah ke skenario YAML** ber-`expect_error`, bukan diberi kode `P#`. Keduanya menguji `@api.constrains` ber-`ValidationError` (`_check_student_state_allowed`, `_check_single_active_leave`), bukan `_sql_constraints`, jadi tidak ada pemicu `P1`–`P12` yang berlaku. Helper `_setup_open_enrollment()` yang hanya melayani kedua test itu ikut dihapus sehingga berkas Python kembali minimal.
- **`invalidate_cache` manual (6 butir)** — keenam step `action: call` bermethod `invalidate_cache` dihapus, diganti `options: {auto_refresh: true}` di tingkat berkas YAML. `invalidate_cache` adalah method ORM yang dihapus di Odoo 17.0; `auto_refresh` memanggil API cache yang benar per-seri.

Dua skenario YAML baru (fixture bersufiks `Y4`/`Y5`, mengikuti pola `Y1`–`Y3` yang sudah ada) menegaskan constraint tetap menggigit dengan tipe error dan potongan pesan yang sama seperti sebelum perubahan, lalu memverifikasi penolakannya tidak merusak state — leave tetap `draft` (Y4) dan hanya satu leave tersisa untuk student itu (Y5). Jumlah perilaku yang diuji bertambah, tidak berkurang.

## Verifikasi

```
#VALIDATOR name=unit-test target=.../ssi_school_student_leave series=14.0 error=0 warn=0 defer=0 excepted=0 status=OK
#GATE repo=ssi-school modules=1 failed=0 skipped=0 status=OK
```

`verify-tests.sh` → `TESTS OK`. `sync-config.sh 14.0` → `SYNC OK` (nol berkas config berubah).

Closes #291