### PR TITLE
[UPD] ssi_school_incident - Perbaiki urutan DROP TABLE di pre-migration 14.0.1.2.1

### DIFF
--- a/ssi_school_incident/migrations/14.0.1.2.1/pre-migration.py
+++ b/ssi_school_incident/migrations/14.0.1.2.1/pre-migration.py
@@ -171,9 +171,14 @@ def migrate(env, version):
     _logger.info("Deleted %s ir.model.data row(s).", cr.rowcount)
 
     # Drop the transient model's own table and its many2many relation
-    # table (school_incident_escalation_criteria selection).
-    openupgrade.logged_query(cr, "DROP TABLE IF EXISTS school_incident_wizard_escalate")
+    # table (school_incident_escalation_criteria selection). Order is
+    # binding: the relation table's wizard_id column carries a foreign
+    # key onto school_incident_wizard_escalate, so the relation table
+    # MUST be dropped first -- dropping the referenced table first
+    # raises psycopg2.errors.DependentObjectsStillExist and rolls back
+    # the whole migration.
     openupgrade.logged_query(
         cr,
         "DROP TABLE IF EXISTS " "rel_school_incident_wizard_escalate_2_criteria",
     )
+    openupgrade.logged_query(cr, "DROP TABLE IF EXISTS school_incident_wizard_escalate")


### PR DESCRIPTION
## Ringkasan

Menukar urutan dua pernyataan `DROP TABLE IF EXISTS` terakhir di
`ssi_school_incident/migrations/14.0.1.2.1/pre-migration.py`: tabel relasi m2m
`rel_school_incident_wizard_escalate_2_criteria` kini dibuang **sebelum**
`school_incident_wizard_escalate`.

## Kenapa

Tabel relasi memegang foreign key
`rel_school_incident_wizard_escalate_2_criteria_wizard_id_fkey` yang menunjuk
tabel wizard. Urutan lama men-drop tabel wizard lebih dulu, sehingga
PostgreSQL melempar `DependentObjectsStillExist` dan seluruh transaksi
migrasi rollback -- perbaikan #359 (PR #360) tidak pernah benar-benar
mendarat di database produksi.

## Perubahan

- Tukar urutan dua `DROP TABLE IF EXISTS`.
- Tambahkan komentar (bahasa Inggris) yang menyebut alasan urutannya mengikat.

Tidak memakai `CASCADE`, tidak memindahkan/mengganti nama direktori migrasi,
tidak menyentuh `__manifest__.py` (bump ditangani `/ocabot merge patch`).

Closes #361