### PR TITLE
[UPD] Selaraskan uji ssi-school 14.0 dengan kontrak hulu baru (blocker CI)

### DIFF
--- a/ssi_school_admission_customer_invoice_export/tests/test_data_admission_create_invoice_export.yaml
+++ b/ssi_school_admission_customer_invoice_export/tests/test_data_admission_create_invoice_export.yaml
@@ -352,13 +352,90 @@ scenarios:
             type: "value"
             expected: "open"
 
-      - step: "Mark invoice Done as fully paid"
+      - step: "Setup - create contra account for the manual payment entry"
+        action: "create"
+        model: "account.account"
+        save_as: "payment_contra_account"
+        values:
+          name: "Payment Contra Account AI1"
+          code: "PCAAI1"
+          user_type_id: "REC: account_type.id"
+
+      - step: "Setup - create general journal for the manual payment entry"
+        action: "create"
+        model: "account.journal"
+        save_as: "payment_journal"
+        values:
+          name: "Payment General Journal AI1"
+          code: "PGJAI1"
+          type: "general"
+
+      - step: "Get invoice Done's receivable journal item"
+        action: "search"
+        model: "account.move.line"
+        domain: [["id", "=", "REC: invoice_done.receivable_move_line_id.id"]]
+        save_as: "invoice_done_receivable_ml"
+        expect_count: 1
+
+      - step: "Create a manual payment entry crediting the receivable account"
+        action: "create"
+        model: "account.move"
+        save_as: "payment_move"
+        values:
+          journal_id: "REC: payment_journal.id"
+          date: "2024-07-01"
+          line_ids:
+            - - 0
+              - 0
+              - name: "Payment"
+                account_id: "REC: ci_account.id"
+                partner_id: "REC: invoice_done.partner_id.id"
+                credit: 500000.0
+            - - 0
+              - 0
+              - name: "Payment contra"
+                account_id: "REC: payment_contra_account.id"
+                debit: 500000.0
+
+      - step: "Post the payment entry"
         action: "call"
+        target: "payment_move"
+        method: "action_post"
+
+      - step: "Get the payment's receivable-side journal item"
+        action: "search"
+        model: "account.move.line"
+        domain:
+          - ["move_id", "=", "REC: payment_move.id"]
+          - ["account_id", "=", "REC: ci_account.id"]
+        save_as: "payment_receivable_ml"
+        expect_count: 1
+
+      - step: "Combine both journal items to reconcile"
+        action: "search"
+        model: "account.move.line"
+        domain:
+          - [
+              "id",
+              "in",
+              ["REC: invoice_done_receivable_ml.id", "REC: payment_receivable_ml.id"],
+            ]
+        save_as: "to_reconcile"
+        expect_count: 2
+
+      - step: "Reconcile the receivable line against the payment"
+        action: "call"
+        target: "to_reconcile"
+        method: "reconcile"
+
+      - step: "Invoice Done becomes done once fully reconciled"
+        action: "assert"
         target: "invoice_done"
-        method: "action_done"
-        as_user: "base.user_admin"
         refresh: true
         asserts:
+          realized:
+            type: "value"
+            expected: true
           state:
             type: "value"
             expected: "done"

--- a/ssi_school_admission_promotion/tests/test_data_school_admission_payment_term_promotion.yaml
+++ b/ssi_school_admission_promotion/tests/test_data_school_admission_payment_term_promotion.yaml
@@ -705,7 +705,7 @@ scenarios:
         asserts:
           state:
             type: "value"
-            expected: "open"
+            expected: "done"
       - step: "The term's own receivable residual is reduced by the discount"
         action: "assert"
         target: "move_line_a"

--- a/ssi_school_customer_invoice_export/tests/test_data_enrollment_create_invoice_export.yaml
+++ b/ssi_school_customer_invoice_export/tests/test_data_enrollment_create_invoice_export.yaml
@@ -389,13 +389,90 @@ scenarios:
             type: "value"
             expected: "open"
 
-      - step: "Mark invoice Done as fully paid"
+      - step: "Setup - create contra account for the manual payment entry"
+        action: "create"
+        model: "account.account"
+        save_as: "payment_contra_account"
+        values:
+          name: "Payment Contra Account IE1"
+          code: "PCAIE1"
+          user_type_id: "REC: account_type.id"
+
+      - step: "Setup - create general journal for the manual payment entry"
+        action: "create"
+        model: "account.journal"
+        save_as: "payment_journal"
+        values:
+          name: "Payment General Journal IE1"
+          code: "PGJIE1"
+          type: "general"
+
+      - step: "Get invoice Done's receivable journal item"
+        action: "search"
+        model: "account.move.line"
+        domain: [["id", "=", "REC: invoice_done.receivable_move_line_id.id"]]
+        save_as: "invoice_done_receivable_ml"
+        expect_count: 1
+
+      - step: "Create a manual payment entry crediting the receivable account"
+        action: "create"
+        model: "account.move"
+        save_as: "payment_move"
+        values:
+          journal_id: "REC: payment_journal.id"
+          date: "2024-07-01"
+          line_ids:
+            - - 0
+              - 0
+              - name: "Payment"
+                account_id: "REC: ci_account.id"
+                partner_id: "REC: invoice_done.partner_id.id"
+                credit: 500000.0
+            - - 0
+              - 0
+              - name: "Payment contra"
+                account_id: "REC: payment_contra_account.id"
+                debit: 500000.0
+
+      - step: "Post the payment entry"
         action: "call"
