### PR TITLE
[UPD] ssi_school_qr_code: ganti invalidate_cache manual dengan auto_refresh

### DIFF
--- a/ssi_school_qr_code/tests/test_data_school_qr_code.yaml
+++ b/ssi_school_qr_code/tests/test_data_school_qr_code.yaml
@@ -1,3 +1,5 @@
+options:
+  auto_refresh: true
 scenarios:
   # NOTE: this scenario MUST stay first in this file. All scenarios in a
   # single YAML file share one DB transaction without rollback, so any
@@ -37,10 +39,6 @@ scenarios:
           code: "STUQR001"
           contact_id: "EVAL: registry['contact'].id"
           school_id: "EVAL: registry['school'].id"
-      - step: "Invalidate student cache before reading computed QR image"
-        action: "call"
-        target: "student"
-        method: "invalidate_cache"
       - step: "Assert student created and qr_image left empty"
         action: "assert"
         target: "student"
@@ -100,10 +98,6 @@ scenarios:
           code: "STUQR002"
           contact_id: "EVAL: registry['contact'].id"
           school_id: "EVAL: registry['school'].id"
-      - step: "Invalidate student cache before reading computed QR image"
-        action: "call"
-        target: "student"
-        method: "invalidate_cache"
       - step: "Assert qr_image is generated from the standard content"
         action: "assert"
         target: "student"
@@ -161,10 +155,6 @@ scenarios:
           code: "STUQR003"
           contact_id: "EVAL: registry['contact'].id"
           school_id: "EVAL: registry['school'].id"
-      - step: "Invalidate student cache before reading computed QR image"
-        action: "call"
-        target: "student"
-        method: "invalidate_cache"
       - step: "Assert qr_image is generated from the custom content"
         action: "assert"
         target: "student"
@@ -222,10 +212,6 @@ scenarios:
           code: "STUQR004"
           contact_id: "EVAL: registry['contact'].id"
           school_id: "EVAL: registry['school'].id"
-      - step: "Invalidate student cache before reading computed QR image"
-        action: "call"
-        target: "student"
-        method: "invalidate_cache"
       - step: "Assert qr_image stays empty without leaking an exception"
         action: "assert"
         target: "student"


### PR DESCRIPTION
## Ringkasan

Menuntaskan temuan validator `unit-test` (`tidak-ada-invalidate-cache-manual-pakai-options-auto-refresh`, 4 butir) hasil `audit-sweep.sh 14.0` pada modul `ssi_school_qr_code`.

- Empat step manual `action: call` + `method: invalidate_cache` di `tests/test_data_school_qr_code.yaml` dihapus.
- Diganti `options: {auto_refresh: true}` di level file — `invalidate_cache` adalah method ORM yang dihapus di Odoo 17.0, sedangkan `auto_refresh` memanggil API cache yang benar per-seri sehingga YAML-nya identik lintas versi.
- Tidak ada assertion yang dilonggarkan atau digeser; tidak ada kegagalan yang tersingkap oleh refresh (modul ini tidak punya dokumen ber-approval/`as_user`, murni mixin QR code pada `school_student`).

## Verifikasi

```
#VALIDATOR name=unit-test target=ssi_school_qr_code series=14.0 error=0 warn=0 defer=0 excepted=0 status=OK
#GATE repo=ssi-school modules=1 failed=0 skipped=0 status=OK
```

Closes #283