### PR TITLE
[UPD] ssi_school_student_graduation: tuntaskan temuan validator unit-test

### DIFF
--- a/ssi_school_student_graduation/tests/test_data_school_student_graduation.yaml
+++ b/ssi_school_student_graduation/tests/test_data_school_student_graduation.yaml
@@ -1,3 +1,6 @@
+options:
+  auto_refresh: true
+
 scenarios:
   - name: "Create Student Graduation Draft"
     steps:
@@ -103,11 +106,6 @@ scenarios:
             type: "value"
             expected: "confirm"
 
-      - step: "Invalidate enrollment cache before approve"
-        action: "call"
-        target: "enrollment"
-        method: "invalidate_cache"
-
       - step: "Approve enrollment"
         action: "call"
         target: "enrollment"
@@ -117,11 +115,6 @@ scenarios:
           state:
             type: "value"
             expected: "open"
-
-      - step: "Invalidate student cache after enrollment approval"
-        action: "call"
-        target: "student"
-        method: "invalidate_cache"
 
       - step: "Assert student moved to enrol"
         action: "assert"
@@ -264,11 +257,6 @@ scenarios:
             type: "value"
             expected: "confirm"
 
-      - step: "Invalidate enrollment cache before approve"
-        action: "call"
-        target: "enrollment"
-        method: "invalidate_cache"
-
       - step: "Approve enrollment"
         action: "call"
         target: "enrollment"
@@ -278,11 +266,6 @@ scenarios:
           state:
             type: "value"
             expected: "open"
-
-      - step: "Invalidate student cache after enrollment approval"
-        action: "call"
-        target: "student"
-        method: "invalidate_cache"
 
       - step: "Assert student moved to enrol"
         action: "assert"
@@ -300,6 +283,11 @@ scenarios:
           date: "2025-06-30"
           student_id: "EVAL: registry['student'].id"
           graduation_date: "2025-06-30"
+          # Required because later steps read this document back as
+          # base.user_admin: school_student_graduation_internal_user_rule
+          # only exposes records the reading user owns, and the default
+          # responsible would otherwise be the superuser that created it.
+          user_id: "REF: base.user_admin"
 
       - step: "Assert graduation created in draft"
         action: "assert"
@@ -319,11 +307,6 @@ scenarios:
             type: "value"
             expected: "confirm"
 
-      - step: "Invalidate graduation cache before approve"
-        action: "call"
-        target: "graduation"
-        method: "invalidate_cache"
-
       - step: "Approve graduation"
         action: "call"
         target: "graduation"
@@ -333,11 +316,6 @@ scenarios:
           state:
             type: "value"
             expected: "done"
-
-      - step: "Invalidate graduation cache after approve"
-        action: "call"
-        target: "graduation"
-        method: "invalidate_cache"
 
       - step: "Assert graduation number generated on done"
         action: "assert"
@@ -367,4 +345,311 @@ scenarios:
           - ["id", "=", "EVAL: registry['enrollment'].id"]
           - ["academic_year_result", "=", "graduate"]
         save_as: "check_enrollment_result"
