### PR TITLE
[UPD] ssi_school_admission_operating_unit: tuntaskan temuan kepatuhan wizard & docstring

### DIFF
--- a/ssi_school_admission_operating_unit/.validator-exceptions
+++ b/ssi_school_admission_operating_unit/.validator-exceptions
@@ -1,0 +1,44 @@
+# Penyimpangan yang diterima untuk validator `module` (lihat validator-contract.md §13).
+#
+# wizards/school_admission_create_enrollment.py,
+# wizards/school_admission_form_create_admission.py, dan
+# wizards/school_admission_test_create_admission.py memakai pola _name +
+# _inherit bernilai sama: ketiganya MENGEKSTENSI wizard milik modul dasar
+# ssi_school_admission, bukan mendefinisikannya --
+# school_admission.wizard_create_enrollment,
+# school_admission_form.wizard_create_admission, dan
+# school_admission_test.wizard_create_admission seluruhnya didefinisikan di
+# ssi_school_admission/wizards/. Konsekuensinya:
+#
+# * _name-nya warisan dan TIDAK boleh diganti -- mengubahnya berarti mengubah
+#   nama tabel/model beserta XML ID model_<nama> yang sudah dirujuk
+#   ir.model.access, view, dan action modul dasar (02-core-principles.md;
+#   10-wizard.md §1 menyebut bentuk ini warisan yang dipertahankan). Karena
+#   _name tidak berubah, nama berkas & nama class turunannya (aturan
+#   nama-berkas-py-name-model, nama-class-pascalcase-dari-name) juga tetap
+#   mengikuti bentuk lama.
+# * ACL-nya hidup di modul dasar ssi_school_admission yang mendefinisikan
+#   model itu; mendefinisikan ulang di modul glue ini akan menggandakan
+#   aturan akses.
+#
+# Wizard BARU di modul ini tetap wajib memakai bentuk benar: frasa kerja
+# snake_case datar, tanpa prefix model induk, tanpa kata 'wizard', tanpa
+# notasi titik.
+# Preseden: ssi_school_admission_lead_operating_unit (.validator-exceptions),
+# issue open-synergy/ssi-school#331; ssi_school_admission_customer_invoice_export_operating_unit,
+# issue open-synergy/ssi-school#331.
+
+module nama-berkas-py-name-model|wizards/school_admission_create_enrollment.py: _name='school_admission.wizard_create_enrollment' menuntut berkas school_admission_wizard_create_enrollment.py -- _name warisan milik modul dasar ssi_school_admission; mengubah nama berkas tanpa mengubah _name tidak diminta, dan _name sendiri tidak boleh diganti (lihat header)
+module nama-berkas-py-name-model|wizards/school_admission_form_create_admission.py: _name='school_admission_form.wizard_create_admission' menuntut berkas school_admission_form_wizard_create_admission.py -- _name warisan milik modul dasar ssi_school_admission; mengubah nama berkas tanpa mengubah _name tidak diminta, dan _name sendiri tidak boleh diganti (lihat header)
+module nama-berkas-py-name-model|wizards/school_admission_test_create_admission.py: _name='school_admission_test.wizard_create_admission' menuntut berkas school_admission_test_wizard_create_admission.py -- _name warisan milik modul dasar ssi_school_admission; mengubah nama berkas tanpa mengubah _name tidak diminta, dan _name sendiri tidak boleh diganti (lihat header)
+module nama-class-pascalcase-dari-name|wizards/school_admission_form_create_admission.py: class SchoolAdmissionFormCreateAdmission, seharusnya SchoolAdmissionFormWizardCreateAdmission -- _name warisan milik modul dasar ssi_school_admission (lihat header); nama class mengikuti _name lama, bukan bentuk yang seharusnya dari _name yang tidak boleh diubah
+module nama-class-pascalcase-dari-name|wizards/school_admission_test_create_admission.py: class SchoolAdmissionTestCreateAdmission, seharusnya SchoolAdmissionTestWizardCreateAdmission -- _name warisan milik modul dasar ssi_school_admission (lihat header); nama class mengikuti _name lama, bukan bentuk yang seharusnya dari _name yang tidak boleh diubah
+module name-wizard-tanpa-notasi-titik|wizards/school_admission_create_enrollment.py: _name 'school_admission.wizard_create_enrollment' memakai notasi titik -- _name warisan milik modul dasar ssi_school_admission; mengubahnya melanggar 02-core-principles.md (XML ID model_<nama> & nama tabel sudah dirujuk ACL, view, dan action)
+module name-wizard-tanpa-notasi-titik|wizards/school_admission_form_create_admission.py: _name 'school_admission_form.wizard_create_admission' memakai notasi titik -- _name warisan milik modul dasar ssi_school_admission; mengubahnya melanggar 02-core-principles.md (XML ID model_<nama> & nama tabel sudah dirujuk ACL, view, dan action)
+module name-wizard-tanpa-notasi-titik|wizards/school_admission_test_create_admission.py: _name 'school_admission_test.wizard_create_admission' memakai notasi titik -- _name warisan milik modul dasar ssi_school_admission; mengubahnya melanggar 02-core-principles.md (XML ID model_<nama> & nama tabel sudah dirujuk ACL, view, dan action)
+module name-wizard-tanpa-kata-wizard|wizards/school_admission_create_enrollment.py: _name 'school_admission.wizard_create_enrollment' memuat kata 'wizard' -- _name warisan milik modul dasar ssi_school_admission; mengubahnya melanggar 02-core-principles.md (XML ID model_<nama> & nama tabel sudah dirujuk ACL, view, dan action)
+module name-wizard-tanpa-kata-wizard|wizards/school_admission_form_create_admission.py: _name 'school_admission_form.wizard_create_admission' memuat kata 'wizard' -- _name warisan milik modul dasar ssi_school_admission; mengubahnya melanggar 02-core-principles.md (XML ID model_<nama> & nama tabel sudah dirujuk ACL, view, dan action)
+module name-wizard-tanpa-kata-wizard|wizards/school_admission_test_create_admission.py: _name 'school_admission_test.wizard_create_admission' memuat kata 'wizard' -- _name warisan milik modul dasar ssi_school_admission; mengubahnya melanggar 02-core-principles.md (XML ID model_<nama> & nama tabel sudah dirujuk ACL, view, dan action)
+module acl-wizard-satu-user-access-tanpa-all-access|school_admission.wizard_create_enrollment: tidak ada ACL sama sekali -- model didefinisikan modul dasar ssi_school_admission dan ACL-nya disediakan di sana; mendefinisikan ulang di modul glue ini akan menggandakan aturan akses
+module acl-wizard-satu-user-access-tanpa-all-access|school_admission_form.wizard_create_admission: tidak ada ACL sama sekali -- model didefinisikan modul dasar ssi_school_admission dan ACL-nya disediakan di sana; mendefinisikan ulang di modul glue ini akan menggandakan aturan akses
+module acl-wizard-satu-user-access-tanpa-all-access|school_admission_test.wizard_create_admission: tidak ada ACL sama sekali -- model didefinisikan modul dasar ssi_school_admission dan ACL-nya disediakan di sana; mendefinisikan ulang di modul glue ini akan menggandakan aturan akses

