### PR TITLE
[UPD] ssi_school_customer_invoice_export_operating_unit - Kurung penamaan & ACL wizard ekstensi

### DIFF
--- a/ssi_school_customer_invoice_export_operating_unit/.validator-exceptions
+++ b/ssi_school_customer_invoice_export_operating_unit/.validator-exceptions
@@ -1,0 +1,22 @@
+# Penyimpangan yang diterima untuk validator `module` (lihat validator-contract.md §13).
+#
+# `_name` wizard `school_enrollment.wizard_create_invoice_export` adalah bentuk WARISAN
+# yang keliru menurut 10-wizard.md §1 (memakai prefix model induk, kata `wizard`, dan
+# notasi titik). Ia dipertahankan apa adanya — bersama nama berkas & nama class-nya —
+# karena mengubah `_name` berarti mengubah nama tabel serta XML ID `model_<nama>` yang
+# sudah dirujuk `ir.model.access`, view, dan `ir.actions.act_window` modul dasar
+# `ssi_school_customer_invoice_export`; itu dilarang 02-core-principles.md §1. ACL-nya
+# pun sudah didefinisikan di modul dasar itu (lihat
+# ssi_school_customer_invoice_export/security/ir_model_access/school_enrollment_wizard_create_invoice_export.xml);
+# mendefinisikan ulang di modul glue ini akan menggandakan aturan akses. Lihat issue
+# open-synergy/ssi-school#334 ("## Keputusan Desain"), preseden
+# ssi_school_admission_customer_invoice_export_operating_unit (issue #262).
+#
+# MENGIKAT KE DEPAN: wizard BARU di modul ini wajib memakai bentuk benar — frasa kerja
+# `snake_case` datar, tanpa prefix model induk, tanpa kata `wizard`, tanpa notasi titik.
+# Pengecualian ini hanya mengurung yang sudah ada, bukan mengesahkan gayanya.
+
+module nama-berkas-py-name-model|wizards/school_enrollment_create_invoice_export.py: _name='school_enrollment.wizard_create_invoice_export' menuntut berkas school_enrollment_wizard_create_invoice_export.py -- nama berkas mengikuti `_name` warisan yang tidak boleh diganti; mengganti nama berkas tanpa mengganti `_name` justru menyimpang lebih jauh dari aturan, dan mengganti `_name` dilarang 02-core-principles.md §1 (XML ID & tabel dipakai data produksi)
+module name-wizard-tanpa-notasi-titik|wizards/school_enrollment_create_invoice_export.py: _name 'school_enrollment.wizard_create_invoice_export' memakai notasi titik -- `_name` warisan; mengubahnya berarti mengubah nama tabel & XML ID `model_school_enrollment_wizard_create_invoice_export` yang sudah dirujuk ACL, view, dan act_window (dilarang 02-core-principles.md §1)
+module name-wizard-tanpa-kata-wizard|wizards/school_enrollment_create_invoice_export.py: _name 'school_enrollment.wizard_create_invoice_export' memuat kata 'wizard' -- `_name` warisan; alasan sama dengan baris di atas — kata `wizard` tak bisa dibuang tanpa mengubah `_name`, dan `_name` dikunci 02-core-principles.md §1
+module acl-wizard-satu-user-access-tanpa-all-access|school_enrollment.wizard_create_invoice_export: tidak ada ACL sama sekali -- model didefinisikan modul dasar ssi_school_customer_invoice_export dan ACL-nya disediakan di sana (security/ir_model_access/school_enrollment_wizard_create_invoice_export.xml); mendefinisikan ulang di modul glue ini akan menggandakan aturan akses


### PR DESCRIPTION
## Ringkasan

Menyatakan 4 temuan ERROR validator `module` di modul
`ssi_school_customer_invoice_export_operating_unit` sebagai penyimpangan sah
lewat `.validator-exceptions` (kontrak validator §13), mengikuti preseden
`ssi_school_admission_customer_invoice_export_operating_unit` (issue #262).

Wizard `wizards/school_enrollment_create_invoice_export.py` memakai pola
`_name` + `_inherit` bernilai sama — ia MENGEKSTENSI wizard
`school_enrollment.wizard_create_invoice_export` milik modul dasar
`ssi_school_customer_invoice_export`, bukan mendefinisikannya. `_name`, nama
berkas, dan nama class-nya warisan dan tidak boleh diganti (02-core-principles.md
§1); ACL-nya sudah didefinisikan di modul dasar
(`security/ir_model_access/school_enrollment_wizard_create_invoice_export.xml`).

**Tidak ada satu baris kode/perilaku yang berubah** — hanya berkas
`.validator-exceptions` baru.

## Verifikasi

```
#VALIDATOR name=module target=.../ssi_school_customer_invoice_export_operating_unit series=14.0 error=0 warn=0 defer=0 excepted=4 status=OK
```

Closes #334