+        expect_count: 1
+
+  - name: "Confirm Student Graduation With Non Enrolled Student Is Rejected"
+    steps:
+      - step: "Setup - create grade type"
+        action: "create"
+        model: "school_grade_type"
+        save_as: "grade_type"
+        values:
+          name: "Grade Type for Graduation Test 3"
+          code: "GTSGY3"
+          sequence: 10
+
+      - step: "Setup - create school"
+        action: "create"
+        model: "school"
+        save_as: "school"
+        values:
+          name: "School for Graduation Test 3"
+          code: "SCHSGY3"
+          grade_type_id: "EVAL: registry['grade_type'].id"
+
+      - step: "Setup - create grade"
+        action: "create"
+        model: "school_grade"
+        save_as: "grade"
+        values:
+          name: "Grade for Graduation Test 3"
+          code: "GSGY3"
+          sequence: 10
+          type_id: "EVAL: registry['grade_type'].id"
+
+      - step: "Setup - create grade class"
+        action: "create"
+        model: "school_grade_class"
+        save_as: "grade_class"
+        values:
+          name: "Class Graduation Test 3"
+          code: "CLSGY3"
+          school_id: "EVAL: registry['school'].id"
+          grade_id: "EVAL: registry['grade'].id"
+          capacity: 30
+
+      - step: "Setup - create academic year"
+        action: "create"
+        model: "school_academic_year"
+        save_as: "academic_year"
+        values:
+          name: "Year Graduation Test 3"
+          code: "AYSGY3"
+          date_start: "2024-07-01"
+          date_end: "2025-06-30"
+
+      - step: "Setup - create academic term"
+        action: "create"
+        model: "school_academic_term"
+        save_as: "academic_term"
+        values:
+          name: "Term Graduation Test 3"
+          code: "TMSGY3"
+          date_start: "2024-07-01"
+          date_end: "2024-12-31"
+          year_id: "EVAL: registry['academic_year'].id"
+          enrollment_state: "open"
+
+      - step: "Setup - create student contact"
+        action: "create"
+        model: "res.partner"
+        save_as: "contact"
+        values:
+          name: "Student Contact Graduation Test 3"
+
+      - step: "Setup - create student"
+        action: "create"
+        model: "school_student"
+        save_as: "student"
+        values:
+          name: "Student Graduation Test 3"
+          code: "STUSGY3"
+          contact_id: "EVAL: registry['contact'].id"
+          school_id: "EVAL: registry['school'].id"
+
+      - step: "Setup - create enrollment"
+        action: "create"
+        model: "school_enrollment"
+        save_as: "enrollment"
+        values:
+          date: "2024-07-01"
+          academic_year_id: "EVAL: registry['academic_year'].id"
+          academic_term_id: "EVAL: registry['academic_term'].id"
+          school_id: "EVAL: registry['school'].id"
+          grade_id: "EVAL: registry['grade'].id"
+          grade_class_id: "EVAL: registry['grade_class'].id"
+          student_id: "EVAL: registry['student'].id"
+          currency_id: "EVAL: env.company.currency_id.id"
+
+      - step: "Confirm enrollment"
+        action: "call"
+        target: "enrollment"
+        method: "action_confirm"
+        as_user: "base.user_admin"
+        asserts:
+          state:
+            type: "value"
+            expected: "confirm"
+
+      - step: "Approve enrollment"
+        action: "call"
+        target: "enrollment"
+        method: "action_approve_approval"
+        as_user: "base.user_admin"
+        asserts:
+          state:
+            type: "value"
+            expected: "open"
+
+      - step: "Assert student moved to enrol"
+        action: "assert"
+        target: "student"
+        asserts:
+          state:
+            type: "value"
+            expected: "enrol"
+
+      - step: "Drop the student so it leaves the enrol state"
+        action: "call"
+        target: "student"
+        method: "action_set_to_dropped"
+        asserts:
+          state:
+            type: "value"
+            expected: "dropped"
+
+      - step: "Create student graduation draft for the dropped student"
+        action: "create"
+        model: "school_student_graduation"
+        save_as: "graduation"
+        values:
+          date: "2025-06-30"
+          student_id: "EVAL: registry['student'].id"
+          graduation_date: "2025-06-30"
+
+      - step: "Confirming the graduation must be rejected"
+        action: "write"
+        target: "graduation"
+        expect_error:
+          type: "ValidationError"
+          message_contains: "is not in enrolled state"
+        values:
+          state: "confirm"
+
+      - step: "Assert graduation stays in draft after the rejection"
+        action: "assert"
+        target: "graduation"
+        asserts:
+          state:
+            type: "value"
+            expected: "draft"
+
+  - name: "Second Active Graduation For Same Student Is Rejected"
+    steps:
+      - step: "Setup - create grade type"
+        action: "create"
+        model: "school_grade_type"
+        save_as: "grade_type"
+        values:
+          name: "Grade Type for Graduation Test 4"
+          code: "GTSGY4"
+          sequence: 10
+
+      - step: "Setup - create school"
+        action: "create"
+        model: "school"
+        save_as: "school"
+        values:
+          name: "School for Graduation Test 4"
+          code: "SCHSGY4"
+          grade_type_id: "EVAL: registry['grade_type'].id"
+
+      - step: "Setup - create grade"
+        action: "create"
+        model: "school_grade"
+        save_as: "grade"
+        values:
+          name: "Grade for Graduation Test 4"
+          code: "GSGY4"
+          sequence: 10
+          type_id: "EVAL: registry['grade_type'].id"
+
+      - step: "Setup - create grade class"
+        action: "create"
+        model: "school_grade_class"
+        save_as: "grade_class"
+        values:
+          name: "Class Graduation Test 4"
+          code: "CLSGY4"
+          school_id: "EVAL: registry['school'].id"
+          grade_id: "EVAL: registry['grade'].id"
+          capacity: 30
+
+      - step: "Setup - create academic year"
+        action: "create"
+        model: "school_academic_year"
+        save_as: "academic_year"
+        values:
+          name: "Year Graduation Test 4"
+          code: "AYSGY4"
+          date_start: "2024-07-01"
+          date_end: "2025-06-30"
+
+      - step: "Setup - create academic term"
+        action: "create"
+        model: "school_academic_term"
+        save_as: "academic_term"
+        values:
+          name: "Term Graduation Test 4"
+          code: "TMSGY4"
+          date_start: "2024-07-01"
+          date_end: "2024-12-31"
+          year_id: "EVAL: registry['academic_year'].id"
+          enrollment_state: "open"
+
+      - step: "Setup - create student contact"
+        action: "create"
+        model: "res.partner"
+        save_as: "contact"
+        values:
+          name: "Student Contact Graduation Test 4"
+
+      - step: "Setup - create student"
+        action: "create"
+        model: "school_student"
+        save_as: "student"
+        values:
+          name: "Student Graduation Test 4"
+          code: "STUSGY4"
+          contact_id: "EVAL: registry['contact'].id"
+          school_id: "EVAL: registry['school'].id"
+
+      - step: "Setup - create enrollment"
+        action: "create"
+        model: "school_enrollment"
+        save_as: "enrollment"
+        values:
+          date: "2024-07-01"
+          academic_year_id: "EVAL: registry['academic_year'].id"
+          academic_term_id: "EVAL: registry['academic_term'].id"
+          school_id: "EVAL: registry['school'].id"
+          grade_id: "EVAL: registry['grade'].id"
+          grade_class_id: "EVAL: registry['grade_class'].id"
+          student_id: "EVAL: registry['student'].id"
+          currency_id: "EVAL: env.company.currency_id.id"
+
+      - step: "Confirm enrollment"
+        action: "call"
+        target: "enrollment"
+        method: "action_confirm"
+        as_user: "base.user_admin"
+        asserts:
+          state:
+            type: "value"
+            expected: "confirm"
+
+      - step: "Approve enrollment"
+        action: "call"
+        target: "enrollment"
+        method: "action_approve_approval"
+        as_user: "base.user_admin"
+        asserts:
+          state:
+            type: "value"
+            expected: "open"
+
+      - step: "Assert student moved to enrol"
+        action: "assert"
+        target: "student"
+        asserts:
+          state:
+            type: "value"
+            expected: "enrol"
+
+      - step: "Create the first student graduation draft"
+        action: "create"
+        model: "school_student_graduation"
+        save_as: "first_graduation"
+        values:
+          date: "2025-06-30"
+          student_id: "EVAL: registry['student'].id"
+          graduation_date: "2025-06-30"
+
+      - step: "Creating a second active graduation must be rejected"
+        action: "create"
+        model: "school_student_graduation"
+        expect_error:
+          type: "ValidationError"
+          message_contains: "is already draft or"
+        values:
+          date: "2025-06-30"
+          student_id: "EVAL: registry['student'].id"
+          graduation_date: "2025-06-30"
+
+      - step: "Assert only one graduation exists for this student"
+        action: "search"
+        model: "school_student_graduation"
+        domain:
+          - ["student_id", "=", "EVAL: registry['student'].id"]
+        save_as: "graduations_of_student"
         expect_count: 1

