### PR TITLE
[UPD] ssi_school_incident: bersihkan sisa model school_incident.wizard_escalate

### DIFF
--- a/ssi_school_incident/__manifest__.py
+++ b/ssi_school_incident/__manifest__.py
@@ -3,7 +3,7 @@
 # License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl).
 {
     "name": "School Incident",
-    "version": "14.0.1.2.0",
+    "version": "14.0.1.2.1",
     "website": "https://simetri-sinergi.id",
     # pylint: disable=line-too-long
     "author": "PT. Simetri Sinergi Indonesia, OpenSynergy Indonesia, Odoo Community Association (OCA)",  # noqa: B950

--- a/ssi_school_incident/migrations/14.0.1.2.1/pre-migration.py
+++ b/ssi_school_incident/migrations/14.0.1.2.1/pre-migration.py
@@ -1,0 +1,179 @@
+# Copyright 2026 OpenSynergy Indonesia
+# Copyright 2026 PT. Simetri Sinergi Indonesia
+# License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl).
+#
+# Migration: 14.0.1.2.0 -> 14.0.1.2.1
+#
+# Changes: the escalation wizard was renamed from
+#          school_incident.wizard_escalate to escalate_incident
+#          (model, view, action, and ACL) without a migration script.
+#          Databases upgraded from any version <= 14.0.1.2.0 keep the
+#          orphaned ir.model, ir.actions.act_window (still bound to
+#          school_incident's "More" menu via binding_model_id),
+#          ir.ui.view, ir.model.access, and ir.model.data rows of the
+#          old model name, which raises
+#          "KeyError: 'school_incident.wizard_escalate'" when School
+#          Incident is updated or opened. This purges every trace of
+#          the old TransientModel before ir.model.data._process_end()
+#          loads this module's data files; its data is disposable
+#          (wizard input, never held state worth keeping).
+
+import logging
+
+from openupgradelib import openupgrade
+
+_logger = logging.getLogger(__name__)
+
+OLD_MODEL = "school_incident.wizard_escalate"
+
+
+@openupgrade.migrate()
+def migrate(env, version):
+    """Purge every leftover record and table of the renamed wizard.
+
+    Removes, in dependency order, the ir.model.access,
+    ir.model.fields.selection, ir.translation, ir.ui.view,
+    ir.actions.act_window (with its ir.actions parent row --
+    ``ir.actions.actions.unlink()`` does not cascade to subtype
+    tables, so both must be deleted explicitly), ir.model.fields,
+    ir.model, and ir.model.data rows that still reference the old
+    model name ``school_incident.wizard_escalate``, then drops its
+    table and many2many relation table.
+
+    Idempotent: every ``DELETE`` is scoped by a condition on the old
+    model name and every ``DROP TABLE`` uses ``IF EXISTS``, so this is
+    a no-op on databases that never installed a pre-rename version.
+
+    :param env: the migration environment
+    :param version: the version being migrated to (unused)
+    :return: nothing; purges leftover
+        ``school_incident.wizard_escalate`` artifacts
+    """
+    cr = env.cr
+
+    # ir.model.access rows for the old model.
+    openupgrade.logged_query(
+        cr,
+        """
+        DELETE FROM ir_model_access
+        WHERE model_id IN (
+            SELECT id FROM ir_model WHERE model = '%s'
+        )
+        """
+        % OLD_MODEL,
+    )
+    _logger.info("Deleted %s ir.model.access row(s).", cr.rowcount)
+
+    # ir.model.fields.selection rows for fields of the old model
+    # (target_level's selection values).
+    openupgrade.logged_query(
+        cr,
+        """
+        DELETE FROM ir_model_fields_selection
+        WHERE field_id IN (
+            SELECT id FROM ir_model_fields WHERE model = '%s'
+        )
+        """
+        % OLD_MODEL,
+    )
+    _logger.info("Deleted %s ir.model.fields.selection row(s).", cr.rowcount)
+
+    # ir.translation rows keyed to the old model name
+    # (name = 'school_incident.wizard_escalate,<field>').
+    openupgrade.logged_query(
+        cr,
+        """
+        DELETE FROM ir_translation
+        WHERE name LIKE '%s,%%'
+        """
+        % OLD_MODEL,
+    )
+    _logger.info("Deleted %s ir.translation row(s).", cr.rowcount)
+
+    # ir.ui.view rows for the old model.
+    openupgrade.logged_query(
+        cr,
+        """
+        DELETE FROM ir_ui_view
+        WHERE model = '%s'
+        """
+        % OLD_MODEL,
+    )
+    _logger.info("Deleted %s ir.ui.view row(s).", cr.rowcount)
+
+    # ir.actions.act_window rows for the old model, then their
+    # ir.actions parent rows. ir.actions.actions.unlink() does NOT
+    # cascade to subtype tables (see the NOTE in that method's
+    # docstring in Odoo core: "ondelete cascade will not work on
+    # ir.actions.actions"), so both tables need an explicit DELETE.
+    # Capture the ids first: both rows of a given action share the
+    # same id (both tables draw from the 'ir_actions_id_seq'
+    # sequence), so the captured act_window ids double as the
+    # ir_actions ids to purge.
+    cr.execute("SELECT id FROM ir_act_window WHERE res_model = %s", (OLD_MODEL,))
+    act_window_ids = [row[0] for row in cr.fetchall()]
+
+    openupgrade.logged_query(
+        cr,
+        """
+        DELETE FROM ir_act_window
+        WHERE res_model = '%s'
+        """
+        % OLD_MODEL,
+    )
+    _logger.info("Deleted %s ir.actions.act_window row(s).", cr.rowcount)
+
+    if act_window_ids:
+        ids_sql = ",".join(str(i) for i in act_window_ids)
+        openupgrade.logged_query(
+            cr,
+            "DELETE FROM ir_actions WHERE id IN (%s)" % ids_sql,
+        )
+        _logger.info("Deleted %s orphaned ir.actions row(s).", cr.rowcount)
+
+    # ir.model.fields rows for the old model.
+    openupgrade.logged_query(
+        cr,
+        """
+        DELETE FROM ir_model_fields
+        WHERE model = '%s'
+        """
+        % OLD_MODEL,
+    )
+    _logger.info("Deleted %s ir.model.fields row(s).", cr.rowcount)
+
+    # ir.model row for the old model.
+    openupgrade.logged_query(
+        cr,
+        """
+        DELETE FROM ir_model
+        WHERE model = '%s'
+        """
+        % OLD_MODEL,
+    )
+    _logger.info("Deleted %s ir.model row(s).", cr.rowcount)
+
+    # ir.model.data rows for the old model's XML IDs (module
+    # ssi_school_incident only; no other module ever referenced it).
+    openupgrade.logged_query(
+        cr,
+        """
+        DELETE FROM ir_model_data
+        WHERE module = 'ssi_school_incident'
+          AND (
+              name = 'model_school_incident_wizard_escalate'
+              OR name LIKE 'school_incident_wizard_escalate\\_%'
+              OR name LIKE 'field_school_incident_wizard_escalate\\_\\_%'
+              OR name LIKE 'selection\\_\\_school_incident_wizard_escalate\\_\\_%'
+          )
+        """,
+    )
+    _logger.info("Deleted %s ir.model.data row(s).", cr.rowcount)
+
+    # Drop the transient model's own table and its many2many relation
+    # table (school_incident_escalation_criteria selection).
+    openupgrade.logged_query(cr, "DROP TABLE IF EXISTS school_incident_wizard_escalate")
+    openupgrade.logged_query(
+        cr,
+        "DROP TABLE IF EXISTS " "rel_school_incident_wizard_escalate_2_criteria",
+    )

--- a/ssi_school_incident/tests/__init__.py
+++ b/ssi_school_incident/tests/__init__.py
@@ -10,4 +10,5 @@ from . import (  # noqa: F401
     test_school_incident_parent_contact,
     test_school_academic_alert,
     test_school_incident_weekly_review,
+    test_escalate_incident_migration,
 )

--- a/ssi_school_incident/tests/test_data_escalate_incident_migration.yaml
+++ b/ssi_school_incident/tests/test_data_escalate_incident_migration.yaml
@@ -1,0 +1,63 @@
+scenarios:
+  - name: "escalate_incident model, action and ACL are registered"
+    steps:
+      - step: "escalate_incident is a registered model"
+        action: "search"
+        model: "ir.model"
+        domain: [["model", "=", "escalate_incident"]]
+        save_as: "escalate_incident_model"
+        expect_count: 1
+
+      - step: "escalate_incident has exactly one ACL, for the user group"
+        action: "search"
+        model: "ir.model.access"
+        domain:
+          - ["model_id.model", "=", "escalate_incident"]
+        save_as: "escalate_incident_access"
+        expect_count: 1
+
+      - step: "Assert the ACL is granted to school_incident_user_group"
+        action: "assert"
+        target: "escalate_incident_access"
+        asserts:
+          group_id:
+            type: "m2o"
+            expected_xml_id: "ssi_school_incident.school_incident_user_group"
+
+      - step: "escalate_incident has exactly one act_window action"
+        action: "search"
+        model: "ir.actions.act_window"
+        domain: [["res_model", "=", "escalate_incident"]]
+        save_as: "escalate_incident_action"
+        expect_count: 1
+
+      - step: "Assert the action is bound to school_incident"
+        action: "assert"
+        target: "escalate_incident_action"
+        asserts:
+          binding_model_id.model:
+            type: "value"
+            expected: "school_incident"
+
+  - name: "school_incident.wizard_escalate leaves no trace"
+    steps:
+      - step: "Old model is not registered"
+        action: "search"
+        model: "ir.model"
+        domain: [["model", "=", "school_incident.wizard_escalate"]]
+        save_as: "old_model"
+        expect_count: 0
+
+      - step: "Old model has no act_window action"
+        action: "search"
+        model: "ir.actions.act_window"
+        domain: [["res_model", "=", "school_incident.wizard_escalate"]]
+        save_as: "old_action"
+        expect_count: 0
+
+      - step: "Old model has no view"
+        action: "search"
+        model: "ir.ui.view"
+        domain: [["model", "=", "school_incident.wizard_escalate"]]
+        save_as: "old_view"
+        expect_count: 0

--- a/ssi_school_incident/tests/test_escalate_incident_migration.py
+++ b/ssi_school_incident/tests/test_escalate_incident_migration.py
@@ -1,0 +1,32 @@
+# Copyright 2026 OpenSynergy Indonesia
+# Copyright 2026 PT. Simetri Sinergi Indonesia
+# License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl).
+
+from odoo_yaml_test import YamlTransactionCase
+
+from odoo.tests import tagged
+
+
+@tagged("post_install", "-at_install")
+class TestEscalateIncidentMigration(
+    YamlTransactionCase
+):  # pylint: disable=too-few-public-methods
+    """Post-rename invariants for the ``escalate_incident`` wizard.
+
+    ``school_incident.wizard_escalate`` was renamed to
+    ``escalate_incident`` in 14.0.1.2.0. The rename itself cannot be
+    exercised here (the migration script runs outside a transaction,
+    and CI always installs on a fresh database where the old model
+    never existed), so these scenarios assert the invariants the
+    migration script (``migrations/14.0.1.2.1/pre-migration.py``) is
+    responsible for keeping true: the new model/action/ACL are
+    registered, and no trace of the old model name is left behind.
+    """
+
+    def test_escalate_incident_migration(self):
+        """Run every post-rename invariant scenario from YAML.
+
+        Scenarios are declared in
+        ``test_data_escalate_incident_migration.yaml``.
+        """
+        self.run_yaml_scenario("test_data_escalate_incident_migration.yaml")


### PR DESCRIPTION
## Ringkasan

`ssi_school_incident` 14.0.1.2.0 me-rename wizard eskalasi
`school_incident.wizard_escalate` → `escalate_incident` tanpa migration
script. Database yang pernah memasang versi <= 14.0.1.2.0 masih menyimpan
`ir.model`, `ir.actions.act_window` (masih ter-`binding_model_id` ke
`school_incident`), `ir.ui.view`, `ir.model.access`, dan `ir.model.data`
milik nama model lama, sehingga `School Incident` melempar
`KeyError: 'school_incident.wizard_escalate'` saat update/dibuka.

PR ini menambahkan `migrations/14.0.1.2.1/pre-migration.py` (pola
`openupgradelib` + `openupgrade.logged_query`, idempoten) yang membuang
seluruh baris & tabel milik model lama, dan bump versi manifest ke
`14.0.1.2.1`.

## Perubahan

- `ssi_school_incident/migrations/14.0.1.2.1/pre-migration.py` (baru)
- `ssi_school_incident/__manifest__.py` — bump versi `14.0.1.2.0` →
  `14.0.1.2.1`
- `ssi_school_incident/tests/test_escalate_incident_migration.py` +
  `tests/test_data_escalate_incident_migration.yaml` (baru) — skenario
  regresi: `escalate_incident` terdaftar (model/ACL/action) dan tidak ada
  jejak `school_incident.wizard_escalate`
- `ssi_school_incident/tests/__init__.py` — daftarkan test baru

Migrasi sendiri tidak bisa dieksekusi lewat unit test (dijalankan loader
modul di luar transaksi test, DB CI selalu fresh-install); verifikasi
jalur migrasi sesungguhnya dilakukan manual di salinan DB produksi.

Closes #359