### PR TITLE
[UPD] ssi_school - Tambah kolom Unrealized di tree payment term enrollment

### DIFF
--- a/ssi_school/models/school_enrollment_payment_term.py
+++ b/ssi_school/models/school_enrollment_payment_term.py
@@ -175,6 +175,18 @@ class SchoolEnrollmentPaymentTerm(models.Model):
         ondelete="restrict",
         help="The customer invoice linked to this payment period.",
     )
+    amount_unrealized = fields.Monetary(
+        string="Unrealized",
+        related="customer_invoice_id.amount_residual",
+        store=True,
+        currency_field="currency_id",
+        readonly=True,
+        help=(
+            "Portion of this term still outstanding on the linked "
+            "customer invoice. Zero when the term has no customer "
+            "invoice yet."
+        ),
+    )
     date_invoice = fields.Date(
         string="Estimated Invoice Date",
         help="Estimated date for issuing the invoice for this billing period.",

--- a/ssi_school/tests/test_data_enrollment_payment_term_management.yaml
+++ b/ssi_school/tests/test_data_enrollment_payment_term_management.yaml
@@ -778,3 +778,273 @@ scenarios:
           manually_control:
             type: "value"
             expected: false
+
+  - name: "Enrollment Payment Term - Unrealized Amount"
+    steps:
+      - step: "Setup - get customer invoice journal"
+        action: "search"
+        model: "account.journal"
+        domain: [["type", "=", "sale"]]
+        save_as: "ci_journal"
+        limit: 1
+
+      - step: "Setup - get receivable account type"
+        action: "ref"
+        xml_id: "account.data_account_type_receivable"
+        save_as: "ci_account_type"
+
+      - step: "Setup - create customer invoice receivable account"
+        action: "create"
+        model: "account.account"
+        save_as: "ci_account"
+        values:
+          name: "Customer Invoice Receivable PTUNR"
+          code: "PTUNR"
+          user_type_id: "REC: ci_account_type.id"
+          reconcile: true
+
+      - step: "Setup - create customer invoice type"
+        action: "create"
+        model: "customer_invoice_type"
+        save_as: "ci_type"
+        values:
+          name: "Customer Invoice Type PTUNR"
+          code: "PTUNR"
+          journal_id: "REC: ci_journal.id"
+          receivable_account_id: "REC: ci_account.id"
+
+      - step: "Setup - get receivable journal"
+        action: "search"
+        model: "account.journal"
+        domain: [["type", "=", "sale"]]
+        save_as: "receivable_journal"
+        limit: 1
+
+      - step: "Setup - get account type ref"
+        action: "ref"
+        xml_id: "account.data_account_type_revenue"
+        save_as: "account_type"
+
+      - step: "Setup - create income account"
+        action: "create"
+        model: "account.account"
+        save_as: "account"
+        values:
+          name: "School Fee Income PTUNR"
+          code: "PTUNR4200"
+          user_type_id: "EVAL: registry['account_type'].id"
+
+      - step: "Setup - create product"
+        action: "create"
+        model: "product.product"
+        save_as: "product"
+        values:
+          name: "School Fee PTUNR"
+          type: "service"
+          list_price: 750000.0
+
+      - step: "Setup - create pricelist"
+        action: "create"
+        model: "product.pricelist"
+        save_as: "pricelist"
+        values:
+          name: "Pricelist PTUNR"
+          currency_id: "EVAL: env.company.currency_id.id"
+
+      - step: "Setup - create grade type"
+        action: "create"
+        model: "school_grade_type"
+        save_as: "grade_type"
+        values:
+          name: "Grade Type PTUNR"
+          code: "GTPTUNR"
+          sequence: 10
+
+      - step: "Setup - create academic year"
+        action: "create"
+        model: "school_academic_year"
+        save_as: "academic_year"
+        values:
+          name: "2024/2025 PTUNR"
+          code: "AYPTUNR"
+          date_start: "2024-07-01"
+          date_end: "2025-06-30"
+
+      - step: "Setup - create academic term"
+        action: "create"
+        model: "school_academic_term"
+        save_as: "academic_term"
+        values:
+          name: "Semester PTUNR"
+          code: "SMPTUNR"
+          date_start: "2024-07-01"
+          date_end: "2025-06-30"
+          year_id: "EVAL: registry['academic_year'].id"
+          enrollment_state: "open"
+
+      - step: "Setup - create school"
+        action: "create"
+        model: "school"
+        save_as: "school"
+        values:
+          name: "School PTUNR"
+          code: "SCHPTUNR"
+          grade_type_id: "EVAL: registry['grade_type'].id"
+
+      - step: "Setup - create grade"
+        action: "create"
+        model: "school_grade"
+        save_as: "grade"
+        values:
+          name: "Grade PTUNR"
+          code: "GPTUNR"
+          sequence: 10
+          type_id: "EVAL: registry['grade_type'].id"
+
+      - step: "Setup - create grade class"
+        action: "create"
+        model: "school_grade_class"
+        save_as: "grade_class"
+        values:
+          name: "Class PTUNR"
+          code: "CLAPTUNR"
+          school_id: "EVAL: registry['school'].id"
+          grade_id: "EVAL: registry['grade'].id"
+
+      - step: "Setup - create student contact"
+        action: "create"
+        model: "res.partner"
+        save_as: "contact"
+        values:
+          name: "Student Contact PTUNR"
+
+      - step: "Setup - create student"
+        action: "create"
+        model: "school_student"
+        save_as: "student"
+        values:
+          name: "Student PTUNR"
+          code: "STUPTUNR"
+          contact_id: "EVAL: registry['contact'].id"
+          school_id: "EVAL: registry['school'].id"
+
+      - step: "Setup - create payment template"
+        action: "create"
+        model: "school_enrollment_payment_template"
+        save_as: "payment_template"
+        values:
+          customer_invoice_type_id: "REC: ci_type.id"
+          name: "Payment Template PTUNR"
+          code: "PMTPTUNR"
+          school_id: "EVAL: registry['school'].id"
+          grade_id: "EVAL: registry['grade'].id"
+          academic_term_id: "EVAL: registry['academic_term'].id"
+          term_ids:
+            - - 0
+              - 0
+              - name: "Term 1 PTUNR"
+                sequence: 10
+                detail_ids:
+                  - - 0
+                    - 0
+                    - product_id: "EVAL: registry['product'].id"
+                      name: "Fee PTUNR"
+                      account_id: "EVAL: registry['account'].id"
+                      uom_quantity: 1.0
+                      uom_id: "REF: uom.product_uom_unit"
+                      price_unit: 750000.0
+
+      - step: "Create enrollment"
+        action: "create"
+        model: "school_enrollment"
+        save_as: "enrollment"
+        values:
+          customer_invoice_type_id: "REC: ci_type.id"
+          receivable_account_id: "REC: ci_account.id"
+          date: "2024-07-01"
+          academic_year_id: "EVAL: registry['academic_year'].id"
+          academic_term_id: "EVAL: registry['academic_term'].id"
+          school_id: "EVAL: registry['school'].id"
+          grade_id: "EVAL: registry['grade'].id"
+          grade_class_id: "EVAL: registry['grade_class'].id"
+          student_id: "EVAL: registry['student'].id"
+          payment_template_id: "EVAL: registry['payment_template'].id"
+          pricelist_id: "EVAL: registry['pricelist'].id"
+          currency_id: "EVAL: env.company.currency_id.id"
+          receivable_journal_id: "EVAL: registry['receivable_journal'].id"
+
+      - step: "Confirm enrollment"
+        action: "call"
+        target: "enrollment"
+        method: "action_confirm"
+        as_user: "base.user_admin"
+
+      - step: "Compute payment"
+        action: "call"
+        target: "enrollment"
+        method: "action_compute_payment"
+        as_user: "base.user_admin"
+
+      - step: "Assert enrollment is confirm before approve (forces refresh, T-04)"
+        action: "assert"
+        target: "enrollment"
+        asserts:
+          state:
+            type: "value"
+            expected: "confirm"
+
+      - step: "Approve enrollment"
+        action: "call"
+        target: "enrollment"
+        method: "action_approve_approval"
+        as_user: "base.user_admin"
+
+      - step: "Get payment term"
+        action: "search"
+        model: "school_enrollment_payment_term"
+        domain: [["enrollment_id", "=", "EVAL: registry['enrollment'].id"]]
+        save_as: "term"
+        expect_count: 1
+
+      - step: "Assert unrealized amount is zero before invoicing"
+        action: "assert"
+        target: "term"
+        asserts:
+          amount_unrealized:
+            type: "value"
+            expected: 0.0
+          customer_invoice_id:
+            type: "value"
+            operator: "is_falsy"
+
+      - step: "Create invoice"
+        action: "call"
+        target: "term"
+        method: "action_create_invoice"
+
+      - step: "Assert unrealized amount mirrors the linked invoice residual"
+        action: "assert"
+        target: "term"
+        asserts:
+          customer_invoice_id:
+            type: "value"
+            operator: "is_truthy"
+          amount_unrealized:
+            type: "value"
+            expected: "REC: term.customer_invoice_id.amount_residual"
+
+      - step: "Disconnect invoice"
+        action: "call"
+        target: "term"
+        method: "action_disconnect_invoice"
+
+      - step: "Assert unrealized amount returns to zero after disconnect"
+        action: "assert"
+        target: "term"
+        asserts:
+          amount_unrealized:
+            type: "value"
+            expected: 0.0
+          customer_invoice_id:
+            type: "value"
+            operator: "is_falsy"

--- a/ssi_school/tests/test_school_enrollment_payment_term_management.py
+++ b/ssi_school/tests/test_school_enrollment_payment_term_management.py
@@ -14,10 +14,13 @@ class TestSchoolEnrollmentPaymentTermManagement(
     """Cover the maintenance actions of an enrollment payment term.
 
     The scenarios exercise deleting the customer invoice generated from
-    the term, disconnecting that invoice without deleting it, and
-    unmarking a term that had been flagged as manual.
+    the term, disconnecting that invoice without deleting it, unmarking
+    a term that had been flagged as manual, and tracking the term's
+    unrealized amount against the linked customer invoice.
     """
 
     def test_enrollment_payment_term_management(self):
-        """Run the delete, disconnect and unmark manual scenarios."""
+        """Run the delete, disconnect, unmark manual, and unrealized
+        amount scenarios.
+        """
         self.run_yaml_scenario("test_data_enrollment_payment_term_management.yaml")

--- a/ssi_school/views/school_enrollment.xml
+++ b/ssi_school/views/school_enrollment.xml
@@ -228,6 +228,7 @@
                             <field name="amount_untaxed" />
                             <field name="amount_tax" />
                             <field name="amount_total" />
+                            <field name="amount_unrealized" />
                             <field name="customer_invoice_id" />
                             <field name="state" />
                             <button

--- a/ssi_school/views/school_enrollment_payment_term_views.xml
+++ b/ssi_school/views/school_enrollment_payment_term_views.xml
@@ -44,6 +44,7 @@
             <field name="amount_untaxed" />
             <field name="amount_tax" />
             <field name="amount_total" />
+            <field name="amount_unrealized" />
             <field name="customer_invoice_id" />
             <field name="state" />
             <button


### PR DESCRIPTION
## Ringkasan

Menambahkan kolom `amount_unrealized` pada tree payment term enrollment
(`school_enrollment_payment_term_view_tree` dan tree `payment_term_ids` yang
tertanam di form `school_enrollment`), sehingga porsi belum tertagih dari
customer invoice bisa dipantau langsung dari satu layar tanpa membuka
dokumen invoice-nya satu per satu.

## Perubahan

- Field baru `amount_unrealized` (Monetary) pada `school_enrollment_payment_term`,
  `related="customer_invoice_id.amount_residual"`, `store=True`,
  `currency_field="currency_id"`, `readonly=True`.
- Kolom `amount_unrealized` ditambahkan tepat setelah kolom Total di kedua
  tree model ini.
- Skenario uji YAML: nilai `0.0` sebelum invoice dibuat, sama dengan
  `amount_residual` invoice setelah `action_create_invoice`, dan kembali
  `0.0` setelah `action_disconnect_invoice`.

## Skenario Uji

- Positif: enrollment `open` dengan termin belum di-invoice → `amount_unrealized = 0.0`.
- Positif: setelah `action_create_invoice` → `amount_unrealized` sama dengan
  `customer_invoice_id.amount_residual`.
- Negatif: setelah `action_disconnect_invoice` → `amount_unrealized` kembali `0.0`.

Closes #363