--- a/ssi_school_student_graduation/tests/test_data_school_student_graduation_batch.yaml
+++ b/ssi_school_student_graduation/tests/test_data_school_student_graduation_batch.yaml
@@ -1,3 +1,6 @@
+options:
+  auto_refresh: true
+
 scenarios:
   - name: "Student Graduation Batch Full Workflow Confirm Approve Done"
     steps:
@@ -98,11 +101,10 @@ scenarios:
         target: "enrollment_1"
         method: "action_confirm"
         as_user: "base.user_admin"
-
-      - step: "Invalidate enrollment 1 cache before approve"
-        action: "call"
-        target: "enrollment_1"
-        method: "invalidate_cache"
+        asserts:
+          state:
+            type: "value"
+            expected: "confirm"
 
       - step: "Approve enrollment 1"
         action: "call"
@@ -150,11 +152,10 @@ scenarios:
         target: "enrollment_2"
         method: "action_confirm"
         as_user: "base.user_admin"
-
-      - step: "Invalidate enrollment 2 cache before approve"
-        action: "call"
-        target: "enrollment_2"
-        method: "invalidate_cache"
+        asserts:
+          state:
+            type: "value"
+            expected: "confirm"
 
       - step: "Approve enrollment 2"
         action: "call"
@@ -175,6 +176,12 @@ scenarios:
           academic_year_id: "EVAL: registry['academic_year'].id"
           academic_term_id: "EVAL: registry['academic_term'].id"
           grade_id: "EVAL: registry['grade'].id"
+          # Required because later steps read this document back as
+          # base.user_admin:
+          # school_student_graduation_batch_internal_user_rule only
+          # exposes records the reading user owns, and the default
+          # responsible would otherwise be the superuser that created it.
+          user_id: "REF: base.user_admin"
 
       - step: "Populate eligible students"
         action: "call"
@@ -200,11 +207,6 @@ scenarios:
             type: "value"
             expected: "confirm"
 
-      - step: "Invalidate batch cache before approve"
-        action: "call"
-        target: "batch"
-        method: "invalidate_cache"
-
       - step: "Approve batch"
         action: "call"
         target: "batch"
@@ -214,11 +216,6 @@ scenarios:
           state:
             type: "value"
             expected: "done"
-
-      - step: "Invalidate batch cache after approve"
-        action: "call"
-        target: "batch"
-        method: "invalidate_cache"
 
       - step: "Assert batch number generated on done"
         action: "assert"
@@ -282,3 +279,562 @@ scenarios:
           - ["state", "=", "done"]
         save_as: "check_graduation_2_done"
         expect_count: 1