+        target: "payment_move"
+        method: "action_post"
+
+      - step: "Get the payment's receivable-side journal item"
+        action: "search"
+        model: "account.move.line"
+        domain:
+          - ["move_id", "=", "REC: payment_move.id"]
+          - ["account_id", "=", "REC: ci_account.id"]
+        save_as: "payment_receivable_ml"
+        expect_count: 1
+
+      - step: "Combine both journal items to reconcile"
+        action: "search"
+        model: "account.move.line"
+        domain:
+          - [
+              "id",
+              "in",
+              ["REC: invoice_done_receivable_ml.id", "REC: payment_receivable_ml.id"],
+            ]
+        save_as: "to_reconcile"
+        expect_count: 2
+
+      - step: "Reconcile the receivable line against the payment"
+        action: "call"
+        target: "to_reconcile"
+        method: "reconcile"
+
+      - step: "Invoice Done becomes done once fully reconciled"
+        action: "assert"
         target: "invoice_done"
-        method: "action_done"
-        as_user: "base.user_admin"
         refresh: true
         asserts:
+          realized:
+            type: "value"
+            expected: true
           state:
             type: "value"
             expected: "done"

--- a/ssi_school_promotion/tests/test_data_school_enrollment_payment_term_promotion.yaml
+++ b/ssi_school_promotion/tests/test_data_school_enrollment_payment_term_promotion.yaml
@@ -744,7 +744,7 @@ scenarios:
         asserts:
           state:
             type: "value"
-            expected: "open"
+            expected: "done"
       - step: "The term's own receivable residual is reduced by the discount"
         action: "assert"
         target: "move_line_a"


### PR DESCRIPTION
## Kenapa PR ini gabungan

CI menjalankan **seluruh repo**, jadi PR yang hanya memuat satu dari empat perbaikan tetap merah oleh tiga sisanya — dan `/ocabot merge` terlarang saat CI merah. Empat item tetap dicatat sebagai empat issue terpisah (satu modul per issue); yang disatukan hanya pendaratannya, dengan **satu commit per modul**.

Closes #345
Closes #346
Closes #347
Closes #348

## Blocker yang diperbaiki

Base `14.0` merah **tanpa satu pun perubahan kode di repo ini**. Dibuktikan lewat eksperimen kontrol, bukan dugaan: run `31980705647` di SHA `ef3c64c` — attempt 1 (17 Agu) `success`, attempt 2 (21 Agu) `failure` dengan 4 kegagalan yang sama. Diff `pip freeze` atas 150 paket antar kedua attempt menyisakan tepat **2 baris**:

| Paket | Dari | Ke | Kontrak yang berubah |
|---|---|---|---|
| `odoo14-addon-ssi_customer_invoice` | 14.0.1.0.3 | 14.0.1.1.0 | guard `_50_check_realized` di `pre_done_check`; tombol Done manual dicabut, transisi `open` → `done` digerbangi `base.automation` saat `realized` jadi `True` |
| `odoo14-addon-ssi_promotion` | 14.0.1.9.1 | 14.0.1.17.0 | `action_open()` memanggil `action_done()` sendiri bila `recognition_state == "not_applicable"` |

Kedua perubahan hulu **disengaja dan terdokumentasi** (IK `05-approve.md` dua cabang, skrip migrasi `14.0.1.17.0/post-migrate.py` yang men-stamp baris lama `open` → `done`, test hulu sendiri sudah diselaraskan). Jadi yang menyesuaikan adalah uji di repo ini.

## Commit

| Commit | Modul | Perubahan |
|---|---|---|
| `9e310af` | `ssi_school_customer_invoice_export` | step `action_done()` langsung → 7 step rekonsiliasi penuh journal item receivable + 2 fixture |
| `a44579b` | `ssi_school_admission_customer_invoice_export` | idem |
| `af672ed` | `ssi_school_promotion` | assert `state` `open` → `done` (1 baris) |
| `41bb924` | `ssi_school_admission_promotion` | idem (1 baris) |

## Yang TIDAK dilakukan

Tidak ada test, assertion, atau tour yang dihapus, di-skip, atau dilonggarkan. Assertion inti tiap skenario tidak disentuh — `source_move_ids`/`move_ids` (`check: exact`) dan `summary_ids` pada uji ekspor, `amount_residual` = `800000.0` pada uji promosi.

Perubahan assert `state` sengaja dipagari hitungan agar tidak menyapu rata: `ssi_school_promotion` **16 → 15** assert `state: "open"` tersisa, `ssi_school_admission_promotion` **19 → 18**. Sisanya milik `school_enrollment`/`school_admission`, `customer_invoice`, dan `promotion_code` — kontraknya tidak berubah.

Fixture kedua uji promosi tidak menyetel `recognition_method`, jadi jatuh ke default hulu `immediate` → `amount_to_recognize` nol → `recognition_state = not_applicable`. `done` memang state yang benar menurut kontrak baru; fixture **tidak** diubah ke Deferred.

## Dampak

PR ini membuka blokir seluruh backlog audit ssi-school 14.0 — #336 (PR #344) dan antrean #337, #329, #330, #331, #332, #333 tertahan di belakangnya.