### PR TITLE
[UPD] ssi_school_admission_lead: selaraskan penamaan onchange & rapikan validator-exceptions

### DIFF
--- a/ssi_school_admission_lead/.validator-exceptions
+++ b/ssi_school_admission_lead/.validator-exceptions
@@ -18,5 +18,14 @@ module name-wizard-tanpa-notasi-titik|models/res_config_settings.py: _name 'res.
 module berkas-wizard-berada-di-wizards|models/res_config_settings.py: TransientModel di luar wizards/ -- res.config.settings bukan wizard SSI, melainkan extension res.config.settings core Odoo; ditempatkan di models/ mengikuti konvensi extension model, bukan wizard
 module acl-wizard-satu-user-access-tanpa-all-access|res.config.settings: tidak ada ACL sama sekali -- ACL res.config.settings sudah disediakan modul base; menambah ACL baru untuk model core akan duplikat/bertentangan dengan ACL base
 module name-wizard-tanpa-notasi-titik|wizard/crm_lead_create_admission_form.py: _name 'crm.lead.create_admission_form' memakai notasi titik -- _name warisan yang dikurung 10-wizard.md §1; menggantinya mengubah nama tabel/model beserta XML ID model_crm_lead_create_admission_form yang sudah dirujuk ir.model.access, view, dan action
-module berkas-wizard-berada-di-wizards|wizard/crm_lead_create_admission_form.py: TransientModel di luar wizards/ -- direktori wizard/ (tunggal) adalah ejaan warisan; 10-wizard.md §3 melarang menyeragamkan modul lama dengan memindahkan direktorinya karena itu mengubah path berkas di manifest dan __init__.py tanpa manfaat fungsional
 module direktori-wizards-jamak-bukan-wizard|wizard/ -- direktori wizard/ (tunggal) adalah ejaan warisan yang DIPERTAHANKAN; 10-wizard.md §3 melarang menyeragamkan modul lama dengan memindahkan direktorinya karena itu mengubah path berkas di manifest dan __init__.py tanpa manfaat fungsional. Modul BARU tetap wajib memakai wizards/
+
+# issue #330: penyelarasan penamaan onchange `_onchange_<field>` ->
+# `onchange_<field>`. Keputusan Desain issue itu menuntut grep lintas
+# repo dulu -- `_onchange_grade_id` juga muncul di
+# ssi_school_admission/models/school_admission_test.py (method onchange
+# lain, model berbeda, kebetulan nama sama; dibatalkan di sana juga oleh
+# issue #329 dengan alasan yang sama). Karena ada perujuk bernama sama di
+# modul LAIN, rename method ini dibatalkan sesuai Keputusan Desain --
+# item ini hanya boleh menyentuh satu modul.
+module method-api-onchange-bernama-onchange-field|wizard/crm_lead_create_admission_form.py _onchange_grade_id -- dibatalkan: nama `_onchange_grade_id` juga dipakai method onchange tak terkait di modul lain (ssi_school_admission/models/school_admission_test.py); Keputusan Desain issue #330 melarang rename bila ada perujuk nama sama di modul lain

--- a/ssi_school_admission_lead/wizard/crm_lead_create_admission_form.py
+++ b/ssi_school_admission_lead/wizard/crm_lead_create_admission_form.py
@@ -123,15 +123,20 @@ class CrmLeadCreateAdmissionForm(models.TransientModel):
         return res
 
     @api.onchange("academic_year_id")
-    def _onchange_academic_year_id(self):
+    def onchange_academic_year_id(self):
         if self.academic_term_id.year_id != self.academic_year_id:
             self.academic_term_id = False
 
     @api.onchange("school_id")
-    def _onchange_school_id(self):
+    def onchange_school_id(self):
         self.grade_id = False
         self.fee_template_id = False
 
+    # NOTE: kept as `_onchange_grade_id` (not `onchange_grade_id`). The
+    # target name collides with an unrelated onchange method of the same
+    # name in ssi_school_admission/models/school_admission_test.py; the
+    # Design Decision of issue #330 forbids renaming when another module
+    # carries a same-named referent. See .validator-exceptions.
     @api.onchange("grade_id")
     def _onchange_grade_id(self):
         self.fee_template_id = False


### PR DESCRIPTION
## Ringkasan

Menindaklanjuti sapuan kepatuhan `audit-sweep.sh 14.0 --strict` (4 ERROR) di modul `ssi_school_admission_lead`:

- Ganti nama method `@api.onchange` dari `_onchange_<field>` menjadi `onchange_<field>` (tanpa garis bawah depan) di `wizard/crm_lead_create_admission_form.py`, untuk target `academic_year_id` dan `school_id`, sesuai `10-onchange.md`.
- **Rename `_onchange_grade_id` DIBATALKAN**: grep lintas repo untuk nama lama menemukan method onchange tak terkait bernama sama (`_onchange_grade_id`) di `ssi_school_admission/models/school_admission_test.py` (model berbeda, kebetulan nama sama — dan rename method itu sendiri sudah dibatalkan sebelumnya oleh issue #329/PR #351 dengan alasan yang sama). Sesuai Keputusan Desain issue #330, item ini hanya boleh menyentuh satu modul, sehingga rename dibatalkan dan dikurung di `.validator-exceptions`.
- Hapus satu baris `.validator-exceptions` yang temuannya sudah tidak muncul lagi (`berkas-wizard-berada-di-wizards` untuk `wizard/crm_lead_create_admission_form.py`), sesuai kontrak validator §13.

## Hasil grep lintas-modul (nama lama)

- `_onchange_academic_year_id` — hanya muncul di modul ini (1 titik). Aman di-rename.
- `_onchange_school_id` — hanya muncul di modul ini (1 titik). Aman di-rename.
- `_onchange_grade_id` — muncul di 2 modul: `ssi_school_admission_lead/wizard/crm_lead_create_admission_form.py:136` (modul ini) dan `ssi_school_admission/models/school_admission_test.py:211` (modul lain, model berbeda, coincidental). Rename dibatalkan.

## Validator

```
#VALIDATOR name=module target=ssi_school_admission_lead series=14.0 error=0 warn=0 defer=0 excepted=6 status=OK
```

Closes #330