+
+  - name: "Complete Graduation Batch Without Line Is Rejected"
+    steps:
+      - step: "Create graduation batch without any line"
+        action: "create"
+        model: "school_student_graduation_batch"
+        save_as: "batch"
+        values:
+          date: "2025-06-30"
+          # Required because later steps read this document back as
+          # base.user_admin:
+          # school_student_graduation_batch_internal_user_rule only
+          # exposes records the reading user owns, and the default
+          # responsible would otherwise be the superuser that created it.
+          user_id: "REF: base.user_admin"
+
+      - step: "Assert batch has no line"
+        action: "assert"
+        target: "batch"
+        asserts:
+          line_ids:
+            type: "o2m"
+            check: "count"
+            expected_count: 0
+
+      - step: "Confirm batch"
+        action: "call"
+        target: "batch"
+        method: "action_confirm"
+        as_user: "base.user_admin"
+        asserts:
+          state:
+            type: "value"
+            expected: "confirm"
+
+      - step: "Approving the empty batch must be rejected"
+        action: "call"
+        target: "batch"
+        method: "action_approve_approval"
+        as_user: "base.user_admin"
+        expect_error:
+          type: "ValidationError"
+          message_contains: "No student line has been added to this batch"
+
+      - step: "Assert batch stays in confirm after the rejection"
+        action: "assert"
+        target: "batch"
+        asserts:
+          state:
+            type: "value"
+            expected: "confirm"
+
+  - name: "Complete Graduation Batch With Non Enrolled Students Is Rejected"
+    steps:
+      - step: "Setup - create grade type"
+        action: "create"
+        model: "school_grade_type"
+        save_as: "grade_type"
+        values:
+          name: "Grade Type for Graduation Batch Test 2"
+          code: "GTSGBY2"
+          sequence: 10
+
+      - step: "Setup - create school"
+        action: "create"
+        model: "school"
+        save_as: "school"
+        values:
+          name: "School for Graduation Batch Test 2"
+          code: "SCHSGBY2"
+          grade_type_id: "EVAL: registry['grade_type'].id"
+
+      - step: "Setup - create grade"
+        action: "create"
+        model: "school_grade"
+        save_as: "grade"
+        values:
+          name: "Grade for Graduation Batch Test 2"
+          code: "GSGBY2"
+          sequence: 10
+          type_id: "EVAL: registry['grade_type'].id"
+
+      - step: "Setup - create grade class"
+        action: "create"
+        model: "school_grade_class"
+        save_as: "grade_class"
+        values:
+          name: "Class Graduation Batch Test 2"
+          code: "CLSGBY2"
+          school_id: "EVAL: registry['school'].id"
+          grade_id: "EVAL: registry['grade'].id"
+          capacity: 30
+
+      - step: "Setup - create academic year"
+        action: "create"
+        model: "school_academic_year"
+        save_as: "academic_year"
+        values:
+          name: "Year Graduation Batch Test 2"
+          code: "AYSGBY2"
+          date_start: "2024-07-01"
+          date_end: "2025-06-30"
+
+      - step: "Setup - create academic term"
+        action: "create"
+        model: "school_academic_term"
+        save_as: "academic_term"
+        values:
+          name: "Term Graduation Batch Test 2"
+          code: "TMSGBY2"
+          date_start: "2024-07-01"
+          date_end: "2024-12-31"
+          year_id: "EVAL: registry['academic_year'].id"
+          enrollment_state: "open"
+
+      - step: "Setup - create student 1 contact"
+        action: "create"
+        model: "res.partner"
+        save_as: "contact_1"
+        values:
+          name: "Student Contact 1 Graduation Batch Test 2"
+
+      - step: "Setup - create student 1"
+        action: "create"
+        model: "school_student"
+        save_as: "student_1"
+        values:
+          name: "Student 1 Graduation Batch Test 2"
+          code: "STUSGBY2A"
+          contact_id: "EVAL: registry['contact_1'].id"
+          school_id: "EVAL: registry['school'].id"
+
+      - step: "Setup - create enrollment for student 1"
+        action: "create"
+        model: "school_enrollment"
+        save_as: "enrollment_1"
+        values:
+          date: "2024-07-01"
+          academic_year_id: "EVAL: registry['academic_year'].id"
+          academic_term_id: "EVAL: registry['academic_term'].id"
+          school_id: "EVAL: registry['school'].id"
+          grade_id: "EVAL: registry['grade'].id"
+          grade_class_id: "EVAL: registry['grade_class'].id"
+          student_id: "EVAL: registry['student_1'].id"
+          currency_id: "EVAL: env.company.currency_id.id"
+
+      - step: "Confirm enrollment 1"
+        action: "call"
+        target: "enrollment_1"
+        method: "action_confirm"
+        as_user: "base.user_admin"
+        asserts:
+          state:
+            type: "value"
+            expected: "confirm"
+
+      - step: "Approve enrollment 1"
+        action: "call"
+        target: "enrollment_1"
+        method: "action_approve_approval"
+        as_user: "base.user_admin"
+        asserts:
+          state:
+            type: "value"
+            expected: "open"
+
+      - step: "Setup - create student 2 contact"
+        action: "create"
+        model: "res.partner"
+        save_as: "contact_2"
+        values:
+          name: "Student Contact 2 Graduation Batch Test 2"
+
+      - step: "Setup - create student 2"
+        action: "create"
+        model: "school_student"
+        save_as: "student_2"
+        values:
+          name: "Student 2 Graduation Batch Test 2"
+          code: "STUSGBY2B"
+          contact_id: "EVAL: registry['contact_2'].id"
+          school_id: "EVAL: registry['school'].id"
+
+      - step: "Setup - create enrollment for student 2"
+        action: "create"
+        model: "school_enrollment"
+        save_as: "enrollment_2"
+        values:
+          date: "2024-07-01"
+          academic_year_id: "EVAL: registry['academic_year'].id"
+          academic_term_id: "EVAL: registry['academic_term'].id"
+          school_id: "EVAL: registry['school'].id"
+          grade_id: "EVAL: registry['grade'].id"
+          grade_class_id: "EVAL: registry['grade_class'].id"
+          student_id: "EVAL: registry['student_2'].id"
+          currency_id: "EVAL: env.company.currency_id.id"
+
+      - step: "Confirm enrollment 2"
+        action: "call"
+        target: "enrollment_2"
+        method: "action_confirm"
+        as_user: "base.user_admin"
+        asserts:
+          state:
+            type: "value"
+            expected: "confirm"
+
+      - step: "Approve enrollment 2"
+        action: "call"
+        target: "enrollment_2"
+        method: "action_approve_approval"
+        as_user: "base.user_admin"
+        asserts:
+          state:
+            type: "value"
+            expected: "open"
+
+      - step: "Create graduation batch with both students"
+        action: "create"
+        model: "school_student_graduation_batch"
+        save_as: "batch"
+        values:
+          date: "2025-06-30"
+          # Required because later steps read this document back as
+          # base.user_admin:
+          # school_student_graduation_batch_internal_user_rule only
+          # exposes records the reading user owns, and the default
+          # responsible would otherwise be the superuser that created it.
+          user_id: "REF: base.user_admin"
+          line_ids:
+            - - 0
+              - 0
+              - student_id: "EVAL: registry['student_1'].id"
+            - - 0
+              - 0
+              - student_id: "EVAL: registry['student_2'].id"
+
+      - step: "Assert two lines created"
+        action: "assert"
+        target: "batch"
+        asserts:
+          line_ids:
+            type: "o2m"
+            check: "count"
+            expected_count: 2
+
+      - step: "Drop student 1 so it leaves the enrol state"
+        action: "call"
+        target: "student_1"
+        method: "action_set_to_dropped"
+        asserts:
+          state:
+            type: "value"
+            expected: "dropped"
+
+      - step: "Drop student 2 so it leaves the enrol state"
+        action: "call"
+        target: "student_2"
+        method: "action_set_to_dropped"
+        asserts:
+          state:
+            type: "value"
+            expected: "dropped"
+
+      - step: "Confirm batch"
+        action: "call"
+        target: "batch"
+        method: "action_confirm"
+        as_user: "base.user_admin"
+        asserts:
+          state:
+            type: "value"
+            expected: "confirm"
+
+      - step: "Approving the batch must be rejected and name every student"
+        action: "call"
+        target: "batch"
+        method: "action_approve_approval"
+        as_user: "base.user_admin"
+        expect_error:
+          type: "ValidationError"
+          message_contains:
+            "Student 1 Graduation Batch Test 2, Student 2 Graduation Batch Test 2"
+
+      - step: "Assert batch stays in confirm after the rejection"
+        action: "assert"
+        target: "batch"
+        asserts:
+          state:
+            type: "value"
+            expected: "confirm"
+
+  - name: "Populate Lines Only Selects Eligible Students"
+    steps:
+      - step: "Setup - create grade type A"
+        action: "create"
+        model: "school_grade_type"
+        save_as: "grade_type_a"
+        values:
+          name: "Grade Type A for Graduation Batch Test 3"
+          code: "GTSGBY3A"
+          sequence: 10
+
+      - step: "Setup - create school A"
+        action: "create"
+        model: "school"
+        save_as: "school_a"
+        values:
+          name: "School A for Graduation Batch Test 3"
+          code: "SCHSGBY3A"
+          grade_type_id: "EVAL: registry['grade_type_a'].id"
+
+      - step: "Setup - create grade A"
+        action: "create"
+        model: "school_grade"
+        save_as: "grade_a"
+        values:
+          name: "Grade A for Graduation Batch Test 3"
+          code: "GSGBY3A"
+          sequence: 10
+          type_id: "EVAL: registry['grade_type_a'].id"
+
+      - step: "Setup - create grade class A"
+        action: "create"
+        model: "school_grade_class"
+        save_as: "grade_class_a"
+        values:
+          name: "Class A Graduation Batch Test 3"
+          code: "CLSGBY3A"
+          school_id: "EVAL: registry['school_a'].id"
+          grade_id: "EVAL: registry['grade_a'].id"
+          capacity: 30
+
+      - step: "Setup - create academic year A"
+        action: "create"
+        model: "school_academic_year"
+        save_as: "academic_year_a"
+        values:
+          name: "Year A Graduation Batch Test 3"
+          code: "AYSGBY3A"
+          date_start: "2024-07-01"
+          date_end: "2025-06-30"
+
+      - step: "Setup - create academic term A"
+        action: "create"
+        model: "school_academic_term"
+        save_as: "academic_term_a"
+        values:
+          name: "Term A Graduation Batch Test 3"
+          code: "TMSGBY3A"
+          date_start: "2024-07-01"
+          date_end: "2024-12-31"
+          year_id: "EVAL: registry['academic_year_a'].id"
+          enrollment_state: "open"
+
+      - step: "Setup - create student A contact"
+        action: "create"
+        model: "res.partner"
+        save_as: "contact_a"
+        values:
+          name: "Student Contact A Graduation Batch Test 3"
+
+      - step: "Setup - create student A"
+        action: "create"
+        model: "school_student"
+        save_as: "student_a"
+        values:
+          name: "Student A Graduation Batch Test 3"
+          code: "STUSGBY3A"
+          contact_id: "EVAL: registry['contact_a'].id"
+          school_id: "EVAL: registry['school_a'].id"
+
+      - step: "Setup - create enrollment for student A"
+        action: "create"
+        model: "school_enrollment"
+        save_as: "enrollment_a"
+        values:
+          date: "2024-07-01"
+          academic_year_id: "EVAL: registry['academic_year_a'].id"
+          academic_term_id: "EVAL: registry['academic_term_a'].id"
+          school_id: "EVAL: registry['school_a'].id"
+          grade_id: "EVAL: registry['grade_a'].id"
+          grade_class_id: "EVAL: registry['grade_class_a'].id"
+          student_id: "EVAL: registry['student_a'].id"
+          currency_id: "EVAL: env.company.currency_id.id"
+
+      - step: "Confirm enrollment A"
+        action: "call"
+        target: "enrollment_a"
+        method: "action_confirm"
+        as_user: "base.user_admin"
+        asserts:
+          state:
+            type: "value"
+            expected: "confirm"
+
+      - step: "Approve enrollment A"
+        action: "call"
+        target: "enrollment_a"
+        method: "action_approve_approval"
+        as_user: "base.user_admin"
+        asserts:
+          state:
+            type: "value"
+            expected: "open"
+
+      - step: "Setup - create grade type B"
+        action: "create"
+        model: "school_grade_type"
+        save_as: "grade_type_b"
+        values:
+          name: "Grade Type B for Graduation Batch Test 3"
+          code: "GTSGBY3B"
+          sequence: 10
+
+      - step: "Setup - create school B"
+        action: "create"
+        model: "school"
+        save_as: "school_b"
+        values:
+          name: "School B for Graduation Batch Test 3"
+          code: "SCHSGBY3B"
+          grade_type_id: "EVAL: registry['grade_type_b'].id"
+
+      - step: "Setup - create grade B"
+        action: "create"
+        model: "school_grade"
+        save_as: "grade_b"
+        values:
+          name: "Grade B for Graduation Batch Test 3"
+          code: "GSGBY3B"
+          sequence: 10
+          type_id: "EVAL: registry['grade_type_b'].id"
+
+      - step: "Setup - create grade class B"
+        action: "create"
+        model: "school_grade_class"
+        save_as: "grade_class_b"
+        values:
+          name: "Class B Graduation Batch Test 3"
+          code: "CLSGBY3B"
+          school_id: "EVAL: registry['school_b'].id"
+          grade_id: "EVAL: registry['grade_b'].id"
+          capacity: 30
+
+      - step: "Setup - create academic year B"
+        action: "create"
+        model: "school_academic_year"
+        save_as: "academic_year_b"
+        values:
+          name: "Year B Graduation Batch Test 3"
+          code: "AYSGBY3B"
+          date_start: "2024-07-01"
+          date_end: "2025-06-30"
+
+      - step: "Setup - create academic term B"
+        action: "create"
+        model: "school_academic_term"
+        save_as: "academic_term_b"
+        values:
+          name: "Term B Graduation Batch Test 3"
+          code: "TMSGBY3B"
+          date_start: "2024-07-01"
+          date_end: "2024-12-31"
+          year_id: "EVAL: registry['academic_year_b'].id"
+          enrollment_state: "open"
+
+      - step: "Setup - create student B contact"
+        action: "create"
+        model: "res.partner"
+        save_as: "contact_b"
+        values:
+          name: "Student Contact B Graduation Batch Test 3"
+
+      - step: "Setup - create student B"
+        action: "create"
+        model: "school_student"
+        save_as: "student_b"
+        values:
+          name: "Student B Graduation Batch Test 3"
+          code: "STUSGBY3B"
+          contact_id: "EVAL: registry['contact_b'].id"
+          school_id: "EVAL: registry['school_b'].id"
+
+      - step: "Setup - create enrollment for student B"
+        action: "create"
+        model: "school_enrollment"
+        save_as: "enrollment_b"
+        values:
+          date: "2024-07-01"
+          academic_year_id: "EVAL: registry['academic_year_b'].id"
+          academic_term_id: "EVAL: registry['academic_term_b'].id"
+          school_id: "EVAL: registry['school_b'].id"
+          grade_id: "EVAL: registry['grade_b'].id"
+          grade_class_id: "EVAL: registry['grade_class_b'].id"
+          student_id: "EVAL: registry['student_b'].id"
+          currency_id: "EVAL: env.company.currency_id.id"
+
+      - step: "Confirm enrollment B"
+        action: "call"
+        target: "enrollment_b"
+        method: "action_confirm"
+        as_user: "base.user_admin"
+        asserts:
+          state:
+            type: "value"
+            expected: "confirm"
+
+      - step: "Approve enrollment B"
+        action: "call"
+        target: "enrollment_b"
+        method: "action_approve_approval"
+        as_user: "base.user_admin"
+        asserts:
+          state:
+            type: "value"
+            expected: "open"
+
+      - step: "Create graduation batch filtered on set A"
+        action: "create"
+        model: "school_student_graduation_batch"
+        save_as: "batch"
+        values:
+          date: "2025-06-30"
+          academic_year_id: "EVAL: registry['academic_year_a'].id"
+          academic_term_id: "EVAL: registry['academic_term_a'].id"
+          grade_id: "EVAL: registry['grade_a'].id"
+
+      - step: "Populate eligible students"
+        action: "call"
+        target: "batch"
+        method: "action_populate_lines"
+
+      - step: "Assert only one line populated"
+        action: "assert"
+        target: "batch"
+        asserts:
+          line_ids:
+            type: "o2m"
+            check: "count"
+            expected_count: 1
+
+      - step: "Assert student A is proposed by the filters"
+        action: "search"
+        model: "school_student_graduation_batch_line"
+        domain:
+          - ["batch_id", "=", "EVAL: registry['batch'].id"]
+          - ["student_id", "=", "EVAL: registry['student_a'].id"]
+        save_as: "line_of_student_a"
+        expect_count: 1
+
+      - step: "Assert student B is left out by the filters"
+        action: "search"
+        model: "school_student_graduation_batch_line"
+        domain:
+          - ["batch_id", "=", "EVAL: registry['batch'].id"]
+          - ["student_id", "=", "EVAL: registry['student_b'].id"]
+        save_as: "line_of_student_b"
+        expect_count: 0