--- a/ssi_school_admission_operating_unit/wizards/school_admission_form_create_admission.py
+++ b/ssi_school_admission_operating_unit/wizards/school_admission_form_create_admission.py
@@ -5,10 +5,27 @@ from odoo import models
 
 
 class SchoolAdmissionFormCreateAdmission(models.TransientModel):
+    """Propagate the admission form's operating unit to the admission.
+
+    Extends the Create Admission wizard so the ``school_admission`` it
+    creates carries the same ``operating_unit_id`` as the source
+    ``school_admission_form``.
+    """
+
     _name = "school_admission_form.wizard_create_admission"
     _inherit = "school_admission_form.wizard_create_admission"
 
     def action_create_admission(self):
+        """Confirm the wizard and stamp the OU on the new admission.
+
+        Side effect: writes ``operating_unit_id`` on the
+        ``school_admission`` record created by the base wizard, when
+        the source admission form has one.
+
+        :return: whatever the base ``action_create_admission`` returns
+            (an ``ir.actions.act_window`` dict pointing at the new
+            ``school_admission``)
+        """
         self.ensure_one()
         res = super().action_create_admission()
         if self.admission_form_id.operating_unit_id and res.get("res_id"):

--- a/ssi_school_admission_operating_unit/wizards/school_admission_test_create_admission.py
+++ b/ssi_school_admission_operating_unit/wizards/school_admission_test_create_admission.py
@@ -5,10 +5,27 @@ from odoo import models
 
 
 class SchoolAdmissionTestCreateAdmission(models.TransientModel):
+    """Propagate the admission test's operating unit to the admission.
+
+    Extends the Create Admission wizard so the ``school_admission`` it
+    creates carries the same ``operating_unit_id`` as the source
+    ``school_admission_test``.
+    """
+
     _name = "school_admission_test.wizard_create_admission"
     _inherit = "school_admission_test.wizard_create_admission"
 
     def action_create_admission(self):
+        """Confirm the wizard and stamp the OU on the new admission.
+
+        Side effect: writes ``operating_unit_id`` on the
+        ``school_admission`` record created by the base wizard, when
+        the source admission test has one.
+
+        :return: whatever the base ``action_create_admission`` returns
+            (an ``ir.actions.act_window`` dict pointing at the new
+            ``school_admission``)
+        """
         self.ensure_one()
         res = super().action_create_admission()
         if self.admission_test_id.operating_unit_id and res.get("res_id"):


### PR DESCRIPTION
## Ringkasan

Menuntaskan 18 temuan ERROR validator `module` di modul `ssi_school_admission_operating_unit` (sapuan audit-sweep 21 Agustus 2026):

* 4 temuan `setiap-class-method-punya-docstring` — **diperbaiki**: docstring reST ditambahkan ke `SchoolAdmissionFormCreateAdmission`, `SchoolAdmissionTestCreateAdmission`, dan method `action_create_admission` masing-masing.
* 14 temuan sisanya (`acl-wizard-satu-user-access-tanpa-all-access` ×3, `nama-berkas-py-name-model` ×3, `name-wizard-tanpa-kata-wizard` ×3, `name-wizard-tanpa-notasi-titik` ×3, `nama-class-pascalcase-dari-name` ×2) — **dinyatakan di `.validator-exceptions`**: ketiga wizard di modul ini memakai pola `_name`/`_inherit` bernilai sama karena mengekstensi wizard milik modul dasar `ssi_school_admission`, sehingga `_name`, nama berkas, nama class, dan ACL-nya tetap warisan modul dasar (preseden: `ssi_school_admission_lead_operating_unit`, issue #331).

Tidak ada perilaku fungsional yang berubah — murni docstring + pernyataan pengecualian.

## Bukti

```
#GATE repo=ssi-school-332 modules=1 failed=0 skipped=0 precommit=OK status=OK
#PRECOMMIT repo=ssi-school-332 hook=dipasang runs=1 status=OK
#VALIDATOR name=module target=.../ssi_school_admission_operating_unit series=14.0 error=0 warn=0 defer=0 excepted=14 status=OK
```

Closes #332