--- a/ssi_school_student_graduation/tests/test_school_student_graduation.py
+++ b/ssi_school_student_graduation/tests/test_school_student_graduation.py
@@ -4,144 +4,27 @@
 
 from odoo_yaml_test import YamlTransactionCase
 
-from odoo.exceptions import ValidationError
 from odoo.tests import tagged
 
 
 @tagged("post_install", "-at_install")
 class TestSchoolStudentGraduation(YamlTransactionCase):
+    """Test the Student Graduation document.
+
+    Runs the YAML scenarios covering the full graduation life cycle:
+    the draft document created for an enrolled student together with
+    the active enrollment snapshot taken from that student, the
+    confirm and approve workflow that completes the document to done,
+    numbers it, moves the student to the graduate state and marks the
+    enrollment academic year result as graduate, and the two
+    constraints that reject a confirmation for a student who is no
+    longer enrolled and a second active graduation for the same
+    student.
+    """
+
     def test_school_student_graduation(self):
+        """Run every Student Graduation scenario in the YAML file.
+
+        :return: None
+        """
         self.run_yaml_scenario("test_data_school_student_graduation.yaml")
-
-    def _setup_open_enrollment(self, suffix):
-        """Create grade type/school/grade/year/term/student and an
-        enrollment already brought to open state (which also moves the
-        student to the "enrol" state via the enrollment's post_open
-        hook), ready to be used as the base fixture for a graduation
-        test."""
-        grade_type = self.env["school_grade_type"].create(
-            {
-                "name": "Grade Type Graduation %s" % suffix,
-                "code": "GTSG%s" % suffix,
-                "sequence": 10,
-            }
-        )
-        school = self.env["school"].create(
-            {
-                "name": "School Graduation %s" % suffix,
-                "code": "SCHSG%s" % suffix,
-                "grade_type_id": grade_type.id,
-            }
-        )
-        grade = self.env["school_grade"].create(
-            {
-                "name": "Grade Graduation %s" % suffix,
-                "code": "GSG%s" % suffix,
-                "sequence": 10,
-                "type_id": grade_type.id,
-            }
-        )
-        grade_class = self.env["school_grade_class"].create(
-            {
-                "name": "Class Graduation %s" % suffix,
-                "code": "CLSG%s" % suffix,
-                "school_id": school.id,
-                "grade_id": grade.id,
-                "capacity": 30,
-            }
-        )
-        year = self.env["school_academic_year"].create(
-            {
-                "name": "Year Graduation %s" % suffix,
-                "code": "AYSG%s" % suffix,
-                "date_start": "2024-07-01",
-                "date_end": "2025-06-30",
-            }
-        )
-        term = self.env["school_academic_term"].create(
-            {
-                "name": "Term Graduation %s" % suffix,
-                "code": "TMSG%s" % suffix,
-                "date_start": "2024-07-01",
-                "date_end": "2024-12-31",
-                "year_id": year.id,
-                "enrollment_state": "open",
-            }
-        )
-        contact = self.env["res.partner"].create(
-            {"name": "Contact Graduation %s" % suffix}
-        )
-        student = self.env["school_student"].create(
-            {
-                "name": "Student Graduation %s" % suffix,
-                "code": "STUSG%s" % suffix,
-                "contact_id": contact.id,
-                "school_id": school.id,
-            }
-        )
-        enrollment = self.env["school_enrollment"].create(
-            {
-                "date": "2024-07-01",
-                "academic_year_id": year.id,
-                "academic_term_id": term.id,
-                "school_id": school.id,
-                "grade_id": grade.id,
-                "grade_class_id": grade_class.id,
-                "student_id": student.id,
-                "currency_id": self.env.company.currency_id.id,
-            }
-        )
-        admin = self.env.ref("base.user_admin")
-        enrollment.with_user(admin).action_confirm()
-        enrollment.invalidate_cache()
-        enrollment.with_user(admin).action_approve_approval()
-        self.assertEqual(enrollment.state, "open")
-        student.invalidate_cache()
-        self.assertEqual(student.state, "enrol")
-        return {
-            "grade_type": grade_type,
-            "school": school,
-            "grade": grade,
-            "grade_class": grade_class,
-            "year": year,
-            "term": term,
-            "student": student,
-            "enrollment": enrollment,
-        }
-
-    def test_constrain_confirm_raises_when_student_dropped(self):
-        """Confirming a graduation whose student is no longer in the
-        "enrol" state (e.g. Dropped) must be rejected."""
-        data = self._setup_open_enrollment("D1")
-        data["student"].sudo().action_set_to_dropped()
-        self.assertEqual(data["student"].state, "dropped")
-
-        graduation = self.env["school_student_graduation"].create(
-            {
-                "date": "2025-06-30",
-                "student_id": data["student"].id,
-                "graduation_date": "2025-06-30",
-            }
-        )
-        with self.assertRaises(ValidationError):
-            graduation.with_user(self.env.ref("base.user_admin")).action_confirm()
-
-    def test_constrain_single_active_graduation_for_same_student(self):
-        """Only one draft/confirm graduation is allowed per student at
-        a time."""
-        data = self._setup_open_enrollment("M1")
-        self.env["school_student_graduation"].create(
-            {
-                "date": "2025-06-30",
-                "student_id": data["student"].id,
-                "graduation_date": "2025-06-30",
-            }
-        )
-        with self.assertRaises(ValidationError):
-            self.env["school_student_graduation"].create(
-                {
-                    "date": "2025-06-30",
-                    "student_id": data["student"].id,
-                    "graduation_date": "2025-06-30",
-                }
-            )

--- a/ssi_school_student_graduation/tests/test_school_student_graduation_batch.py
+++ b/ssi_school_student_graduation/tests/test_school_student_graduation_batch.py
@@ -4,168 +4,25 @@
 
 from odoo_yaml_test import YamlTransactionCase
 
-from odoo.exceptions import ValidationError
 from odoo.tests import tagged
 
 
 @tagged("post_install", "-at_install")
 class TestSchoolStudentGraduationBatch(YamlTransactionCase):
+    """Test the Student Graduation Batch document.
+
+    Runs the YAML scenarios covering the batch life cycle: populating
+    the batch lines from the academic year, academic term and grade
+    filters, the confirm and approve workflow that completes the batch
+    to done and generates one done Student Graduation document per
+    line, and the two completion checks that reject a batch without
+    any student line and a batch whose lines point at students who are
+    no longer enrolled.
+    """
+
     def test_school_student_graduation_batch(self):
+        """Run every Student Graduation Batch scenario in the YAML file.
+
+        :return: None
+        """
         self.run_yaml_scenario("test_data_school_student_graduation_batch.yaml")
-
-    def _setup_open_enrollment(self, suffix, grade=None, grade_type=None, school=None):
-        """Create (or reuse) grade type/school/grade/year/term and an
-        enrolled student, ready to be used as a batch line fixture. A
-        single grade per grade type has an empty next_grade_id, so it
-        is always eligible as a "final grade" for graduation."""
-        if grade_type is None:
-            grade_type = self.env["school_grade_type"].create(
-                {
-                    "name": "Grade Type Graduation Batch %s" % suffix,
-                    "code": "GTSGB%s" % suffix,
-                    "sequence": 10,
-                }
-            )
-        if school is None:
-            school = self.env["school"].create(
-                {
-                    "name": "School Graduation Batch %s" % suffix,
-                    "code": "SCHSGB%s" % suffix,
-                    "grade_type_id": grade_type.id,
-                }
-            )
-        if grade is None:
-            grade = self.env["school_grade"].create(
-                {
-                    "name": "Grade Graduation Batch %s" % suffix,
-                    "code": "GSGB%s" % suffix,
-                    "sequence": 10,
-                    "type_id": grade_type.id,
-                }
-            )
-        grade_class = self.env["school_grade_class"].create(
-            {
-                "name": "Class Graduation Batch %s" % suffix,
-                "code": "CLSGB%s" % suffix,
-                "school_id": school.id,
-                "grade_id": grade.id,
-                "capacity": 30,
-            }
-        )
-        year = self.env["school_academic_year"].create(
-            {
-                "name": "Year Graduation Batch %s" % suffix,
-                "code": "AYSGB%s" % suffix,
-                "date_start": "2024-07-01",
-                "date_end": "2025-06-30",
-            }
-        )
-        term = self.env["school_academic_term"].create(
-            {
-                "name": "Term Graduation Batch %s" % suffix,
-                "code": "TMSGB%s" % suffix,
-                "date_start": "2024-07-01",
-                "date_end": "2024-12-31",
-                "year_id": year.id,
-                "enrollment_state": "open",
-            }
-        )
-        contact = self.env["res.partner"].create(
-            {"name": "Contact Graduation Batch %s" % suffix}
-        )
-        student = self.env["school_student"].create(
-            {
-                "name": "Student Graduation Batch %s" % suffix,
-                "code": "STUSGB%s" % suffix,
-                "contact_id": contact.id,
-                "school_id": school.id,
-            }
-        )
-        enrollment = self.env["school_enrollment"].create(
-            {
-                "date": "2024-07-01",
-                "academic_year_id": year.id,
-                "academic_term_id": term.id,
-                "school_id": school.id,
-                "grade_id": grade.id,
-                "grade_class_id": grade_class.id,
-                "student_id": student.id,
-                "currency_id": self.env.company.currency_id.id,
-            }
-        )
-        admin = self.env.ref("base.user_admin")
-        enrollment.with_user(admin).action_confirm()
-        enrollment.invalidate_cache()
-        enrollment.with_user(admin).action_approve_approval()
-        self.assertEqual(enrollment.state, "open")
-        student.invalidate_cache()
-        self.assertEqual(student.state, "enrol")
-        return {
-            "grade_type": grade_type,
-            "school": school,
-            "grade": grade,
-            "year": year,
-            "term": term,
-            "student": student,
-            "enrollment": enrollment,
-        }
-
-    def test_pre_done_check_raises_when_no_lines(self):
-        """Completing a batch with no student line must be rejected."""
-        batch = self.env["school_student_graduation_batch"].create(
-            {
-                "date": "2025-06-30",
-            }
-        )
-        admin = self.env.ref("base.user_admin")
-        batch.with_user(admin).action_confirm()
-        batch.invalidate_cache()
-        with self.assertRaises(ValidationError):
-            batch.with_user(admin).action_approve_approval()
-
-    def test_pre_done_check_raises_when_line_student_not_enrolled(self):
-        """Completing a batch where a line's student is no longer
-        enrolled must be rejected, and the error must name every
-        offending student (collected, not stop-at-first)."""
-        data_1 = self._setup_open_enrollment("PD1")
-        data_2 = self._setup_open_enrollment("PD2")
-        data_1["student"].sudo().action_set_to_dropped()
-        data_2["student"].sudo().action_set_to_dropped()
-        self.assertEqual(data_1["student"].state, "dropped")
-        self.assertEqual(data_2["student"].state, "dropped")
-
-        batch = self.env["school_student_graduation_batch"].create(
-            {
-                "date": "2025-06-30",
-                "line_ids": [
-                    (0, 0, {"student_id": data_1["student"].id}),
-                    (0, 0, {"student_id": data_2["student"].id}),
-                ],
-            }
-        )
-        admin = self.env.ref("base.user_admin")
-        batch.with_user(admin).action_confirm()
-        batch.invalidate_cache()
-        with self.assertRaises(ValidationError):
-            batch.with_user(admin).action_approve_approval()
-
-    def test_populate_lines_filters_eligible_students(self):
-        """action_populate_lines only proposes students that are
-        enrolled, match the academic year/term/grade filters (via
-        their active enrollment), and have no next grade."""
-        data = self._setup_open_enrollment("EL1")
-        other_data = self._setup_open_enrollment("EL2")
-
-        batch = self.env["school_student_graduation_batch"].create(
-            {
-                "date": "2025-06-30",
-                "academic_year_id": data["year"].id,
-                "academic_term_id": data["term"].id,
-                "grade_id": data["grade"].id,
-            }
-        )
-        batch.action_populate_lines()
-
-        student_ids = batch.line_ids.mapped("student_id")
-        self.assertIn(data["student"], student_ids)
-        self.assertNotIn(other_data["student"], student_ids)


### PR DESCRIPTION
Closes #286

## Ringkasan

Menuntaskan 19 butir temuan validator `unit-test` pada modul
`ssi_school_student_graduation` (3 aturan gagal), tanpa satu pun test atau
assertion dilonggarkan dan tanpa satu baris kode produksi diubah.

### 1. `setiap-class-method-test-punya-docstring` (4 butir)

Docstring reST bahasa Inggris (≤ 79 kolom) ditambahkan pada kedua class test dan
kedua method `test_*`.

### 2. `test-python-murni-menyebut-kode-pemicu-p-dan-keterbatasan-l-` (5 butir)

Kelima test Python murni **tidak** memenuhi pemicu `P1`–`P13` mana pun, jadi
seluruhnya dipindahkan ke skenario YAML — bukan ditempeli kode `P#`:

| Test Python lama | Skenario YAML baru | Mekanisme |
|---|---|---|
| `test_constrain_confirm_raises_when_student_dropped` | Confirm Student Graduation With Non Enrolled Student Is Rejected | `write` + `expect_error` |
| `test_constrain_single_active_graduation_for_same_student` | Second Active Graduation For Same Student Is Rejected | `create` + `expect_error` |
| `test_pre_done_check_raises_when_no_lines` | Complete Graduation Batch Without Line Is Rejected | `call` + `expect_error` |
| `test_pre_done_check_raises_when_line_student_not_enrolled` | Complete Graduation Batch With Non Enrolled Students Is Rejected | `call` + `expect_error` |
| `test_populate_lines_filters_eligible_students` | Populate Lines Only Selects Eligible Students | `call` + `assert o2m` + dua `search` |

Kedua helper `_setup_open_enrollment()` ikut dihapus sehingga kedua berkas Python
kembali minimal (`verify-tests.sh` → `TESTS OK`).

Cakupan **bertambah**, bukan berkurang: tiap skenario `expect_error` juga
meng-assert keadaan sesudah penolakan (dokumen tetap `draft` / batch tetap
`confirm`, `expect_count: 1`), dan skenario batch non-enrol meng-assert **kedua**
nama siswa muncul di pesan error sehingga sifat *collected, not stop-at-first*
benar-benar teruji.

### 3. `tidak-ada-invalidate-cache-manual-pakai-options-auto-refresh` (10 butir)

Kesepuluh step manual diganti `options: {auto_refresh: true}` di tingkat berkas
pada kedua YAML. Dua akibat lanjutan yang diantisipasi di muka:

- `auto_refresh` hanya memicu `_refresh()` menjelang `assert` dan `search`,
  **tidak pernah** menjelang `action: call` (`case.py` baris 461 & 741). Karena
  itu setiap `action_confirm` diberi assertion `state`, supaya `approve_ok` tidak
  terbaca basi saat `action_approve_approval` menyusul.
- Refresh membuat record dibaca ulang dari DB sehingga record rule benar-benar
  dievaluasi. Fixture `school_student_graduation` / `school_student_graduation_batch`
  yang dibaca ulang sebagai `base.user_admin` karena itu diberi
  `user_id: "REF: base.user_admin"` — perbaikan di sisi fixture, **bukan**
  pelonggaran assertion dan **bukan** pelebaran grup security modul.

## Verifikasi

```
#GATE repo=ssi-school modules=1 failed=0 skipped=0 status=OK
#VALIDATOR name=unit-test target=…/ssi_school_student_graduation series=14.0 error=0 warn=0 defer=0 excepted=0 status=OK
```

Peringatan lama `setiap-@api.constrains-diuji-dengan-expect-error` ikut hilang
karena kedua constraint kini punya skenario `expect_error`-nya sendiri.